### PR TITLE
Converters and Test Data Factories (#232)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <groupId>com.forgerock.openbanking.uk</groupId>
     <artifactId>openbanking-uk-datamodel</artifactId>
     <packaging>jar</packaging>
-    <version>3.1.2.16</version>
+    <version>3.1.2.17-SNAPSHOT</version>
     <name>openbanking-uk-datamodel</name>
     <description>
         A Java UK Data Model, generated from the swagger, to help implementing the Open Banking standard : https://www.openbanking.org.uk/read-write-apis/
@@ -200,7 +200,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-uk-datamodel.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-uk-datamodel.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-uk-datamodel.git</url>
-        <tag>openbanking-uk-datamodel-3.1.2.16</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <groupId>com.forgerock.openbanking.uk</groupId>
     <artifactId>openbanking-uk-datamodel</artifactId>
     <packaging>jar</packaging>
-    <version>3.1.2.17-SNAPSHOT</version>
+    <version>3.1.2.16-SNAPSHOT</version>
     <name>openbanking-uk-datamodel</name>
     <description>
         A Java UK Data Model, generated from the swagger, to help implementing the Open Banking standard : https://www.openbanking.org.uk/read-write-apis/
@@ -37,10 +37,9 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-parent</artifactId>
-        <version>1.0.61</version>
+        <version>1.0.70</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
-
     
     <properties>
         <jersey.version>2.30</jersey.version>
@@ -97,6 +96,11 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,17 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>
                 <version>3.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <groupId>com.forgerock.openbanking.uk</groupId>
     <artifactId>openbanking-uk-datamodel</artifactId>
     <packaging>jar</packaging>
-    <version>3.1.2.16-SNAPSHOT</version>
+    <version>3.1.2.16</version>
     <name>openbanking-uk-datamodel</name>
     <description>
         A Java UK Data Model, generated from the swagger, to help implementing the Open Banking standard : https://www.openbanking.org.uk/read-write-apis/
@@ -200,7 +200,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-uk-datamodel.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-uk-datamodel.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-uk-datamodel.git</url>
-        <tag>HEAD</tag>
+        <tag>openbanking-uk-datamodel-3.1.2.16</tag>
     </scm>
 
     <distributionManagement>

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/account/OBAccountConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/account/OBAccountConverter.java
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package uk.org.openbanking.datamodel.service.converter;
+package uk.org.openbanking.datamodel.service.converter.account;
 import uk.org.openbanking.datamodel.account.*;
 import uk.org.openbanking.datamodel.payment.OBExternalAccountIdentification2Code;
 

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/account/OBBeneficiaryConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/account/OBBeneficiaryConverter.java
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package uk.org.openbanking.datamodel.service.converter;
+package uk.org.openbanking.datamodel.service.converter.account;
 
 import uk.org.openbanking.datamodel.account.*;
 import uk.org.openbanking.datamodel.payment.OBExternalAccountIdentification2Code;

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/account/OBBranchAndFinancialInstitutionIdentificationConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/account/OBBranchAndFinancialInstitutionIdentificationConverter.java
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package uk.org.openbanking.datamodel.service.converter;
+package uk.org.openbanking.datamodel.service.converter.account;
 
 import uk.org.openbanking.datamodel.account.OBBranchAndFinancialInstitutionIdentification2;
 import uk.org.openbanking.datamodel.account.OBBranchAndFinancialInstitutionIdentification4;

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/account/OBCashAccountConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/account/OBCashAccountConverter.java
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package uk.org.openbanking.datamodel.service.converter;
+package uk.org.openbanking.datamodel.service.converter.account;
 
 import uk.org.openbanking.datamodel.account.*;
 import uk.org.openbanking.datamodel.payment.OBExternalAccountIdentification2Code;

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/account/OBExternalAccountIdentificationConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/account/OBExternalAccountIdentificationConverter.java
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package uk.org.openbanking.datamodel.service.converter;
+package uk.org.openbanking.datamodel.service.converter.account;
 
 import uk.org.openbanking.datamodel.account.OBExternalAccountIdentification3Code;
 import uk.org.openbanking.datamodel.account.OBExternalAccountIdentification4Code;

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/account/OBProductConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/account/OBProductConverter.java
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package uk.org.openbanking.datamodel.service.converter;
+package uk.org.openbanking.datamodel.service.converter.account;
 
 import uk.org.openbanking.datamodel.account.OBExternalProductType1Code;
 import uk.org.openbanking.datamodel.account.OBExternalProductType2Code;

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/account/OBStandingOrderConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/account/OBStandingOrderConverter.java
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package uk.org.openbanking.datamodel.service.converter;
+package uk.org.openbanking.datamodel.service.converter.account;
 
 import uk.org.openbanking.datamodel.account.OBStandingOrder1;
 import uk.org.openbanking.datamodel.account.OBStandingOrder2;

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/account/OBTransactionConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/account/OBTransactionConverter.java
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package uk.org.openbanking.datamodel.service.converter;
+package uk.org.openbanking.datamodel.service.converter.account;
 
 import uk.org.openbanking.datamodel.account.*;
 

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/ConverterHelper.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/ConverterHelper.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.datamodel.service.converter.payment;
+
+import java.lang.reflect.Field;
+
+/**
+ * Helper class providing utility methods for object conversions.
+ */
+class ConverterHelper {
+
+    /**
+     * Uses reflection to copy a field from one object to another.
+     *
+     * @param newObject      The new object that the field's value is to be copied to.
+     * @param originalObject The original object that the field's value is to be copied from.
+     * @param fieldName      The name of the field concerned.
+     * @param <T>            The type of the new object.
+     * @param <U>            The type of the original object.
+     */
+    static <T, U> void copyField(T newObject, U originalObject, String fieldName) {
+        if (originalObject == null) {
+            return; // optional fields may be null
+        }
+        if (newObject == null) {
+            throw new IllegalArgumentException("Cannot copy value to a null object");
+        }
+        try {
+            Field newField = newObject.getClass().getDeclaredField(fieldName);
+            newField.setAccessible(true);
+            Field originalField = originalObject.getClass().getDeclaredField(fieldName);
+            originalField.setAccessible(true);
+            newField.set(newObject, originalField.get(originalObject));
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to set value for field " + fieldName, e);
+        }
+    }
+}

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBAccountConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBAccountConverter.java
@@ -50,6 +50,14 @@ public class OBAccountConverter {
         return toAccount(new OBCashAccount3(), debtorAccount);
     }
 
+    public static OBCashAccount3 toOBCashAccount3(OBCashAccountDebtor4 debtorAccount) {
+        return toAccount(new OBCashAccount3(), debtorAccount);
+    }
+
+    public static OBCashAccount3 toOBCashAccount3(OBCashAccountCreditor3 creditorAccount) {
+        return toAccount(new OBCashAccount3(), creditorAccount);
+    }
+
     public static OBCashAccount5 toOBCashAccount5(OBWriteInternationalStandingOrder4DataInitiationCreditorAccount creditorAccount) {
         return toAccount(new OBCashAccount5(), creditorAccount);
     }

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBAccountConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBAccountConverter.java
@@ -94,6 +94,14 @@ public class OBAccountConverter {
         return toAccount(new OBCashAccountDebtor4(), debtorAccount);
     }
 
+    public static OBCashAccountDebtor4 toOBCashAccountDebtor4(OBCashAccount3 debtorAccount) {
+        return toAccount(new OBCashAccountDebtor4(), debtorAccount);
+    }
+
+    public static OBCashAccountCreditor3 toOBCashAccountCreditor3(OBCashAccount3 creditorAccount) {
+        return toAccount(new OBCashAccountCreditor3(), creditorAccount);
+    }
+
     public static OBCashAccountCreditor3 toOBCashAccountCreditor3(OBWriteDomesticStandingOrder3DataInitiationCreditorAccount creditorAccount) {
         return toAccount(new OBCashAccountCreditor3(), creditorAccount);
     }

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBAccountConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBAccountConverter.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.datamodel.service.converter.payment;
+
+import uk.org.openbanking.datamodel.account.OBCashAccount3;
+import uk.org.openbanking.datamodel.account.OBCashAccount5;
+import uk.org.openbanking.datamodel.payment.OBCashAccountCreditor3;
+import uk.org.openbanking.datamodel.payment.OBCashAccountDebtor4;
+import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationCreditorAccount;
+import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationDebtorAccount;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3DataInitiationCreditorAccount;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3DataInitiationDebtorAccount;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrder4DataInitiationCreditorAccount;
+
+import static uk.org.openbanking.datamodel.service.converter.payment.ConverterHelper.copyField;
+
+public class OBAccountConverter {
+
+    public static OBCashAccount3 toOBCashAccount3(OBWriteDomestic2DataInitiationDebtorAccount debtorAccount) {
+        return toAccount(new OBCashAccount3(), debtorAccount);
+    }
+
+    public static OBCashAccount3 toOBCashAccount3(OBWriteDomestic2DataInitiationCreditorAccount creditorAccount) {
+        return toAccount(new OBCashAccount3(), creditorAccount);
+    }
+
+    public static OBCashAccount3 toOBCashAccount3(OBWriteInternationalStandingOrder4DataInitiationCreditorAccount creditorAccount) {
+        return toAccount(new OBCashAccount3(), creditorAccount);
+    }
+
+    public static OBCashAccount3 toOBCashAccount3(OBWriteDomesticStandingOrder3DataInitiationDebtorAccount debtorAccount) {
+        return toAccount(new OBCashAccount3(), debtorAccount);
+    }
+
+    public static OBCashAccount5 toOBCashAccount5(OBWriteInternationalStandingOrder4DataInitiationCreditorAccount creditorAccount) {
+        return toAccount(new OBCashAccount5(), creditorAccount);
+    }
+
+    public static OBWriteDomestic2DataInitiationDebtorAccount toOBWriteDomestic2DataInitiationDebtorAccount(OBCashAccount3 debtorAccount) {
+        return toAccount(new OBWriteDomestic2DataInitiationDebtorAccount(), debtorAccount);
+    }
+
+    public static OBWriteDomestic2DataInitiationCreditorAccount toOBWriteDomestic2DataInitiationCreditorAccount(OBCashAccount3 creditorAccount) {
+        return toAccount(new OBWriteDomestic2DataInitiationCreditorAccount(), creditorAccount);
+    }
+
+    public static OBWriteDomesticStandingOrder3DataInitiationDebtorAccount toOBWriteDomesticStandingOrder3DataInitiationDebtorAccount(OBCashAccountDebtor4 debtorAccount) {
+        return toAccount(new OBWriteDomesticStandingOrder3DataInitiationDebtorAccount(), debtorAccount);
+    }
+
+    public static OBWriteDomesticStandingOrder3DataInitiationCreditorAccount toOBWriteDomesticStandingOrder3DataInitiationCreditorAccount(OBCashAccountCreditor3 creditorAccount) {
+        return toAccount(new OBWriteDomesticStandingOrder3DataInitiationCreditorAccount(), creditorAccount);
+    }
+
+    public static OBWriteDomesticStandingOrder3DataInitiationDebtorAccount toOBWriteDomesticStandingOrder3DataInitiationDebtorAccount(OBCashAccount3 debtorAccount) {
+        return toAccount(new OBWriteDomesticStandingOrder3DataInitiationDebtorAccount(), debtorAccount);
+    }
+
+    public static OBWriteInternationalStandingOrder4DataInitiationCreditorAccount toOBWriteInternationalStandingOrder4DataInitiationCreditorAccount(OBCashAccount3 creditorAccount) {
+        return toAccount(new OBWriteInternationalStandingOrder4DataInitiationCreditorAccount(), creditorAccount);
+    }
+
+    public static OBWriteInternationalStandingOrder4DataInitiationCreditorAccount toOBWriteInternationalStandingOrder4DataInitiationCreditorAccount(OBCashAccountCreditor3 creditorAccount) {
+        return toAccount(new OBWriteInternationalStandingOrder4DataInitiationCreditorAccount(), creditorAccount);
+    }
+
+    public static OBCashAccountDebtor4 toOBCashAccountDebtor4(OBWriteDomesticStandingOrder3DataInitiationDebtorAccount debtorAccount) {
+        return toAccount(new OBCashAccountDebtor4(), debtorAccount);
+    }
+
+    public static OBCashAccountCreditor3 toOBCashAccountCreditor3(OBWriteDomesticStandingOrder3DataInitiationCreditorAccount creditorAccount) {
+        return toAccount(new OBCashAccountCreditor3(), creditorAccount);
+    }
+
+    public static OBCashAccountCreditor3 toOBCashAccountCreditor3(OBWriteInternationalStandingOrder4DataInitiationCreditorAccount creditorAccount) {
+        return toAccount(new OBCashAccountCreditor3(), creditorAccount);
+    }
+
+    private static <T, U> T toAccount(T newAccount, U originalAccount) {
+        if (originalAccount == null) {
+            return null;
+        }
+        copyField(newAccount, originalAccount, "schemeName");
+        copyField(newAccount, originalAccount, "identification");
+        copyField(newAccount, originalAccount, "name");
+        copyField(newAccount, originalAccount, "secondaryIdentification");
+        return newAccount;
+    }
+
+}

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBAmountConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBAmountConverter.java
@@ -20,15 +20,7 @@
  */
 package uk.org.openbanking.datamodel.service.converter.payment;
 
-import uk.org.openbanking.datamodel.payment.OBActiveOrHistoricCurrencyAndAmount;
-import uk.org.openbanking.datamodel.payment.OBDomestic2InstructedAmount;
-import uk.org.openbanking.datamodel.payment.OBDomesticStandingOrder3FinalPaymentAmount;
-import uk.org.openbanking.datamodel.payment.OBDomesticStandingOrder3FirstPaymentAmount;
-import uk.org.openbanking.datamodel.payment.OBDomesticStandingOrder3RecurringPaymentAmount;
-import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstructedAmount;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3DataInitiationFinalPaymentAmount;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3DataInitiationFirstPaymentAmount;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3DataInitiationRecurringPaymentAmount;
+import uk.org.openbanking.datamodel.payment.*;
 
 import static uk.org.openbanking.datamodel.service.converter.payment.ConverterHelper.copyField;
 
@@ -62,6 +54,10 @@ public class OBAmountConverter {
         return toAmount(new OBWriteDomestic2DataInitiationInstructedAmount(), amount);
     }
 
+    public static OBDomestic2InstructedAmount toOBDomestic2InstructedAmount(OBActiveOrHistoricCurrencyAndAmount amount) {
+        return toAmount(new OBDomestic2InstructedAmount(), amount);
+    }
+
     public static OBDomestic2InstructedAmount toOBDomestic2InstructedAmount(OBWriteDomestic2DataInitiationInstructedAmount amount) {
         return toAmount(new OBDomestic2InstructedAmount(), amount);
     }
@@ -87,6 +83,18 @@ public class OBAmountConverter {
     }
 
     public static OBDomesticStandingOrder3FinalPaymentAmount toOBDomesticStandingOrder3FinalPaymentAmount(OBWriteDomesticStandingOrder3DataInitiationFinalPaymentAmount amount) {
+        return toAmount(new OBDomesticStandingOrder3FinalPaymentAmount(), amount);
+    }
+
+    public static OBDomesticStandingOrder3FirstPaymentAmount toOBDomesticStandingOrder3FirstPaymentAmount(OBActiveOrHistoricCurrencyAndAmount amount) {
+        return toAmount(new OBDomesticStandingOrder3FirstPaymentAmount(), amount);
+    }
+
+    public static OBDomesticStandingOrder3RecurringPaymentAmount toOBDomesticStandingOrder3RecurringPaymentAmount(OBActiveOrHistoricCurrencyAndAmount amount) {
+        return toAmount(new OBDomesticStandingOrder3RecurringPaymentAmount(), amount);
+    }
+
+    public static OBDomesticStandingOrder3FinalPaymentAmount toOBDomesticStandingOrder3FinalPaymentAmount(OBActiveOrHistoricCurrencyAndAmount amount) {
         return toAmount(new OBDomesticStandingOrder3FinalPaymentAmount(), amount);
     }
 

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBAmountConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBAmountConverter.java
@@ -38,6 +38,22 @@ public class OBAmountConverter {
         return toAmount(new OBActiveOrHistoricCurrencyAndAmount(), amount);
     }
 
+    public static OBActiveOrHistoricCurrencyAndAmount toOBActiveOrHistoricCurrencyAndAmount(OBDomestic2InstructedAmount amount) {
+        return toAmount(new OBActiveOrHistoricCurrencyAndAmount(), amount);
+    }
+
+    public static OBActiveOrHistoricCurrencyAndAmount toOBActiveOrHistoricCurrencyAndAmount(OBDomesticStandingOrder3FinalPaymentAmount amount) {
+        return toAmount(new OBActiveOrHistoricCurrencyAndAmount(), amount);
+    }
+
+    public static OBActiveOrHistoricCurrencyAndAmount toOBActiveOrHistoricCurrencyAndAmount(OBDomesticStandingOrder3RecurringPaymentAmount amount) {
+        return toAmount(new OBActiveOrHistoricCurrencyAndAmount(), amount);
+    }
+
+    public static OBActiveOrHistoricCurrencyAndAmount toOBActiveOrHistoricCurrencyAndAmount(OBDomesticStandingOrder3FirstPaymentAmount amount) {
+        return toAmount(new OBActiveOrHistoricCurrencyAndAmount(), amount);
+    }
+
     public static OBWriteDomestic2DataInitiationInstructedAmount toOBWriteDomestic2DataInitiationInstructedAmount(OBActiveOrHistoricCurrencyAndAmount amount) {
         return toAmount(new OBWriteDomestic2DataInitiationInstructedAmount(), amount);
     }

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBAmountConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBAmountConverter.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.datamodel.service.converter.payment;
+
+import uk.org.openbanking.datamodel.payment.OBActiveOrHistoricCurrencyAndAmount;
+import uk.org.openbanking.datamodel.payment.OBDomestic2InstructedAmount;
+import uk.org.openbanking.datamodel.payment.OBDomesticStandingOrder3FinalPaymentAmount;
+import uk.org.openbanking.datamodel.payment.OBDomesticStandingOrder3FirstPaymentAmount;
+import uk.org.openbanking.datamodel.payment.OBDomesticStandingOrder3RecurringPaymentAmount;
+import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstructedAmount;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3DataInitiationFinalPaymentAmount;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3DataInitiationFirstPaymentAmount;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3DataInitiationRecurringPaymentAmount;
+
+import static uk.org.openbanking.datamodel.service.converter.payment.ConverterHelper.copyField;
+
+public class OBAmountConverter {
+
+    public static OBActiveOrHistoricCurrencyAndAmount toOBActiveOrHistoricCurrencyAndAmount(OBWriteDomestic2DataInitiationInstructedAmount amount) {
+        return toAmount(new OBActiveOrHistoricCurrencyAndAmount(), amount);
+    }
+
+    public static OBWriteDomestic2DataInitiationInstructedAmount toOBWriteDomestic2DataInitiationInstructedAmount(OBActiveOrHistoricCurrencyAndAmount amount) {
+        return toAmount(new OBWriteDomestic2DataInitiationInstructedAmount(), amount);
+    }
+
+    public static OBWriteDomestic2DataInitiationInstructedAmount toOBWriteDomestic2DataInitiationInstructedAmount(OBDomestic2InstructedAmount amount) {
+        return toAmount(new OBWriteDomestic2DataInitiationInstructedAmount(), amount);
+    }
+
+    public static OBDomestic2InstructedAmount toOBDomestic2InstructedAmount(OBWriteDomestic2DataInitiationInstructedAmount amount) {
+        return toAmount(new OBDomestic2InstructedAmount(), amount);
+    }
+
+    public static OBWriteDomesticStandingOrder3DataInitiationFirstPaymentAmount toOBWriteDomesticStandingOrder3DataInitiationFirstPaymentAmount(OBDomesticStandingOrder3FirstPaymentAmount amount) {
+        return toAmount(new OBWriteDomesticStandingOrder3DataInitiationFirstPaymentAmount(), amount);
+    }
+
+    public static OBWriteDomesticStandingOrder3DataInitiationRecurringPaymentAmount toOBWriteDomesticStandingOrder3DataInitiationRecurringPaymentAmount(OBDomesticStandingOrder3RecurringPaymentAmount amount) {
+        return toAmount(new OBWriteDomesticStandingOrder3DataInitiationRecurringPaymentAmount(), amount);
+    }
+
+    public static OBWriteDomesticStandingOrder3DataInitiationFinalPaymentAmount toOBWriteDomesticStandingOrder3DataInitiationFinalPaymentAmount(OBDomesticStandingOrder3FinalPaymentAmount amount) {
+        return toAmount(new OBWriteDomesticStandingOrder3DataInitiationFinalPaymentAmount(), amount);
+    }
+
+    public static OBDomesticStandingOrder3FirstPaymentAmount toOBDomesticStandingOrder3FirstPaymentAmount(OBWriteDomesticStandingOrder3DataInitiationFirstPaymentAmount amount) {
+        return toAmount(new OBDomesticStandingOrder3FirstPaymentAmount(), amount);
+    }
+
+    public static OBDomesticStandingOrder3RecurringPaymentAmount toOBDomesticStandingOrder3RecurringPaymentAmount(OBWriteDomesticStandingOrder3DataInitiationRecurringPaymentAmount amount) {
+        return toAmount(new OBDomesticStandingOrder3RecurringPaymentAmount(), amount);
+    }
+
+    public static OBDomesticStandingOrder3FinalPaymentAmount toOBDomesticStandingOrder3FinalPaymentAmount(OBWriteDomesticStandingOrder3DataInitiationFinalPaymentAmount amount) {
+        return toAmount(new OBDomesticStandingOrder3FinalPaymentAmount(), amount);
+    }
+
+    public static uk.org.openbanking.datamodel.account.OBActiveOrHistoricCurrencyAndAmount toAccountOBActiveOrHistoricCurrencyAndAmount(OBWriteDomestic2DataInitiationInstructedAmount amount) {
+        return toAmount(new uk.org.openbanking.datamodel.account.OBActiveOrHistoricCurrencyAndAmount(), amount);
+    }
+
+    private static <T, U> T toAmount(T newAmount, U originalAmount) {
+        if (originalAmount == null) {
+            return null;
+        }
+        copyField(newAmount, originalAmount, "currency");
+        copyField(newAmount, originalAmount, "amount");
+        return newAmount;
+    }
+}

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBAuthorisationCodeConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBAuthorisationCodeConverter.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.datamodel.service.converter.payment;
+
+import uk.org.openbanking.datamodel.payment.OBExternalAuthorisation1Code;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent3DataAuthorisation.AuthorisationTypeEnum;
+
+public class OBAuthorisationCodeConverter {
+
+    public static OBExternalAuthorisation1Code toOBExternalAuthorisation1Code(AuthorisationTypeEnum authorisationType) {
+        return authorisationType == null ? null : OBExternalAuthorisation1Code.valueOf(authorisationType.name());
+    }
+
+    public static AuthorisationTypeEnum toAuthorisationTypeEnum(OBExternalAuthorisation1Code authorisation1Code) {
+        return authorisation1Code == null ? null : AuthorisationTypeEnum.valueOf(authorisation1Code.name());
+    }
+}

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBConsentAuthorisationConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBConsentAuthorisationConverter.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.datamodel.service.converter.payment;
+
+import uk.org.openbanking.datamodel.payment.OBAuthorisation1;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent3DataAuthorisation;
+
+import static uk.org.openbanking.datamodel.service.converter.payment.OBAuthorisationCodeConverter.toAuthorisationTypeEnum;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBAuthorisationCodeConverter.toOBExternalAuthorisation1Code;
+
+public class OBConsentAuthorisationConverter {
+
+    public static OBWriteDomesticConsent3DataAuthorisation toOBWriteDomesticConsent3DataAuthorisation(OBAuthorisation1 authorisation) {
+        return authorisation == null ? null : (new OBWriteDomesticConsent3DataAuthorisation())
+                .authorisationType(toAuthorisationTypeEnum(authorisation.getAuthorisationType()))
+                .completionDateTime(authorisation.getCompletionDateTime());
+    }
+
+    public static OBAuthorisation1 toOBAuthorisation1(OBWriteDomesticConsent3DataAuthorisation authorisation) {
+        return authorisation == null ? null : (new OBAuthorisation1())
+                .authorisationType(toOBExternalAuthorisation1Code(authorisation.getAuthorisationType()))
+                .completionDateTime(authorisation.getCompletionDateTime());
+    }
+
+}

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBDomesticConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBDomesticConverter.java
@@ -34,53 +34,54 @@ import static uk.org.openbanking.datamodel.service.converter.payment.OBRemittanc
 
 public class OBDomesticConverter {
 
-    public static OBDomestic2 toOBDomestic2(OBDomestic1 domestic1) {
-        return (new OBDomestic2())
-                .creditorAccount(domestic1.getCreditorAccount())
-                .creditorPostalAddress(domestic1.getCreditorPostalAddress())
-                .debtorAccount(domestic1.getDebtorAccount())
-                .endToEndIdentification(domestic1.getEndToEndIdentification())
-                .instructedAmount(domestic1.getInstructedAmount())
-                .instructionIdentification(domestic1.getInstructionIdentification())
-                .localInstrument(domestic1.getLocalInstrument())
-                .remittanceInformation(domestic1.getRemittanceInformation());
+    public static OBDomestic1 toOBDomestic1(OBDomestic2 obDomestic2) {
+        return obDomestic2 == null ? null : (new OBDomestic1())
+                .instructionIdentification(obDomestic2.getInstructionIdentification())
+                .endToEndIdentification(obDomestic2.getEndToEndIdentification())
+                .localInstrument(obDomestic2.getLocalInstrument())
+                .instructedAmount(obDomestic2.getInstructedAmount())
+                .debtorAccount(obDomestic2.getDebtorAccount())
+                .creditorAccount(obDomestic2.getCreditorAccount())
+                .creditorPostalAddress(obDomestic2.getCreditorPostalAddress())
+                .remittanceInformation(obDomestic2.getRemittanceInformation());
     }
 
-    public static OBDomestic1 toOBDomestic1(OBDomestic2 domestic2) {
-        return (new OBDomestic1())
-                .creditorAccount(domestic2.getCreditorAccount())
-                .creditorPostalAddress(domestic2.getCreditorPostalAddress())
-                .debtorAccount(domestic2.getDebtorAccount())
-                .endToEndIdentification(domestic2.getEndToEndIdentification())
-                .instructedAmount(domestic2.getInstructedAmount())
-                .instructionIdentification(domestic2.getInstructionIdentification())
-                .localInstrument(domestic2.getLocalInstrument())
-                .remittanceInformation(domestic2.getRemittanceInformation());
+    public static OBDomestic2 toOBDomestic2(OBDomestic1 obDomestic1) {
+        return obDomestic1 == null ? null : (new OBDomestic2())
+                .instructionIdentification(obDomestic1.getInstructionIdentification())
+                .endToEndIdentification(obDomestic1.getEndToEndIdentification())
+                .localInstrument(obDomestic1.getLocalInstrument())
+                .instructedAmount(obDomestic1.getInstructedAmount())
+                .debtorAccount(obDomestic1.getDebtorAccount())
+                .creditorAccount(obDomestic1.getCreditorAccount())
+                .creditorPostalAddress(obDomestic1.getCreditorPostalAddress())
+                .remittanceInformation(obDomestic1.getRemittanceInformation())
+                .supplementaryData(null);
     }
 
     public static OBDomestic2 toOBDomestic2(OBWriteDomestic2DataInitiation initiation) {
         return initiation == null ? null : (new OBDomestic2())
+                .instructionIdentification(initiation.getInstructionIdentification())
+                .endToEndIdentification(initiation.getEndToEndIdentification())
+                .localInstrument(initiation.getLocalInstrument())
+                .instructedAmount(toOBActiveOrHistoricCurrencyAndAmount(initiation.getInstructedAmount()))
+                .debtorAccount(toOBCashAccount3(initiation.getDebtorAccount()))
                 .creditorAccount(toOBCashAccount3(initiation.getCreditorAccount()))
                 .creditorPostalAddress(initiation.getCreditorPostalAddress())
-                .debtorAccount(toOBCashAccount3(initiation.getDebtorAccount()))
-                .endToEndIdentification(initiation.getEndToEndIdentification())
-                .instructedAmount(toOBActiveOrHistoricCurrencyAndAmount(initiation.getInstructedAmount()))
-                .instructionIdentification(initiation.getInstructionIdentification())
-                .localInstrument(initiation.getLocalInstrument())
                 .remittanceInformation(toOBRemittanceInformation1(initiation.getRemittanceInformation()))
                 .supplementaryData(initiation.getSupplementaryData());
     }
 
-    public static OBWriteDomestic2DataInitiation toOBWriteDomestic2DataInitiation(OBDomestic2 initiation) {
-        return initiation == null ? null : (new OBWriteDomestic2DataInitiation())
-                .instructionIdentification(initiation.getInstructionIdentification())
-                .endToEndIdentification(initiation.getEndToEndIdentification())
-                .localInstrument(initiation.getLocalInstrument())
-                .instructedAmount(toOBWriteDomestic2DataInitiationInstructedAmount(initiation.getInstructedAmount()))
-                .debtorAccount(toOBWriteDomestic2DataInitiationDebtorAccount(initiation.getDebtorAccount()))
-                .creditorAccount(toOBWriteDomestic2DataInitiationCreditorAccount(initiation.getCreditorAccount()))
-                .creditorPostalAddress(initiation.getCreditorPostalAddress())
-                .remittanceInformation(toOBWriteDomestic2DataInitiationRemittanceInformation(initiation.getRemittanceInformation()))
-                .supplementaryData(initiation.getSupplementaryData());
+    public static OBWriteDomestic2DataInitiation toOBWriteDomestic2DataInitiation(OBDomestic2 obDomestic2) {
+        return obDomestic2 == null ? null : (new OBWriteDomestic2DataInitiation())
+                .instructionIdentification(obDomestic2.getInstructionIdentification())
+                .endToEndIdentification(obDomestic2.getEndToEndIdentification())
+                .localInstrument(obDomestic2.getLocalInstrument())
+                .instructedAmount(toOBWriteDomestic2DataInitiationInstructedAmount(obDomestic2.getInstructedAmount()))
+                .debtorAccount(toOBWriteDomestic2DataInitiationDebtorAccount(obDomestic2.getDebtorAccount()))
+                .creditorAccount(toOBWriteDomestic2DataInitiationCreditorAccount(obDomestic2.getCreditorAccount()))
+                .creditorPostalAddress(obDomestic2.getCreditorPostalAddress())
+                .remittanceInformation(toOBWriteDomestic2DataInitiationRemittanceInformation(obDomestic2.getRemittanceInformation()))
+                .supplementaryData(obDomestic2.getSupplementaryData());
     }
 }

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBDomesticConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBDomesticConverter.java
@@ -20,6 +20,7 @@
  */
 package uk.org.openbanking.datamodel.service.converter.payment;
 
+import uk.org.openbanking.datamodel.payment.OBDomestic1;
 import uk.org.openbanking.datamodel.payment.OBDomestic2;
 import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiation;
 
@@ -32,6 +33,30 @@ import static uk.org.openbanking.datamodel.service.converter.payment.OBRemittanc
 import static uk.org.openbanking.datamodel.service.converter.payment.OBRemittanceInformationConverter.toOBWriteDomestic2DataInitiationRemittanceInformation;
 
 public class OBDomesticConverter {
+
+    public static OBDomestic2 toOBDomestic2(OBDomestic1 domestic1) {
+        return (new OBDomestic2())
+                .creditorAccount(domestic1.getCreditorAccount())
+                .creditorPostalAddress(domestic1.getCreditorPostalAddress())
+                .debtorAccount(domestic1.getDebtorAccount())
+                .endToEndIdentification(domestic1.getEndToEndIdentification())
+                .instructedAmount(domestic1.getInstructedAmount())
+                .instructionIdentification(domestic1.getInstructionIdentification())
+                .localInstrument(domestic1.getLocalInstrument())
+                .remittanceInformation(domestic1.getRemittanceInformation());
+    }
+
+    public static OBDomestic1 toOBDomestic1(OBDomestic2 domestic2) {
+        return (new OBDomestic1())
+                .creditorAccount(domestic2.getCreditorAccount())
+                .creditorPostalAddress(domestic2.getCreditorPostalAddress())
+                .debtorAccount(domestic2.getDebtorAccount())
+                .endToEndIdentification(domestic2.getEndToEndIdentification())
+                .instructedAmount(domestic2.getInstructedAmount())
+                .instructionIdentification(domestic2.getInstructionIdentification())
+                .localInstrument(domestic2.getLocalInstrument())
+                .remittanceInformation(domestic2.getRemittanceInformation());
+    }
 
     public static OBDomestic2 toOBDomestic2(OBWriteDomestic2DataInitiation initiation) {
         return initiation == null ? null : (new OBDomestic2())

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBDomesticConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBDomesticConverter.java
@@ -20,67 +20,42 @@
  */
 package uk.org.openbanking.datamodel.service.converter.payment;
 
-import uk.org.openbanking.datamodel.payment.*;
+import uk.org.openbanking.datamodel.payment.OBDomestic2;
+import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiation;
+
+import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBCashAccount3;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBWriteDomestic2DataInitiationCreditorAccount;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBWriteDomestic2DataInitiationDebtorAccount;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBAmountConverter.toOBActiveOrHistoricCurrencyAndAmount;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBAmountConverter.toOBWriteDomestic2DataInitiationInstructedAmount;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBRemittanceInformationConverter.toOBRemittanceInformation1;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBRemittanceInformationConverter.toOBWriteDomestic2DataInitiationRemittanceInformation;
 
 public class OBDomesticConverter {
 
-    public static OBDomestic2 toOBDomestic2(OBDomestic1 domestic1) {
-        return new OBDomestic2()
-                .creditorAccount(domestic1.getCreditorAccount())
-                .creditorPostalAddress(domestic1.getCreditorPostalAddress())
-                .debtorAccount(domestic1.getDebtorAccount())
-                .endToEndIdentification(domestic1.getEndToEndIdentification())
-                .instructedAmount(domestic1.getInstructedAmount())
-                .instructionIdentification(domestic1.getInstructionIdentification())
-                .localInstrument(domestic1.getLocalInstrument())
-                .remittanceInformation(domestic1.getRemittanceInformation());
+    public static OBDomestic2 toOBDomestic2(OBWriteDomestic2DataInitiation initiation) {
+        return initiation == null ? null : (new OBDomestic2())
+                .creditorAccount(toOBCashAccount3(initiation.getCreditorAccount()))
+                .creditorPostalAddress(initiation.getCreditorPostalAddress())
+                .debtorAccount(toOBCashAccount3(initiation.getDebtorAccount()))
+                .endToEndIdentification(initiation.getEndToEndIdentification())
+                .instructedAmount(toOBActiveOrHistoricCurrencyAndAmount(initiation.getInstructedAmount()))
+                .instructionIdentification(initiation.getInstructionIdentification())
+                .localInstrument(initiation.getLocalInstrument())
+                .remittanceInformation(toOBRemittanceInformation1(initiation.getRemittanceInformation()))
+                .supplementaryData(initiation.getSupplementaryData());
     }
 
-    public static OBDomestic1 toOBDomestic1(OBDomestic2 domestic2) {
-        return new OBDomestic1()
-                .creditorAccount(domestic2.getCreditorAccount())
-                .creditorPostalAddress(domestic2.getCreditorPostalAddress())
-                .debtorAccount(domestic2.getDebtorAccount())
-                .endToEndIdentification(domestic2.getEndToEndIdentification())
-                .instructedAmount(domestic2.getInstructedAmount())
-                .instructionIdentification(domestic2.getInstructionIdentification())
-                .localInstrument(domestic2.getLocalInstrument())
-                .remittanceInformation(domestic2.getRemittanceInformation());
-    }
-
-    public static OBWriteDomesticConsent2 toOBWriteDomesticConsent2(OBWriteDomesticConsent1 obWriteDomesticConsent1) {
-        return new OBWriteDomesticConsent2()
-                .data(new OBWriteDataDomesticConsent2()
-                        .authorisation(obWriteDomesticConsent1.getData().getAuthorisation())
-                        .initiation(toOBDomestic2(obWriteDomesticConsent1.getData().getInitiation()))
-                )
-                .risk(obWriteDomesticConsent1.getRisk());
-    }
-
-    public static OBWriteDomesticConsent1 toOBWriteDomesticConsent1(OBWriteDomesticConsent2 obWriteDomesticConsent2) {
-        return new OBWriteDomesticConsent1()
-                .data(new OBWriteDataDomesticConsent1()
-                        .authorisation(obWriteDomesticConsent2.getData().getAuthorisation())
-                        .initiation(toOBDomestic1(obWriteDomesticConsent2.getData().getInitiation()))
-                )
-                .risk(obWriteDomesticConsent2.getRisk());
-    }
-
-    public static OBWriteDomestic2 toOBWriteDomestic2(OBWriteDomestic1 obWriteDomestic1) {
-        return new OBWriteDomestic2()
-                .data(new OBWriteDataDomestic2()
-                        .consentId(obWriteDomestic1.getData().getConsentId())
-                        .initiation(toOBDomestic2(obWriteDomestic1.getData().getInitiation()))
-                )
-                .risk(obWriteDomestic1.getRisk());
-    }
-
-    public static OBWriteDomestic1 toOBWriteDomestic1(OBWriteDomestic2 obWriteDomestic2) {
-        return new OBWriteDomestic1()
-                .data(new OBWriteDataDomestic1()
-                        .consentId(obWriteDomestic2.getData().getConsentId())
-                        .initiation(toOBDomestic1(obWriteDomestic2.getData().getInitiation()))
-                )
-                .risk(obWriteDomestic2.getRisk());
+    public static OBWriteDomestic2DataInitiation toOBWriteDomestic2DataInitiation(OBDomestic2 initiation) {
+        return initiation == null ? null : (new OBWriteDomestic2DataInitiation())
+                .instructionIdentification(initiation.getInstructionIdentification())
+                .endToEndIdentification(initiation.getEndToEndIdentification())
+                .localInstrument(initiation.getLocalInstrument())
+                .instructedAmount(toOBWriteDomestic2DataInitiationInstructedAmount(initiation.getInstructedAmount()))
+                .debtorAccount(toOBWriteDomestic2DataInitiationDebtorAccount(initiation.getDebtorAccount()))
+                .creditorAccount(toOBWriteDomestic2DataInitiationCreditorAccount(initiation.getCreditorAccount()))
+                .creditorPostalAddress(initiation.getCreditorPostalAddress())
+                .remittanceInformation(toOBWriteDomestic2DataInitiationRemittanceInformation(initiation.getRemittanceInformation()))
+                .supplementaryData(initiation.getSupplementaryData());
     }
 }

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBDomesticScheduledConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBDomesticScheduledConverter.java
@@ -34,6 +34,32 @@ import static uk.org.openbanking.datamodel.service.converter.payment.OBRemittanc
 
 public class OBDomesticScheduledConverter {
 
+    public static OBDomesticScheduled2 toOBDomesticScheduled2(OBDomesticScheduled1 domesticScheduled1) {
+        return (new OBDomesticScheduled2())
+                .creditorAccount(domesticScheduled1.getCreditorAccount())
+                .creditorPostalAddress(domesticScheduled1.getCreditorPostalAddress())
+                .debtorAccount(domesticScheduled1.getDebtorAccount())
+                .endToEndIdentification(domesticScheduled1.getEndToEndIdentification())
+                .instructedAmount(domesticScheduled1.getInstructedAmount())
+                .instructionIdentification(domesticScheduled1.getInstructionIdentification())
+                .localInstrument(domesticScheduled1.getLocalInstrument())
+                .remittanceInformation(domesticScheduled1.getRemittanceInformation())
+                .requestedExecutionDateTime(domesticScheduled1.getRequestedExecutionDateTime());
+    }
+
+    public static OBDomesticScheduled1 toOBDomesticScheduled1(OBDomesticScheduled2 domesticScheduled2) {
+        return (new OBDomesticScheduled1())
+                .creditorAccount(domesticScheduled2.getCreditorAccount())
+                .creditorPostalAddress(domesticScheduled2.getCreditorPostalAddress())
+                .debtorAccount(domesticScheduled2.getDebtorAccount())
+                .endToEndIdentification(domesticScheduled2.getEndToEndIdentification())
+                .instructedAmount(domesticScheduled2.getInstructedAmount())
+                .instructionIdentification(domesticScheduled2.getInstructionIdentification())
+                .localInstrument(domesticScheduled2.getLocalInstrument())
+                .remittanceInformation(domesticScheduled2.getRemittanceInformation())
+                .requestedExecutionDateTime(domesticScheduled2.getRequestedExecutionDateTime());
+    }
+
     public static OBDomesticScheduled1 toOBDomesticScheduled1(OBWriteDomesticScheduled2DataInitiation initiation) {
         return initiation == null ? null : (new OBDomesticScheduled1())
                 .instructionIdentification(initiation.getInstructionIdentification())

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBDomesticScheduledConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBDomesticScheduledConverter.java
@@ -34,30 +34,17 @@ import static uk.org.openbanking.datamodel.service.converter.payment.OBRemittanc
 
 public class OBDomesticScheduledConverter {
 
-    public static OBDomesticScheduled2 toOBDomesticScheduled2(OBDomesticScheduled1 domesticScheduled1) {
-        return (new OBDomesticScheduled2())
-                .creditorAccount(domesticScheduled1.getCreditorAccount())
-                .creditorPostalAddress(domesticScheduled1.getCreditorPostalAddress())
-                .debtorAccount(domesticScheduled1.getDebtorAccount())
-                .endToEndIdentification(domesticScheduled1.getEndToEndIdentification())
-                .instructedAmount(domesticScheduled1.getInstructedAmount())
-                .instructionIdentification(domesticScheduled1.getInstructionIdentification())
-                .localInstrument(domesticScheduled1.getLocalInstrument())
-                .remittanceInformation(domesticScheduled1.getRemittanceInformation())
-                .requestedExecutionDateTime(domesticScheduled1.getRequestedExecutionDateTime());
-    }
-
-    public static OBDomesticScheduled1 toOBDomesticScheduled1(OBDomesticScheduled2 domesticScheduled2) {
-        return (new OBDomesticScheduled1())
-                .creditorAccount(domesticScheduled2.getCreditorAccount())
-                .creditorPostalAddress(domesticScheduled2.getCreditorPostalAddress())
-                .debtorAccount(domesticScheduled2.getDebtorAccount())
-                .endToEndIdentification(domesticScheduled2.getEndToEndIdentification())
-                .instructedAmount(domesticScheduled2.getInstructedAmount())
-                .instructionIdentification(domesticScheduled2.getInstructionIdentification())
-                .localInstrument(domesticScheduled2.getLocalInstrument())
-                .remittanceInformation(domesticScheduled2.getRemittanceInformation())
-                .requestedExecutionDateTime(domesticScheduled2.getRequestedExecutionDateTime());
+    public static OBDomesticScheduled1 toOBDomesticScheduled1(OBDomesticScheduled2 obDomesticScheduled2) {
+        return obDomesticScheduled2 == null ? null : (new OBDomesticScheduled1())
+                .instructionIdentification(obDomesticScheduled2.getInstructionIdentification())
+                .endToEndIdentification(obDomesticScheduled2.getEndToEndIdentification())
+                .localInstrument(obDomesticScheduled2.getLocalInstrument())
+                .requestedExecutionDateTime(obDomesticScheduled2.getRequestedExecutionDateTime())
+                .instructedAmount(obDomesticScheduled2.getInstructedAmount())
+                .debtorAccount(obDomesticScheduled2.getDebtorAccount())
+                .creditorAccount(obDomesticScheduled2.getCreditorAccount())
+                .creditorPostalAddress(obDomesticScheduled2.getCreditorPostalAddress())
+                .remittanceInformation(obDomesticScheduled2.getRemittanceInformation());
     }
 
     public static OBDomesticScheduled1 toOBDomesticScheduled1(OBWriteDomesticScheduled2DataInitiation initiation) {
@@ -71,6 +58,20 @@ public class OBDomesticScheduledConverter {
                 .creditorAccount(toOBCashAccount3(initiation.getCreditorAccount()))
                 .creditorPostalAddress(initiation.getCreditorPostalAddress())
                 .remittanceInformation(toOBRemittanceInformation1(initiation.getRemittanceInformation()));
+    }
+
+    public static OBDomesticScheduled2 toOBDomesticScheduled2(OBDomesticScheduled1 obDomesticScheduled1) {
+        return obDomesticScheduled1 == null ? null : (new OBDomesticScheduled2())
+                .instructionIdentification(obDomesticScheduled1.getInstructionIdentification())
+                .endToEndIdentification(obDomesticScheduled1.getEndToEndIdentification())
+                .localInstrument(obDomesticScheduled1.getLocalInstrument())
+                .requestedExecutionDateTime(obDomesticScheduled1.getRequestedExecutionDateTime())
+                .instructedAmount(obDomesticScheduled1.getInstructedAmount())
+                .debtorAccount(obDomesticScheduled1.getDebtorAccount())
+                .creditorAccount(obDomesticScheduled1.getCreditorAccount())
+                .creditorPostalAddress(obDomesticScheduled1.getCreditorPostalAddress())
+                .remittanceInformation(obDomesticScheduled1.getRemittanceInformation())
+                .supplementaryData(null);
     }
 
     public static OBDomesticScheduled2 toOBDomesticScheduled2(OBWriteDomesticScheduled2DataInitiation initiation) {
@@ -87,17 +88,17 @@ public class OBDomesticScheduledConverter {
                 .supplementaryData(initiation.getSupplementaryData());
     }
 
-    public static OBWriteDomesticScheduled2DataInitiation toOBWriteDomesticScheduled2DataInitiation(OBDomesticScheduled2 initiation) {
-        return initiation == null ? null : (new OBWriteDomesticScheduled2DataInitiation())
-                .instructionIdentification(initiation.getInstructionIdentification())
-                .endToEndIdentification(initiation.getEndToEndIdentification())
-                .localInstrument(initiation.getLocalInstrument())
-                .requestedExecutionDateTime(initiation.getRequestedExecutionDateTime())
-                .instructedAmount(toOBWriteDomestic2DataInitiationInstructedAmount(initiation.getInstructedAmount()))
-                .debtorAccount(toOBWriteDomestic2DataInitiationDebtorAccount(initiation.getDebtorAccount()))
-                .creditorAccount(toOBWriteDomestic2DataInitiationCreditorAccount(initiation.getCreditorAccount()))
-                .creditorPostalAddress(initiation.getCreditorPostalAddress())
-                .remittanceInformation(toOBWriteDomestic2DataInitiationRemittanceInformation(initiation.getRemittanceInformation()))
-                .supplementaryData(initiation.getSupplementaryData());
+    public static OBWriteDomesticScheduled2DataInitiation toOBWriteDomesticScheduled2DataInitiation(OBDomesticScheduled2 obDomesticScheduled2) {
+        return obDomesticScheduled2 == null ? null : (new OBWriteDomesticScheduled2DataInitiation())
+                .instructionIdentification(obDomesticScheduled2.getInstructionIdentification())
+                .endToEndIdentification(obDomesticScheduled2.getEndToEndIdentification())
+                .localInstrument(obDomesticScheduled2.getLocalInstrument())
+                .requestedExecutionDateTime(obDomesticScheduled2.getRequestedExecutionDateTime())
+                .instructedAmount(toOBWriteDomestic2DataInitiationInstructedAmount(obDomesticScheduled2.getInstructedAmount()))
+                .debtorAccount(toOBWriteDomestic2DataInitiationDebtorAccount(obDomesticScheduled2.getDebtorAccount()))
+                .creditorAccount(toOBWriteDomestic2DataInitiationCreditorAccount(obDomesticScheduled2.getCreditorAccount()))
+                .creditorPostalAddress(obDomesticScheduled2.getCreditorPostalAddress())
+                .remittanceInformation(toOBWriteDomestic2DataInitiationRemittanceInformation(obDomesticScheduled2.getRemittanceInformation()))
+                .supplementaryData(obDomesticScheduled2.getSupplementaryData());
     }
 }

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBDomesticScheduledConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBDomesticScheduledConverter.java
@@ -20,72 +20,58 @@
  */
 package uk.org.openbanking.datamodel.service.converter.payment;
 
-import uk.org.openbanking.datamodel.payment.*;
+import uk.org.openbanking.datamodel.payment.OBDomesticScheduled1;
+import uk.org.openbanking.datamodel.payment.OBDomesticScheduled2;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduled2DataInitiation;
+
+import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBCashAccount3;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBWriteDomestic2DataInitiationCreditorAccount;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBWriteDomestic2DataInitiationDebtorAccount;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBAmountConverter.toOBActiveOrHistoricCurrencyAndAmount;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBAmountConverter.toOBWriteDomestic2DataInitiationInstructedAmount;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBRemittanceInformationConverter.toOBRemittanceInformation1;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBRemittanceInformationConverter.toOBWriteDomestic2DataInitiationRemittanceInformation;
 
 public class OBDomesticScheduledConverter {
 
-    public static OBDomesticScheduled2 toOBDomesticScheduled2(OBDomesticScheduled1 domesticScheduled1) {
-        return new OBDomesticScheduled2()
-                .creditorAccount(domesticScheduled1.getCreditorAccount())
-                .creditorPostalAddress(domesticScheduled1.getCreditorPostalAddress())
-                .debtorAccount(domesticScheduled1.getDebtorAccount())
-                .endToEndIdentification(domesticScheduled1.getEndToEndIdentification())
-                .instructedAmount(domesticScheduled1.getInstructedAmount())
-                .instructionIdentification(domesticScheduled1.getInstructionIdentification())
-                .localInstrument(domesticScheduled1.getLocalInstrument())
-                .remittanceInformation(domesticScheduled1.getRemittanceInformation())
-                .requestedExecutionDateTime(domesticScheduled1.getRequestedExecutionDateTime());
+    public static OBDomesticScheduled1 toOBDomesticScheduled1(OBWriteDomesticScheduled2DataInitiation initiation) {
+        return initiation == null ? null : (new OBDomesticScheduled1())
+                .instructionIdentification(initiation.getInstructionIdentification())
+                .endToEndIdentification(initiation.getEndToEndIdentification())
+                .localInstrument(initiation.getLocalInstrument())
+                .requestedExecutionDateTime(initiation.getRequestedExecutionDateTime())
+                .instructedAmount(toOBActiveOrHistoricCurrencyAndAmount(initiation.getInstructedAmount()))
+                .debtorAccount(toOBCashAccount3(initiation.getDebtorAccount()))
+                .creditorAccount(toOBCashAccount3(initiation.getCreditorAccount()))
+                .creditorPostalAddress(initiation.getCreditorPostalAddress())
+                .remittanceInformation(toOBRemittanceInformation1(initiation.getRemittanceInformation()));
     }
 
-    public static OBDomesticScheduled1 toOBDomesticScheduled1(OBDomesticScheduled2 domesticScheduled2) {
-        return new OBDomesticScheduled1()
-                .creditorAccount(domesticScheduled2.getCreditorAccount())
-                .creditorPostalAddress(domesticScheduled2.getCreditorPostalAddress())
-                .debtorAccount(domesticScheduled2.getDebtorAccount())
-                .endToEndIdentification(domesticScheduled2.getEndToEndIdentification())
-                .instructedAmount(domesticScheduled2.getInstructedAmount())
-                .instructionIdentification(domesticScheduled2.getInstructionIdentification())
-                .localInstrument(domesticScheduled2.getLocalInstrument())
-                .remittanceInformation(domesticScheduled2.getRemittanceInformation())
-                .requestedExecutionDateTime(domesticScheduled2.getRequestedExecutionDateTime());
+    public static OBDomesticScheduled2 toOBDomesticScheduled2(OBWriteDomesticScheduled2DataInitiation initiation) {
+        return initiation == null ? null : (new OBDomesticScheduled2())
+                .instructionIdentification(initiation.getInstructionIdentification())
+                .endToEndIdentification(initiation.getEndToEndIdentification())
+                .localInstrument(initiation.getLocalInstrument())
+                .requestedExecutionDateTime(initiation.getRequestedExecutionDateTime())
+                .instructedAmount(toOBActiveOrHistoricCurrencyAndAmount(initiation.getInstructedAmount()))
+                .debtorAccount(toOBCashAccount3(initiation.getDebtorAccount()))
+                .creditorAccount(toOBCashAccount3(initiation.getCreditorAccount()))
+                .creditorPostalAddress(initiation.getCreditorPostalAddress())
+                .remittanceInformation(toOBRemittanceInformation1(initiation.getRemittanceInformation()))
+                .supplementaryData(initiation.getSupplementaryData());
     }
 
-
-    public static OBWriteDomesticScheduledConsent2 toOBWriteDomesticScheduledConsent2(OBWriteDomesticScheduledConsent1 obWriteDomesticScheduledConsent1) {
-        return new OBWriteDomesticScheduledConsent2()
-                .data(new OBWriteDataDomesticScheduledConsent2()
-                        .authorisation(obWriteDomesticScheduledConsent1.getData().getAuthorisation())
-                        .initiation(toOBDomesticScheduled2(obWriteDomesticScheduledConsent1.getData().getInitiation()))
-                        .permission(obWriteDomesticScheduledConsent1.getData().getPermission())
-                )
-                .risk(obWriteDomesticScheduledConsent1.getRisk());
-    }
-
-    public static OBWriteDomesticScheduledConsent1 toOBWriteDomesticScheduledConsent1(OBWriteDomesticScheduledConsent2 obWriteDomesticScheduledConsent2) {
-        return new OBWriteDomesticScheduledConsent1()
-                .data(new OBWriteDataDomesticScheduledConsent1()
-                        .authorisation(obWriteDomesticScheduledConsent2.getData().getAuthorisation())
-                        .initiation(toOBDomesticScheduled1(obWriteDomesticScheduledConsent2.getData().getInitiation()))
-                        .permission(obWriteDomesticScheduledConsent2.getData().getPermission())
-                )
-                .risk(obWriteDomesticScheduledConsent2.getRisk());
-    }
-
-    public static OBWriteDomesticScheduled2 toOBWriteDomesticScheduled2(OBWriteDomesticScheduled1 obWriteDomesticScheduled1) {
-        return new OBWriteDomesticScheduled2()
-                .data(new OBWriteDataDomesticScheduled2()
-                        .consentId(obWriteDomesticScheduled1.getData().getConsentId())
-                        .initiation(toOBDomesticScheduled2(obWriteDomesticScheduled1.getData().getInitiation()))
-                )
-                .risk(obWriteDomesticScheduled1.getRisk());
-    }
-
-    public static OBWriteDomesticScheduled1 toOBWriteDomesticScheduled1(OBWriteDomesticScheduled2 obWriteDomesticScheduled2) {
-        return new OBWriteDomesticScheduled1()
-                .data(new OBWriteDataDomesticScheduled1()
-                        .consentId(obWriteDomesticScheduled2.getData().getConsentId())
-                        .initiation(toOBDomesticScheduled1(obWriteDomesticScheduled2.getData().getInitiation()))
-                )
-                .risk(obWriteDomesticScheduled2.getRisk());
+    public static OBWriteDomesticScheduled2DataInitiation toOBWriteDomesticScheduled2DataInitiation(OBDomesticScheduled2 initiation) {
+        return initiation == null ? null : (new OBWriteDomesticScheduled2DataInitiation())
+                .instructionIdentification(initiation.getInstructionIdentification())
+                .endToEndIdentification(initiation.getEndToEndIdentification())
+                .localInstrument(initiation.getLocalInstrument())
+                .requestedExecutionDateTime(initiation.getRequestedExecutionDateTime())
+                .instructedAmount(toOBWriteDomestic2DataInitiationInstructedAmount(initiation.getInstructedAmount()))
+                .debtorAccount(toOBWriteDomestic2DataInitiationDebtorAccount(initiation.getDebtorAccount()))
+                .creditorAccount(toOBWriteDomestic2DataInitiationCreditorAccount(initiation.getCreditorAccount()))
+                .creditorPostalAddress(initiation.getCreditorPostalAddress())
+                .remittanceInformation(toOBWriteDomestic2DataInitiationRemittanceInformation(initiation.getRemittanceInformation()))
+                .supplementaryData(initiation.getSupplementaryData());
     }
 }

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBDomesticStandingOrderConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBDomesticStandingOrderConverter.java
@@ -20,75 +20,46 @@
  */
 package uk.org.openbanking.datamodel.service.converter.payment;
 
-import uk.org.openbanking.datamodel.payment.*;
+import uk.org.openbanking.datamodel.payment.OBDomesticStandingOrder3;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3DataInitiation;
+
+import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBCashAccountCreditor3;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBCashAccountDebtor4;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBWriteDomesticStandingOrder3DataInitiationCreditorAccount;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBWriteDomesticStandingOrder3DataInitiationDebtorAccount;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBAmountConverter.*;
 
 public class OBDomesticStandingOrderConverter {
 
-    public static OBDomesticStandingOrder2 toOBDomesticStandingOrder2(OBDomesticStandingOrder1 domesticStandingOrder1) {
-        return new OBDomesticStandingOrder2()
-                .creditorAccount(domesticStandingOrder1.getCreditorAccount())
-                .debtorAccount(domesticStandingOrder1.getDebtorAccount())
-                .finalPaymentAmount(domesticStandingOrder1.getFinalPaymentAmount())
-                .finalPaymentDateTime(domesticStandingOrder1.getFinalPaymentDateTime())
-                .firstPaymentAmount(domesticStandingOrder1.getFirstPaymentAmount())
-                .firstPaymentDateTime(domesticStandingOrder1.getFirstPaymentDateTime())
-                .recurringPaymentAmount(domesticStandingOrder1.getRecurringPaymentAmount())
-                .recurringPaymentDateTime(domesticStandingOrder1.getRecurringPaymentDateTime())
-                .frequency(domesticStandingOrder1.getFrequency())
-                .numberOfPayments(domesticStandingOrder1.getNumberOfPayments())
-                .reference(domesticStandingOrder1.getReference());
+    public static OBDomesticStandingOrder3 toOBDomesticStandingOrder3(OBWriteDomesticStandingOrder3DataInitiation initiation) {
+        return initiation == null ? null : (new OBDomesticStandingOrder3())
+                .frequency(initiation.getFrequency())
+                .reference(initiation.getReference())
+                .numberOfPayments(initiation.getNumberOfPayments())
+                .firstPaymentDateTime(initiation.getFirstPaymentDateTime())
+                .recurringPaymentDateTime(initiation.getRecurringPaymentDateTime())
+                .finalPaymentDateTime(initiation.getFinalPaymentDateTime())
+                .firstPaymentAmount(toOBDomesticStandingOrder3FirstPaymentAmount(initiation.getFirstPaymentAmount()))
+                .recurringPaymentAmount(toOBDomesticStandingOrder3RecurringPaymentAmount(initiation.getRecurringPaymentAmount()))
+                .finalPaymentAmount(toOBDomesticStandingOrder3FinalPaymentAmount(initiation.getFinalPaymentAmount()))
+                .debtorAccount(toOBCashAccountDebtor4(initiation.getDebtorAccount()))
+                .creditorAccount(toOBCashAccountCreditor3(initiation.getCreditorAccount()))
+                .supplementaryData(initiation.getSupplementaryData());
     }
 
-    public static OBDomesticStandingOrder1 toOBDomesticStandingOrder1(OBDomesticStandingOrder2 domesticStandingOrder2) {
-        return new OBDomesticStandingOrder1()
-                .creditorAccount(domesticStandingOrder2.getCreditorAccount())
-                .debtorAccount(domesticStandingOrder2.getDebtorAccount())
-                .finalPaymentAmount(domesticStandingOrder2.getFinalPaymentAmount())
-                .finalPaymentDateTime(domesticStandingOrder2.getFinalPaymentDateTime())
-                .firstPaymentAmount(domesticStandingOrder2.getFirstPaymentAmount())
-                .firstPaymentDateTime(domesticStandingOrder2.getFirstPaymentDateTime())
-                .recurringPaymentAmount(domesticStandingOrder2.getRecurringPaymentAmount())
-                .recurringPaymentDateTime(domesticStandingOrder2.getRecurringPaymentDateTime())
-                .frequency(domesticStandingOrder2.getFrequency())
-                .numberOfPayments(domesticStandingOrder2.getNumberOfPayments())
-                .reference(domesticStandingOrder2.getReference());
-    }
-
-    public static OBWriteDomesticStandingOrderConsent2 toOBWriteDomesticStandingOrderConsent2(OBWriteDomesticStandingOrderConsent1 obWriteDomesticStandingOrderConsent1) {
-        return new OBWriteDomesticStandingOrderConsent2()
-                .data(new OBWriteDataDomesticStandingOrderConsent2()
-                        .authorisation(obWriteDomesticStandingOrderConsent1.getData().getAuthorisation())
-                        .initiation(toOBDomesticStandingOrder2(obWriteDomesticStandingOrderConsent1.getData().getInitiation()))
-                        .permission(obWriteDomesticStandingOrderConsent1.getData().getPermission())
-                )
-                .risk(obWriteDomesticStandingOrderConsent1.getRisk());
-    }
-
-    public static OBWriteDomesticStandingOrderConsent1 toOBWriteDomesticStandingOrderConsent1(OBWriteDomesticStandingOrderConsent2 obWriteDomesticStandingOrderConsent2) {
-        return new OBWriteDomesticStandingOrderConsent1()
-                .data(new OBWriteDataDomesticStandingOrderConsent1()
-                        .authorisation(obWriteDomesticStandingOrderConsent2.getData().getAuthorisation())
-                        .initiation(toOBDomesticStandingOrder1(obWriteDomesticStandingOrderConsent2.getData().getInitiation()))
-                        .permission(obWriteDomesticStandingOrderConsent2.getData().getPermission())
-                )
-                .risk(obWriteDomesticStandingOrderConsent2.getRisk());
-    }
-
-    public static OBWriteDomesticStandingOrder2 toOBWriteDomesticStandingOrder2(OBWriteDomesticStandingOrder1 obWriteDomesticStandingOrder1) {
-        return new OBWriteDomesticStandingOrder2()
-                .data(new OBWriteDataDomesticStandingOrder2()
-                        .consentId(obWriteDomesticStandingOrder1.getData().getConsentId())
-                        .initiation(toOBDomesticStandingOrder2(obWriteDomesticStandingOrder1.getData().getInitiation()))
-                )
-                .risk(obWriteDomesticStandingOrder1.getRisk());
-    }
-
-    public static OBWriteDomesticStandingOrder1 toOBWriteDomesticStandingOrder1(OBWriteDomesticStandingOrder2 obWriteDomesticStandingOrder2) {
-        return new OBWriteDomesticStandingOrder1()
-                .data(new OBWriteDataDomesticStandingOrder1()
-                        .consentId(obWriteDomesticStandingOrder2.getData().getConsentId())
-                        .initiation(toOBDomesticStandingOrder1(obWriteDomesticStandingOrder2.getData().getInitiation()))
-                )
-                .risk(obWriteDomesticStandingOrder2.getRisk());
+    public static OBWriteDomesticStandingOrder3DataInitiation toOBWriteDomesticStandingOrder3DataInitiation(OBDomesticStandingOrder3 initiation) {
+        return initiation == null ? null : (new OBWriteDomesticStandingOrder3DataInitiation())
+                .frequency(initiation.getFrequency())
+                .reference(initiation.getReference())
+                .numberOfPayments(initiation.getNumberOfPayments())
+                .firstPaymentDateTime(initiation.getFirstPaymentDateTime())
+                .recurringPaymentDateTime(initiation.getRecurringPaymentDateTime())
+                .finalPaymentDateTime(initiation.getFinalPaymentDateTime())
+                .firstPaymentAmount(toOBWriteDomesticStandingOrder3DataInitiationFirstPaymentAmount(initiation.getFirstPaymentAmount()))
+                .recurringPaymentAmount(toOBWriteDomesticStandingOrder3DataInitiationRecurringPaymentAmount(initiation.getRecurringPaymentAmount()))
+                .finalPaymentAmount(toOBWriteDomesticStandingOrder3DataInitiationFinalPaymentAmount(initiation.getFinalPaymentAmount()))
+                .debtorAccount(toOBWriteDomesticStandingOrder3DataInitiationDebtorAccount(initiation.getDebtorAccount()))
+                .creditorAccount(toOBWriteDomesticStandingOrder3DataInitiationCreditorAccount(initiation.getCreditorAccount()))
+                .supplementaryData(initiation.getSupplementaryData());
     }
 }

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBDomesticStandingOrderConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBDomesticStandingOrderConverter.java
@@ -96,6 +96,22 @@ public class OBDomesticStandingOrderConverter {
                 .supplementaryData(obDomesticStandingOrder3.getSupplementaryData());
     }
 
+    public static OBDomesticStandingOrder3 toOBDomesticStandingOrder3(OBDomesticStandingOrder2 obDomesticStandingOrder2) {
+        return obDomesticStandingOrder2 == null ? null : (new OBDomesticStandingOrder3())
+                .frequency(obDomesticStandingOrder2.getFrequency())
+                .reference(obDomesticStandingOrder2.getReference())
+                .numberOfPayments(obDomesticStandingOrder2.getNumberOfPayments())
+                .firstPaymentDateTime(obDomesticStandingOrder2.getFirstPaymentDateTime())
+                .recurringPaymentDateTime(obDomesticStandingOrder2.getRecurringPaymentDateTime())
+                .finalPaymentDateTime(obDomesticStandingOrder2.getFinalPaymentDateTime())
+                .firstPaymentAmount(toOBDomesticStandingOrder3FirstPaymentAmount(obDomesticStandingOrder2.getFirstPaymentAmount()))
+                .recurringPaymentAmount(toOBDomesticStandingOrder3RecurringPaymentAmount(obDomesticStandingOrder2.getRecurringPaymentAmount()))
+                .finalPaymentAmount(toOBDomesticStandingOrder3FinalPaymentAmount(obDomesticStandingOrder2.getFinalPaymentAmount()))
+                .debtorAccount(toOBCashAccountDebtor4(obDomesticStandingOrder2.getDebtorAccount()))
+                .creditorAccount(toOBCashAccountCreditor3(obDomesticStandingOrder2.getCreditorAccount()))
+                .supplementaryData(obDomesticStandingOrder2.getSupplementaryData());
+    }
+
     public static OBDomesticStandingOrder3 toOBDomesticStandingOrder3(OBWriteDomesticStandingOrder3DataInitiation initiation) {
         return initiation == null ? null : (new OBDomesticStandingOrder3())
                 .frequency(initiation.getFrequency())

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBDomesticStandingOrderConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBDomesticStandingOrderConverter.java
@@ -25,6 +25,7 @@ import uk.org.openbanking.datamodel.payment.OBDomesticStandingOrder2;
 import uk.org.openbanking.datamodel.payment.OBDomesticStandingOrder3;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3DataInitiation;
 
+import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBCashAccount3;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBCashAccountCreditor3;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBCashAccountDebtor4;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBWriteDomesticStandingOrder3DataInitiationCreditorAccount;
@@ -33,34 +34,66 @@ import static uk.org.openbanking.datamodel.service.converter.payment.OBAmountCon
 
 public class OBDomesticStandingOrderConverter {
 
-    public static OBDomesticStandingOrder2 toOBDomesticStandingOrder2(OBDomesticStandingOrder1 domesticStandingOrder1) {
-        return (new OBDomesticStandingOrder2())
-                .creditorAccount(domesticStandingOrder1.getCreditorAccount())
-                .debtorAccount(domesticStandingOrder1.getDebtorAccount())
-                .finalPaymentAmount(domesticStandingOrder1.getFinalPaymentAmount())
-                .finalPaymentDateTime(domesticStandingOrder1.getFinalPaymentDateTime())
-                .firstPaymentAmount(domesticStandingOrder1.getFirstPaymentAmount())
-                .firstPaymentDateTime(domesticStandingOrder1.getFirstPaymentDateTime())
-                .recurringPaymentAmount(domesticStandingOrder1.getRecurringPaymentAmount())
-                .recurringPaymentDateTime(domesticStandingOrder1.getRecurringPaymentDateTime())
-                .frequency(domesticStandingOrder1.getFrequency())
-                .numberOfPayments(domesticStandingOrder1.getNumberOfPayments())
-                .reference(domesticStandingOrder1.getReference());
+    public static OBDomesticStandingOrder1 toOBDomesticStandingOrder1(OBDomesticStandingOrder2 obDomesticStandingOrder2) {
+        return obDomesticStandingOrder2 == null ? null : (new OBDomesticStandingOrder1())
+                .frequency(obDomesticStandingOrder2.getFrequency())
+                .reference(obDomesticStandingOrder2.getReference())
+                .numberOfPayments(obDomesticStandingOrder2.getNumberOfPayments())
+                .firstPaymentDateTime(obDomesticStandingOrder2.getFirstPaymentDateTime())
+                .recurringPaymentDateTime(obDomesticStandingOrder2.getRecurringPaymentDateTime())
+                .finalPaymentDateTime(obDomesticStandingOrder2.getFinalPaymentDateTime())
+                .firstPaymentAmount(obDomesticStandingOrder2.getFirstPaymentAmount())
+                .recurringPaymentAmount(obDomesticStandingOrder2.getRecurringPaymentAmount())
+                .finalPaymentAmount(obDomesticStandingOrder2.getFinalPaymentAmount())
+                .debtorAccount(obDomesticStandingOrder2.getDebtorAccount())
+                .creditorAccount(obDomesticStandingOrder2.getCreditorAccount());
     }
 
-    public static OBDomesticStandingOrder1 toOBDomesticStandingOrder1(OBDomesticStandingOrder2 domesticStandingOrder2) {
-        return (new OBDomesticStandingOrder1())
-                .creditorAccount(domesticStandingOrder2.getCreditorAccount())
-                .debtorAccount(domesticStandingOrder2.getDebtorAccount())
-                .finalPaymentAmount(domesticStandingOrder2.getFinalPaymentAmount())
-                .finalPaymentDateTime(domesticStandingOrder2.getFinalPaymentDateTime())
-                .firstPaymentAmount(domesticStandingOrder2.getFirstPaymentAmount())
-                .firstPaymentDateTime(domesticStandingOrder2.getFirstPaymentDateTime())
-                .recurringPaymentAmount(domesticStandingOrder2.getRecurringPaymentAmount())
-                .recurringPaymentDateTime(domesticStandingOrder2.getRecurringPaymentDateTime())
-                .frequency(domesticStandingOrder2.getFrequency())
-                .numberOfPayments(domesticStandingOrder2.getNumberOfPayments())
-                .reference(domesticStandingOrder2.getReference());
+    public static OBDomesticStandingOrder1 toOBDomesticStandingOrder1(OBDomesticStandingOrder3 obDomesticStandingOrder3) {
+        return obDomesticStandingOrder3 == null ? null : (new OBDomesticStandingOrder1())
+                .frequency(obDomesticStandingOrder3.getFrequency())
+                .reference(obDomesticStandingOrder3.getReference())
+                .numberOfPayments(obDomesticStandingOrder3.getNumberOfPayments())
+                .firstPaymentDateTime(obDomesticStandingOrder3.getFirstPaymentDateTime())
+                .recurringPaymentDateTime(obDomesticStandingOrder3.getRecurringPaymentDateTime())
+                .finalPaymentDateTime(obDomesticStandingOrder3.getFinalPaymentDateTime())
+                .firstPaymentAmount(toOBActiveOrHistoricCurrencyAndAmount(obDomesticStandingOrder3.getFirstPaymentAmount()))
+                .recurringPaymentAmount(toOBActiveOrHistoricCurrencyAndAmount(obDomesticStandingOrder3.getRecurringPaymentAmount()))
+                .finalPaymentAmount(toOBActiveOrHistoricCurrencyAndAmount(obDomesticStandingOrder3.getFinalPaymentAmount()))
+                .debtorAccount(toOBCashAccount3(obDomesticStandingOrder3.getDebtorAccount()))
+                .creditorAccount(toOBCashAccount3(obDomesticStandingOrder3.getCreditorAccount()));
+    }
+
+    public static OBDomesticStandingOrder2 toOBDomesticStandingOrder2(OBDomesticStandingOrder1 obDomesticStandingOrder1) {
+        return obDomesticStandingOrder1 == null ? null : (new OBDomesticStandingOrder2())
+                .frequency(obDomesticStandingOrder1.getFrequency())
+                .reference(obDomesticStandingOrder1.getReference())
+                .numberOfPayments(obDomesticStandingOrder1.getNumberOfPayments())
+                .firstPaymentDateTime(obDomesticStandingOrder1.getFirstPaymentDateTime())
+                .recurringPaymentDateTime(obDomesticStandingOrder1.getRecurringPaymentDateTime())
+                .finalPaymentDateTime(obDomesticStandingOrder1.getFinalPaymentDateTime())
+                .firstPaymentAmount(obDomesticStandingOrder1.getFirstPaymentAmount())
+                .recurringPaymentAmount(obDomesticStandingOrder1.getRecurringPaymentAmount())
+                .finalPaymentAmount(obDomesticStandingOrder1.getFinalPaymentAmount())
+                .debtorAccount(obDomesticStandingOrder1.getDebtorAccount())
+                .creditorAccount(obDomesticStandingOrder1.getCreditorAccount())
+                .supplementaryData(null);
+    }
+
+    public static OBDomesticStandingOrder2 toOBDomesticStandingOrder2(OBDomesticStandingOrder3 obDomesticStandingOrder3) {
+        return obDomesticStandingOrder3 == null ? null : (new OBDomesticStandingOrder2())
+                .frequency(obDomesticStandingOrder3.getFrequency())
+                .reference(obDomesticStandingOrder3.getReference())
+                .numberOfPayments(obDomesticStandingOrder3.getNumberOfPayments())
+                .firstPaymentDateTime(obDomesticStandingOrder3.getFirstPaymentDateTime())
+                .recurringPaymentDateTime(obDomesticStandingOrder3.getRecurringPaymentDateTime())
+                .finalPaymentDateTime(obDomesticStandingOrder3.getFinalPaymentDateTime())
+                .firstPaymentAmount(toOBActiveOrHistoricCurrencyAndAmount(obDomesticStandingOrder3.getFirstPaymentAmount()))
+                .recurringPaymentAmount(toOBActiveOrHistoricCurrencyAndAmount(obDomesticStandingOrder3.getRecurringPaymentAmount()))
+                .finalPaymentAmount(toOBActiveOrHistoricCurrencyAndAmount(obDomesticStandingOrder3.getFinalPaymentAmount()))
+                .debtorAccount(toOBCashAccount3(obDomesticStandingOrder3.getDebtorAccount()))
+                .creditorAccount(toOBCashAccount3(obDomesticStandingOrder3.getCreditorAccount()))
+                .supplementaryData(obDomesticStandingOrder3.getSupplementaryData());
     }
 
     public static OBDomesticStandingOrder3 toOBDomesticStandingOrder3(OBWriteDomesticStandingOrder3DataInitiation initiation) {
@@ -79,19 +112,19 @@ public class OBDomesticStandingOrderConverter {
                 .supplementaryData(initiation.getSupplementaryData());
     }
 
-    public static OBWriteDomesticStandingOrder3DataInitiation toOBWriteDomesticStandingOrder3DataInitiation(OBDomesticStandingOrder3 initiation) {
-        return initiation == null ? null : (new OBWriteDomesticStandingOrder3DataInitiation())
-                .frequency(initiation.getFrequency())
-                .reference(initiation.getReference())
-                .numberOfPayments(initiation.getNumberOfPayments())
-                .firstPaymentDateTime(initiation.getFirstPaymentDateTime())
-                .recurringPaymentDateTime(initiation.getRecurringPaymentDateTime())
-                .finalPaymentDateTime(initiation.getFinalPaymentDateTime())
-                .firstPaymentAmount(toOBWriteDomesticStandingOrder3DataInitiationFirstPaymentAmount(initiation.getFirstPaymentAmount()))
-                .recurringPaymentAmount(toOBWriteDomesticStandingOrder3DataInitiationRecurringPaymentAmount(initiation.getRecurringPaymentAmount()))
-                .finalPaymentAmount(toOBWriteDomesticStandingOrder3DataInitiationFinalPaymentAmount(initiation.getFinalPaymentAmount()))
-                .debtorAccount(toOBWriteDomesticStandingOrder3DataInitiationDebtorAccount(initiation.getDebtorAccount()))
-                .creditorAccount(toOBWriteDomesticStandingOrder3DataInitiationCreditorAccount(initiation.getCreditorAccount()))
-                .supplementaryData(initiation.getSupplementaryData());
+    public static OBWriteDomesticStandingOrder3DataInitiation toOBWriteDomesticStandingOrder3DataInitiation(OBDomesticStandingOrder3 obDomesticStandingOrder3) {
+        return obDomesticStandingOrder3 == null ? null : (new OBWriteDomesticStandingOrder3DataInitiation())
+                .frequency(obDomesticStandingOrder3.getFrequency())
+                .reference(obDomesticStandingOrder3.getReference())
+                .numberOfPayments(obDomesticStandingOrder3.getNumberOfPayments())
+                .firstPaymentDateTime(obDomesticStandingOrder3.getFirstPaymentDateTime())
+                .recurringPaymentDateTime(obDomesticStandingOrder3.getRecurringPaymentDateTime())
+                .finalPaymentDateTime(obDomesticStandingOrder3.getFinalPaymentDateTime())
+                .firstPaymentAmount(toOBWriteDomesticStandingOrder3DataInitiationFirstPaymentAmount(obDomesticStandingOrder3.getFirstPaymentAmount()))
+                .recurringPaymentAmount(toOBWriteDomesticStandingOrder3DataInitiationRecurringPaymentAmount(obDomesticStandingOrder3.getRecurringPaymentAmount()))
+                .finalPaymentAmount(toOBWriteDomesticStandingOrder3DataInitiationFinalPaymentAmount(obDomesticStandingOrder3.getFinalPaymentAmount()))
+                .debtorAccount(toOBWriteDomesticStandingOrder3DataInitiationDebtorAccount(obDomesticStandingOrder3.getDebtorAccount()))
+                .creditorAccount(toOBWriteDomesticStandingOrder3DataInitiationCreditorAccount(obDomesticStandingOrder3.getCreditorAccount()))
+                .supplementaryData(obDomesticStandingOrder3.getSupplementaryData());
     }
 }

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBDomesticStandingOrderConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBDomesticStandingOrderConverter.java
@@ -20,6 +20,8 @@
  */
 package uk.org.openbanking.datamodel.service.converter.payment;
 
+import uk.org.openbanking.datamodel.payment.OBDomesticStandingOrder1;
+import uk.org.openbanking.datamodel.payment.OBDomesticStandingOrder2;
 import uk.org.openbanking.datamodel.payment.OBDomesticStandingOrder3;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3DataInitiation;
 
@@ -30,6 +32,36 @@ import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountCo
 import static uk.org.openbanking.datamodel.service.converter.payment.OBAmountConverter.*;
 
 public class OBDomesticStandingOrderConverter {
+
+    public static OBDomesticStandingOrder2 toOBDomesticStandingOrder2(OBDomesticStandingOrder1 domesticStandingOrder1) {
+        return (new OBDomesticStandingOrder2())
+                .creditorAccount(domesticStandingOrder1.getCreditorAccount())
+                .debtorAccount(domesticStandingOrder1.getDebtorAccount())
+                .finalPaymentAmount(domesticStandingOrder1.getFinalPaymentAmount())
+                .finalPaymentDateTime(domesticStandingOrder1.getFinalPaymentDateTime())
+                .firstPaymentAmount(domesticStandingOrder1.getFirstPaymentAmount())
+                .firstPaymentDateTime(domesticStandingOrder1.getFirstPaymentDateTime())
+                .recurringPaymentAmount(domesticStandingOrder1.getRecurringPaymentAmount())
+                .recurringPaymentDateTime(domesticStandingOrder1.getRecurringPaymentDateTime())
+                .frequency(domesticStandingOrder1.getFrequency())
+                .numberOfPayments(domesticStandingOrder1.getNumberOfPayments())
+                .reference(domesticStandingOrder1.getReference());
+    }
+
+    public static OBDomesticStandingOrder1 toOBDomesticStandingOrder1(OBDomesticStandingOrder2 domesticStandingOrder2) {
+        return (new OBDomesticStandingOrder1())
+                .creditorAccount(domesticStandingOrder2.getCreditorAccount())
+                .debtorAccount(domesticStandingOrder2.getDebtorAccount())
+                .finalPaymentAmount(domesticStandingOrder2.getFinalPaymentAmount())
+                .finalPaymentDateTime(domesticStandingOrder2.getFinalPaymentDateTime())
+                .firstPaymentAmount(domesticStandingOrder2.getFirstPaymentAmount())
+                .firstPaymentDateTime(domesticStandingOrder2.getFirstPaymentDateTime())
+                .recurringPaymentAmount(domesticStandingOrder2.getRecurringPaymentAmount())
+                .recurringPaymentDateTime(domesticStandingOrder2.getRecurringPaymentDateTime())
+                .frequency(domesticStandingOrder2.getFrequency())
+                .numberOfPayments(domesticStandingOrder2.getNumberOfPayments())
+                .reference(domesticStandingOrder2.getReference());
+    }
 
     public static OBDomesticStandingOrder3 toOBDomesticStandingOrder3(OBWriteDomesticStandingOrder3DataInitiation initiation) {
         return initiation == null ? null : (new OBDomesticStandingOrder3())

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBExchangeRateConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBExchangeRateConverter.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.datamodel.service.converter.payment;
+
+import uk.org.openbanking.datamodel.payment.OBExchangeRate1;
+import uk.org.openbanking.datamodel.payment.OBExchangeRate2;
+import uk.org.openbanking.datamodel.payment.OBExchangeRateType2Code;
+import uk.org.openbanking.datamodel.payment.OBWriteInternational3DataInitiationExchangeRateInformation;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse4DataExchangeRateInformation;
+
+public class OBExchangeRateConverter {
+
+    public static OBExchangeRate1 toOBExchangeRate1(OBWriteInternational3DataInitiationExchangeRateInformation exchangeRateInformation) {
+        return exchangeRateInformation == null ? null : (new OBExchangeRate1())
+                .unitCurrency(exchangeRateInformation.getUnitCurrency())
+                .exchangeRate(exchangeRateInformation.getExchangeRate())
+                .rateType(toOBExchangeRateType2Code(exchangeRateInformation.getRateType()))
+                .contractIdentification(exchangeRateInformation.getContractIdentification());
+    }
+
+    public static OBExchangeRate2 toOBExchangeRate2(OBWriteInternationalConsentResponse4DataExchangeRateInformation calculatedExchangeRate) {
+        return calculatedExchangeRate == null ? null : (new OBExchangeRate2())
+                .unitCurrency(calculatedExchangeRate.getUnitCurrency())
+                .exchangeRate(calculatedExchangeRate.getExchangeRate())
+                .rateType(toOBExchangeRateType2Code(calculatedExchangeRate.getRateType()))
+                .contractIdentification(calculatedExchangeRate.getContractIdentification())
+                .expirationDateTime(calculatedExchangeRate.getExpirationDateTime());
+    }
+
+    public static OBWriteInternational3DataInitiationExchangeRateInformation toOBWriteInternational3DataInitiationExchangeRateInformation(OBExchangeRate1 exchangeRateInformation) {
+        return exchangeRateInformation == null ? null : (new OBWriteInternational3DataInitiationExchangeRateInformation())
+                .unitCurrency(exchangeRateInformation.getUnitCurrency())
+                .exchangeRate(exchangeRateInformation.getExchangeRate())
+                .rateType(toRateTypeEnum(exchangeRateInformation.getRateType()))
+                .contractIdentification(exchangeRateInformation.getContractIdentification());
+    }
+
+    public static OBWriteInternational3DataInitiationExchangeRateInformation.RateTypeEnum toRateTypeEnum(OBExchangeRateType2Code rateType) {
+        return rateType == null ? null : OBWriteInternational3DataInitiationExchangeRateInformation.RateTypeEnum.valueOf(rateType.name());
+    }
+
+    public static OBExchangeRateType2Code toOBExchangeRateType2Code(OBWriteInternational3DataInitiationExchangeRateInformation.RateTypeEnum rateType) {
+        return rateType == null ? null : OBExchangeRateType2Code.valueOf(rateType.name());
+    }
+
+    public static OBExchangeRateType2Code toOBExchangeRateType2Code(OBWriteInternationalConsentResponse4DataExchangeRateInformation.RateTypeEnum rateType) {
+        return rateType == null ? null : OBExchangeRateType2Code.valueOf(rateType.name());
+    }
+}

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBFileConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBFileConverter.java
@@ -20,65 +20,42 @@
  */
 package uk.org.openbanking.datamodel.service.converter.payment;
 
-import uk.org.openbanking.datamodel.payment.*;
+import uk.org.openbanking.datamodel.payment.OBFile2;
+import uk.org.openbanking.datamodel.payment.OBWriteFile2DataInitiation;
+
+import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBCashAccount3;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBWriteDomestic2DataInitiationDebtorAccount;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBRemittanceInformationConverter.toOBRemittanceInformation1;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBRemittanceInformationConverter.toOBWriteDomestic2DataInitiationRemittanceInformation;
 
 public class OBFileConverter {
 
-    public static OBFile2 toOBFile2(OBFile1 obFile1) {
-        return new OBFile2()
-                .controlSum(obFile1.getControlSum())
-                .debtorAccount(obFile1.getDebtorAccount())
-                .fileHash(obFile1.getFileHash())
-                .fileReference(obFile1.getFileReference())
-                .fileType(obFile1.getFileType())
-                .localInstrument(obFile1.getLocalInstrument())
-                .numberOfTransactions(obFile1.getNumberOfTransactions())
-                .requestedExecutionDateTime(obFile1.getRequestedExecutionDateTime())
-                .remittanceInformation(obFile1.getRemittanceInformation());
+    public static OBFile2 toOBFile2(OBWriteFile2DataInitiation initiation) {
+        return initiation == null ? null : (new OBFile2())
+                .fileType(initiation.getFileType())
+                .fileHash(initiation.getFileHash())
+                .fileReference(initiation.getFileReference())
+                .numberOfTransactions(initiation.getNumberOfTransactions())
+                .controlSum(initiation.getControlSum())
+                .requestedExecutionDateTime(initiation.getRequestedExecutionDateTime())
+                .localInstrument(initiation.getLocalInstrument())
+                .debtorAccount(toOBCashAccount3(initiation.getDebtorAccount()))
+                .remittanceInformation(toOBRemittanceInformation1(initiation.getRemittanceInformation()))
+                .supplementaryData(initiation.getSupplementaryData());
     }
 
-    public static OBFile1 toOBFile1(OBFile2 obFile2) {
-        return new OBFile1()
-                .controlSum(obFile2.getControlSum())
-                .debtorAccount(obFile2.getDebtorAccount())
-                .fileHash(obFile2.getFileHash())
-                .fileReference(obFile2.getFileReference())
-                .fileType(obFile2.getFileType())
-                .localInstrument(obFile2.getLocalInstrument())
-                .numberOfTransactions(obFile2.getNumberOfTransactions())
-                .requestedExecutionDateTime(obFile2.getRequestedExecutionDateTime())
-                .remittanceInformation(obFile2.getRemittanceInformation());
+    public static OBWriteFile2DataInitiation toOBWriteFile2DataInitiation(OBFile2 initiation) {
+        return initiation == null ? null : (new OBWriteFile2DataInitiation())
+                .fileType(initiation.getFileType())
+                .fileHash(initiation.getFileHash())
+                .fileReference(initiation.getFileReference())
+                .numberOfTransactions(initiation.getNumberOfTransactions())
+                .controlSum(initiation.getControlSum())
+                .requestedExecutionDateTime(initiation.getRequestedExecutionDateTime())
+                .localInstrument(initiation.getLocalInstrument())
+                .debtorAccount(toOBWriteDomestic2DataInitiationDebtorAccount(initiation.getDebtorAccount()))
+                .remittanceInformation(toOBWriteDomestic2DataInitiationRemittanceInformation(initiation.getRemittanceInformation()))
+                .supplementaryData(initiation.getSupplementaryData());
     }
 
-    public static OBWriteFileConsent2 toOBWriteFileConsent2(OBWriteFileConsent1 obWriteFileConsent1) {
-        return new OBWriteFileConsent2()
-                .data(new OBWriteDataFileConsent2()
-                        .authorisation(obWriteFileConsent1.getData().getAuthorisation())
-                        .initiation(toOBFile2(obWriteFileConsent1.getData().getInitiation()))
-                );
-    }
-
-    public static OBWriteFileConsent1 toOBWriteFileConsent1(OBWriteFileConsent2 obWriteFileConsent2) {
-        return new OBWriteFileConsent1()
-                .data(new OBWriteDataFileConsent1()
-                        .authorisation(obWriteFileConsent2.getData().getAuthorisation())
-                        .initiation(toOBFile1(obWriteFileConsent2.getData().getInitiation()))
-                );
-    }
-
-    public static OBWriteFile2 toOBWriteFile2(OBWriteFile1 obWriteFile1) {
-        return new OBWriteFile2()
-                .data(new OBWriteDataFile2()
-                        .consentId(obWriteFile1.getData().getConsentId())
-                        .initiation(toOBFile2(obWriteFile1.getData().getInitiation()))
-                );
-    }
-
-    public static OBWriteFile1 toOBWriteFile1(OBWriteFile2 obWriteFile2) {
-        return new OBWriteFile1()
-                .data(new OBWriteDataFile1()
-                        .consentId(obWriteFile2.getData().getConsentId())
-                        .initiation(toOBFile1(obWriteFile2.getData().getInitiation()))
-                );
-    }
 }

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBFileConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBFileConverter.java
@@ -20,6 +20,7 @@
  */
 package uk.org.openbanking.datamodel.service.converter.payment;
 
+import uk.org.openbanking.datamodel.payment.OBFile1;
 import uk.org.openbanking.datamodel.payment.OBFile2;
 import uk.org.openbanking.datamodel.payment.OBWriteFile2DataInitiation;
 
@@ -29,6 +30,32 @@ import static uk.org.openbanking.datamodel.service.converter.payment.OBRemittanc
 import static uk.org.openbanking.datamodel.service.converter.payment.OBRemittanceInformationConverter.toOBWriteDomestic2DataInitiationRemittanceInformation;
 
 public class OBFileConverter {
+
+    public static OBFile1 toOBFile1(OBFile2 obFile2) {
+        return (new OBFile1())
+                .controlSum(obFile2.getControlSum())
+                .debtorAccount(obFile2.getDebtorAccount())
+                .fileHash(obFile2.getFileHash())
+                .fileReference(obFile2.getFileReference())
+                .fileType(obFile2.getFileType())
+                .localInstrument(obFile2.getLocalInstrument())
+                .numberOfTransactions(obFile2.getNumberOfTransactions())
+                .requestedExecutionDateTime(obFile2.getRequestedExecutionDateTime())
+                .remittanceInformation(obFile2.getRemittanceInformation());
+    }
+
+    public static OBFile2 toOBFile2(OBFile1 obFile1) {
+        return (new OBFile2())
+                .controlSum(obFile1.getControlSum())
+                .debtorAccount(obFile1.getDebtorAccount())
+                .fileHash(obFile1.getFileHash())
+                .fileReference(obFile1.getFileReference())
+                .fileType(obFile1.getFileType())
+                .localInstrument(obFile1.getLocalInstrument())
+                .numberOfTransactions(obFile1.getNumberOfTransactions())
+                .requestedExecutionDateTime(obFile1.getRequestedExecutionDateTime())
+                .remittanceInformation(obFile1.getRemittanceInformation());
+    }
 
     public static OBFile2 toOBFile2(OBWriteFile2DataInitiation initiation) {
         return initiation == null ? null : (new OBFile2())

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBFileConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBFileConverter.java
@@ -54,7 +54,8 @@ public class OBFileConverter {
                 .localInstrument(obFile1.getLocalInstrument())
                 .numberOfTransactions(obFile1.getNumberOfTransactions())
                 .requestedExecutionDateTime(obFile1.getRequestedExecutionDateTime())
-                .remittanceInformation(obFile1.getRemittanceInformation());
+                .remittanceInformation(obFile1.getRemittanceInformation())
+                .supplementaryData(null);
     }
 
     public static OBFile2 toOBFile2(OBWriteFile2DataInitiation initiation) {

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBInternationalConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBInternationalConverter.java
@@ -20,79 +20,81 @@
  */
 package uk.org.openbanking.datamodel.service.converter.payment;
 
-import uk.org.openbanking.datamodel.payment.*;
+import uk.org.openbanking.datamodel.payment.OBInternational1;
+import uk.org.openbanking.datamodel.payment.OBInternational2;
+import uk.org.openbanking.datamodel.payment.OBWriteInternational3DataInitiation;
+
+import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBCashAccount3;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBWriteDomestic2DataInitiationCreditorAccount;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBWriteDomestic2DataInitiationDebtorAccount;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBAmountConverter.toOBActiveOrHistoricCurrencyAndAmount;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBAmountConverter.toOBWriteDomestic2DataInitiationInstructedAmount;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBExchangeRateConverter.toOBExchangeRate1;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBExchangeRateConverter.toOBWriteInternational3DataInitiationExchangeRateInformation;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalIdentifierConverter.toOBBranchAndFinancialInstitutionIdentification3;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalIdentifierConverter.toOBPartyIdentification43;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalIdentifierConverter.toOBWriteInternational3DataInitiationCreditor;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalIdentifierConverter.toOBWriteInternational3DataInitiationCreditorAgent;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBPriorityCodeConverter.toOBPriority2Code;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBPriorityCodeConverter.toOBWriteInternational3DataInitiationInstructionPriorityEnum;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBRemittanceInformationConverter.toOBRemittanceInformation1;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBRemittanceInformationConverter.toOBWriteDomestic2DataInitiationRemittanceInformation;
 
 public class OBInternationalConverter {
 
-    public static OBInternational2 toOBInternational2(OBInternational1 obInternational1) {
-        return new OBInternational2()
-                .creditorAccount(obInternational1.getCreditorAccount())
-                .debtorAccount(obInternational1.getDebtorAccount())
-                .endToEndIdentification(obInternational1.getEndToEndIdentification())
-                .instructedAmount(obInternational1.getInstructedAmount())
-                .instructionIdentification(obInternational1.getInstructionIdentification())
-                .localInstrument(obInternational1.getLocalInstrument())
-                .remittanceInformation(obInternational1.getRemittanceInformation())
-                .chargeBearer(obInternational1.getChargeBearer())
-                .creditor(obInternational1.getCreditor())
-                .creditorAgent(obInternational1.getCreditorAgent())
-                .currencyOfTransfer(obInternational1.getCurrencyOfTransfer())
-                .exchangeRateInformation(obInternational1.getExchangeRateInformation())
-                .instructionPriority(obInternational1.getInstructionPriority())
-                ;
+    public static OBInternational1 toOBInternational1(OBWriteInternational3DataInitiation initiation) {
+        return initiation == null ? null : (new OBInternational1())
+                .instructionIdentification(initiation.getInstructionIdentification())
+                .endToEndIdentification(initiation.getEndToEndIdentification())
+                .localInstrument(initiation.getLocalInstrument())
+                .instructionPriority(toOBPriority2Code(initiation.getInstructionPriority()))
+                .purpose(initiation.getPurpose())
+                .chargeBearer(initiation.getChargeBearer())
+                .currencyOfTransfer(initiation.getCurrencyOfTransfer())
+                .instructedAmount(toOBActiveOrHistoricCurrencyAndAmount(initiation.getInstructedAmount()))
+                .exchangeRateInformation(toOBExchangeRate1(initiation.getExchangeRateInformation()))
+                .debtorAccount(toOBCashAccount3(initiation.getDebtorAccount()))
+                .creditor(toOBPartyIdentification43(initiation.getCreditor()))
+                .creditorAgent(toOBBranchAndFinancialInstitutionIdentification3(initiation.getCreditorAgent()))
+                .creditorAccount(toOBCashAccount3(initiation.getCreditorAccount()))
+                .remittanceInformation(toOBRemittanceInformation1(initiation.getRemittanceInformation()));
     }
 
-    public static OBInternational1 toOBInternational1(OBInternational2 obInternational2) {
-        return new OBInternational1()
-                .creditorAccount(obInternational2.getCreditorAccount())
-                .debtorAccount(obInternational2.getDebtorAccount())
-                .endToEndIdentification(obInternational2.getEndToEndIdentification())
-                .instructedAmount(obInternational2.getInstructedAmount())
+    public static OBInternational2 toOBInternational2(OBWriteInternational3DataInitiation initiation) {
+        return initiation == null ? null : (new OBInternational2())
+                .instructionIdentification(initiation.getInstructionIdentification())
+                .endToEndIdentification(initiation.getEndToEndIdentification())
+                .localInstrument(initiation.getLocalInstrument())
+                .instructionPriority(toOBPriority2Code(initiation.getInstructionPriority()))
+                .purpose(initiation.getPurpose())
+                .chargeBearer(initiation.getChargeBearer())
+                .currencyOfTransfer(initiation.getCurrencyOfTransfer())
+                .instructedAmount(toOBActiveOrHistoricCurrencyAndAmount(initiation.getInstructedAmount()))
+                .exchangeRateInformation(toOBExchangeRate1(initiation.getExchangeRateInformation()))
+                .debtorAccount(toOBCashAccount3(initiation.getDebtorAccount()))
+                .creditor(toOBPartyIdentification43(initiation.getCreditor()))
+                .creditorAgent(toOBBranchAndFinancialInstitutionIdentification3(initiation.getCreditorAgent()))
+                .creditorAccount(toOBCashAccount3(initiation.getCreditorAccount()))
+                .remittanceInformation(toOBRemittanceInformation1(initiation.getRemittanceInformation()))
+                .supplementaryData(initiation.getSupplementaryData());
+    }
+
+    public static OBWriteInternational3DataInitiation toOBWriteInternational3DataInitiation(OBInternational2 obInternational2) {
+        return obInternational2 == null ? null : (new OBWriteInternational3DataInitiation())
                 .instructionIdentification(obInternational2.getInstructionIdentification())
+                .endToEndIdentification(obInternational2.getEndToEndIdentification())
                 .localInstrument(obInternational2.getLocalInstrument())
-                .remittanceInformation(obInternational2.getRemittanceInformation())
+                .instructionPriority(toOBWriteInternational3DataInitiationInstructionPriorityEnum(obInternational2.getInstructionPriority()))
+                .purpose(obInternational2.getPurpose())
                 .chargeBearer(obInternational2.getChargeBearer())
-                .creditor(obInternational2.getCreditor())
-                .creditorAgent(obInternational2.getCreditorAgent())
                 .currencyOfTransfer(obInternational2.getCurrencyOfTransfer())
-                .exchangeRateInformation(obInternational2.getExchangeRateInformation())
-                .instructionPriority(obInternational2.getInstructionPriority())
-                ;
-    }
-
-    public static OBWriteInternationalConsent2 toOBWriteInternationalConsent2(OBWriteInternationalConsent1 obWriteInternationalConsent1) {
-        return new OBWriteInternationalConsent2()
-                .data(new OBWriteDataInternationalConsent2()
-                        .authorisation(obWriteInternationalConsent1.getData().getAuthorisation())
-                        .initiation(toOBInternational2(obWriteInternationalConsent1.getData().getInitiation()))
-                )
-                .risk(obWriteInternationalConsent1.getRisk());
-    }
-
-    public static OBWriteInternationalConsent1 toOBWriteInternationalConsent1(OBWriteInternationalConsent2 obWriteInternationalConsent2) {
-        return new OBWriteInternationalConsent1()
-                .data(new OBWriteDataInternationalConsent1()
-                        .authorisation(obWriteInternationalConsent2.getData().getAuthorisation())
-                        .initiation(toOBInternational1(obWriteInternationalConsent2.getData().getInitiation()))
-                )
-                .risk(obWriteInternationalConsent2.getRisk());
-    }
-
-    public static OBWriteInternational2 toOBWriteInternational2(OBWriteInternational1 obWriteInternational1) {
-        return new OBWriteInternational2()
-                .data(new OBWriteDataInternational2()
-                        .consentId(obWriteInternational1.getData().getConsentId())
-                        .initiation(toOBInternational2(obWriteInternational1.getData().getInitiation()))
-                )
-                .risk(obWriteInternational1.getRisk());
-    }
-
-    public static OBWriteInternational1 toOBWriteInternational1(OBWriteInternational2 obWriteInternational2) {
-        return new OBWriteInternational1()
-                .data(new OBWriteDataInternational1()
-                        .consentId(obWriteInternational2.getData().getConsentId())
-                        .initiation(toOBInternational1(obWriteInternational2.getData().getInitiation()))
-                )
-                .risk(obWriteInternational2.getRisk());
+                .instructedAmount(toOBWriteDomestic2DataInitiationInstructedAmount(obInternational2.getInstructedAmount()))
+                .exchangeRateInformation(toOBWriteInternational3DataInitiationExchangeRateInformation(obInternational2.getExchangeRateInformation()))
+                .debtorAccount(toOBWriteDomestic2DataInitiationDebtorAccount(obInternational2.getDebtorAccount()))
+                .creditor(toOBWriteInternational3DataInitiationCreditor(obInternational2.getCreditor()))
+                .creditorAgent(toOBWriteInternational3DataInitiationCreditorAgent(obInternational2.getCreditorAgent()))
+                .creditorAccount(toOBWriteDomestic2DataInitiationCreditorAccount(obInternational2.getCreditorAccount()))
+                .remittanceInformation(toOBWriteDomestic2DataInitiationRemittanceInformation(obInternational2.getRemittanceInformation()))
+                .supplementaryData(obInternational2.getSupplementaryData());
     }
 }

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBInternationalConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBInternationalConverter.java
@@ -42,6 +42,40 @@ import static uk.org.openbanking.datamodel.service.converter.payment.OBRemittanc
 
 public class OBInternationalConverter {
 
+    public static OBInternational2 toOBInternational2(OBInternational1 obInternational1) {
+        return obInternational1 == null ? null : (new OBInternational2())
+                .creditorAccount(obInternational1.getCreditorAccount())
+                .debtorAccount(obInternational1.getDebtorAccount())
+                .endToEndIdentification(obInternational1.getEndToEndIdentification())
+                .instructedAmount(obInternational1.getInstructedAmount())
+                .instructionIdentification(obInternational1.getInstructionIdentification())
+                .localInstrument(obInternational1.getLocalInstrument())
+                .remittanceInformation(obInternational1.getRemittanceInformation())
+                .chargeBearer(obInternational1.getChargeBearer())
+                .creditor(obInternational1.getCreditor())
+                .creditorAgent(obInternational1.getCreditorAgent())
+                .currencyOfTransfer(obInternational1.getCurrencyOfTransfer())
+                .exchangeRateInformation(obInternational1.getExchangeRateInformation())
+                .instructionPriority(obInternational1.getInstructionPriority());
+    }
+
+    public static OBInternational1 toOBInternational1(OBInternational2 obInternational2) {
+        return obInternational2 == null ? null : (new OBInternational1())
+                .creditorAccount(obInternational2.getCreditorAccount())
+                .debtorAccount(obInternational2.getDebtorAccount())
+                .endToEndIdentification(obInternational2.getEndToEndIdentification())
+                .instructedAmount(obInternational2.getInstructedAmount())
+                .instructionIdentification(obInternational2.getInstructionIdentification())
+                .localInstrument(obInternational2.getLocalInstrument())
+                .remittanceInformation(obInternational2.getRemittanceInformation())
+                .chargeBearer(obInternational2.getChargeBearer())
+                .creditor(obInternational2.getCreditor())
+                .creditorAgent(obInternational2.getCreditorAgent())
+                .currencyOfTransfer(obInternational2.getCurrencyOfTransfer())
+                .exchangeRateInformation(obInternational2.getExchangeRateInformation())
+                .instructionPriority(obInternational2.getInstructionPriority());
+    }
+
     public static OBInternational1 toOBInternational1(OBWriteInternational3DataInitiation initiation) {
         return initiation == null ? null : (new OBInternational1())
                 .instructionIdentification(initiation.getInstructionIdentification())

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBInternationalConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBInternationalConverter.java
@@ -42,38 +42,22 @@ import static uk.org.openbanking.datamodel.service.converter.payment.OBRemittanc
 
 public class OBInternationalConverter {
 
-    public static OBInternational2 toOBInternational2(OBInternational1 obInternational1) {
-        return obInternational1 == null ? null : (new OBInternational2())
-                .creditorAccount(obInternational1.getCreditorAccount())
-                .debtorAccount(obInternational1.getDebtorAccount())
-                .endToEndIdentification(obInternational1.getEndToEndIdentification())
-                .instructedAmount(obInternational1.getInstructedAmount())
-                .instructionIdentification(obInternational1.getInstructionIdentification())
-                .localInstrument(obInternational1.getLocalInstrument())
-                .remittanceInformation(obInternational1.getRemittanceInformation())
-                .chargeBearer(obInternational1.getChargeBearer())
-                .creditor(obInternational1.getCreditor())
-                .creditorAgent(obInternational1.getCreditorAgent())
-                .currencyOfTransfer(obInternational1.getCurrencyOfTransfer())
-                .exchangeRateInformation(obInternational1.getExchangeRateInformation())
-                .instructionPriority(obInternational1.getInstructionPriority());
-    }
-
     public static OBInternational1 toOBInternational1(OBInternational2 obInternational2) {
         return obInternational2 == null ? null : (new OBInternational1())
-                .creditorAccount(obInternational2.getCreditorAccount())
-                .debtorAccount(obInternational2.getDebtorAccount())
-                .endToEndIdentification(obInternational2.getEndToEndIdentification())
-                .instructedAmount(obInternational2.getInstructedAmount())
                 .instructionIdentification(obInternational2.getInstructionIdentification())
+                .endToEndIdentification(obInternational2.getEndToEndIdentification())
                 .localInstrument(obInternational2.getLocalInstrument())
-                .remittanceInformation(obInternational2.getRemittanceInformation())
+                .instructionPriority(obInternational2.getInstructionPriority())
+                .purpose(obInternational2.getPurpose())
                 .chargeBearer(obInternational2.getChargeBearer())
+                .currencyOfTransfer(obInternational2.getCurrencyOfTransfer())
+                .instructedAmount(obInternational2.getInstructedAmount())
+                .exchangeRateInformation(obInternational2.getExchangeRateInformation())
+                .debtorAccount(obInternational2.getDebtorAccount())
                 .creditor(obInternational2.getCreditor())
                 .creditorAgent(obInternational2.getCreditorAgent())
-                .currencyOfTransfer(obInternational2.getCurrencyOfTransfer())
-                .exchangeRateInformation(obInternational2.getExchangeRateInformation())
-                .instructionPriority(obInternational2.getInstructionPriority());
+                .creditorAccount(obInternational2.getCreditorAccount())
+                .remittanceInformation(obInternational2.getRemittanceInformation());
     }
 
     public static OBInternational1 toOBInternational1(OBWriteInternational3DataInitiation initiation) {
@@ -92,6 +76,25 @@ public class OBInternationalConverter {
                 .creditorAgent(toOBBranchAndFinancialInstitutionIdentification3(initiation.getCreditorAgent()))
                 .creditorAccount(toOBCashAccount3(initiation.getCreditorAccount()))
                 .remittanceInformation(toOBRemittanceInformation1(initiation.getRemittanceInformation()));
+    }
+
+    public static OBInternational2 toOBInternational2(OBInternational1 obInternational1) {
+        return obInternational1 == null ? null : (new OBInternational2())
+                .instructionIdentification(obInternational1.getInstructionIdentification())
+                .endToEndIdentification(obInternational1.getEndToEndIdentification())
+                .localInstrument(obInternational1.getLocalInstrument())
+                .instructionPriority(obInternational1.getInstructionPriority())
+                .purpose(obInternational1.getPurpose())
+                .chargeBearer(obInternational1.getChargeBearer())
+                .currencyOfTransfer(obInternational1.getCurrencyOfTransfer())
+                .instructedAmount(obInternational1.getInstructedAmount())
+                .exchangeRateInformation(obInternational1.getExchangeRateInformation())
+                .debtorAccount(obInternational1.getDebtorAccount())
+                .creditor(obInternational1.getCreditor())
+                .creditorAgent(obInternational1.getCreditorAgent())
+                .creditorAccount(obInternational1.getCreditorAccount())
+                .remittanceInformation(obInternational1.getRemittanceInformation())
+                .supplementaryData(null);
     }
 
     public static OBInternational2 toOBInternational2(OBWriteInternational3DataInitiation initiation) {

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBInternationalIdentifierConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBInternationalIdentifierConverter.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.datamodel.service.converter.payment;
+
+import uk.org.openbanking.datamodel.payment.OBBranchAndFinancialInstitutionIdentification3;
+import uk.org.openbanking.datamodel.payment.OBBranchAndFinancialInstitutionIdentification6;
+import uk.org.openbanking.datamodel.payment.OBPartyIdentification43;
+import uk.org.openbanking.datamodel.payment.OBWriteInternational3DataInitiationCreditor;
+import uk.org.openbanking.datamodel.payment.OBWriteInternational3DataInitiationCreditorAgent;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrder4DataInitiationCreditorAgent;
+
+import static uk.org.openbanking.datamodel.service.converter.payment.ConverterHelper.copyField;
+
+public class OBInternationalIdentifierConverter {
+
+    public static OBWriteInternational3DataInitiationCreditorAgent toOBWriteInternational3DataInitiationCreditorAgent(OBBranchAndFinancialInstitutionIdentification3 creditorAgent) {
+        return toAgent(new OBWriteInternational3DataInitiationCreditorAgent(), creditorAgent);
+    }
+
+    public static OBBranchAndFinancialInstitutionIdentification3 toOBBranchAndFinancialInstitutionIdentification3(OBWriteInternational3DataInitiationCreditorAgent creditorAgent) {
+        return toAgent(new OBBranchAndFinancialInstitutionIdentification3(), creditorAgent);
+    }
+
+    public static OBBranchAndFinancialInstitutionIdentification3 toOBBranchAndFinancialInstitutionIdentification3(OBWriteInternationalStandingOrder4DataInitiationCreditorAgent creditorAgent) {
+        return toAgent(new OBBranchAndFinancialInstitutionIdentification3(), creditorAgent);
+    }
+
+    public static OBBranchAndFinancialInstitutionIdentification6 toOBBranchAndFinancialInstitutionIdentification6(OBWriteInternationalStandingOrder4DataInitiationCreditorAgent creditorAgent) {
+        return toAgent(new OBBranchAndFinancialInstitutionIdentification6(), creditorAgent);
+    }
+
+    public static OBWriteInternationalStandingOrder4DataInitiationCreditorAgent toOBWriteInternationalStandingOrder4DataInitiationCreditorAgent(OBBranchAndFinancialInstitutionIdentification3 creditorAgent) {
+        return toAgent(new OBWriteInternationalStandingOrder4DataInitiationCreditorAgent(), creditorAgent);
+    }
+
+    public static OBWriteInternationalStandingOrder4DataInitiationCreditorAgent toOBWriteInternationalStandingOrder4DataInitiationCreditorAgent(OBBranchAndFinancialInstitutionIdentification6 creditorAgent) {
+        return toAgent(new OBWriteInternationalStandingOrder4DataInitiationCreditorAgent(), creditorAgent);
+    }
+
+    public static OBWriteInternational3DataInitiationCreditor toOBWriteInternational3DataInitiationCreditor(OBPartyIdentification43 creditor) {
+        return toCreditor(new OBWriteInternational3DataInitiationCreditor(), creditor);
+    }
+
+    public static OBPartyIdentification43 toOBPartyIdentification43(OBWriteInternational3DataInitiationCreditor creditor) {
+        return toCreditor(new OBPartyIdentification43(), creditor);
+    }
+
+    private static <T, U> T toAgent(T newAgent, U originalAgent) {
+        if (originalAgent == null) {
+            return null;
+        }
+        copyField(newAgent, originalAgent, "schemeName");
+        copyField(newAgent, originalAgent, "identification");
+        copyField(newAgent, originalAgent, "name");
+        copyField(newAgent, originalAgent, "postalAddress");
+        return newAgent;
+    }
+
+    private static <T, U> T toCreditor(T newCreditor, U originalCreditor) {
+        if (originalCreditor == null) {
+            return null;
+        }
+        copyField(newCreditor, originalCreditor, "name");
+        copyField(newCreditor, originalCreditor, "postalAddress");
+        return newCreditor;
+    }
+}

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBInternationalIdentifierConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBInternationalIdentifierConverter.java
@@ -51,6 +51,10 @@ public class OBInternationalIdentifierConverter {
         return toAgent(new OBBranchAndFinancialInstitutionIdentification6(), creditorAgent);
     }
 
+    public static OBBranchAndFinancialInstitutionIdentification6 toOBBranchAndFinancialInstitutionIdentification6(OBBranchAndFinancialInstitutionIdentification3 creditorAgent) {
+        return toAgent(new OBBranchAndFinancialInstitutionIdentification6(), creditorAgent);
+    }
+
     public static OBWriteInternationalStandingOrder4DataInitiationCreditorAgent toOBWriteInternationalStandingOrder4DataInitiationCreditorAgent(OBBranchAndFinancialInstitutionIdentification3 creditorAgent) {
         return toAgent(new OBWriteInternationalStandingOrder4DataInitiationCreditorAgent(), creditorAgent);
     }

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBInternationalIdentifierConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBInternationalIdentifierConverter.java
@@ -35,6 +35,10 @@ public class OBInternationalIdentifierConverter {
         return toAgent(new OBWriteInternational3DataInitiationCreditorAgent(), creditorAgent);
     }
 
+    public static OBBranchAndFinancialInstitutionIdentification3 toOBBranchAndFinancialInstitutionIdentification3(OBBranchAndFinancialInstitutionIdentification6 creditorAgent) {
+        return toAgent(new OBBranchAndFinancialInstitutionIdentification3(), creditorAgent);
+    }
+
     public static OBBranchAndFinancialInstitutionIdentification3 toOBBranchAndFinancialInstitutionIdentification3(OBWriteInternational3DataInitiationCreditorAgent creditorAgent) {
         return toAgent(new OBBranchAndFinancialInstitutionIdentification3(), creditorAgent);
     }

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBInternationalScheduledConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBInternationalScheduledConverter.java
@@ -42,6 +42,42 @@ import static uk.org.openbanking.datamodel.service.converter.payment.OBRemittanc
 
 public class OBInternationalScheduledConverter {
 
+    public static OBInternationalScheduled1 toOBInternationalScheduled1(OBInternationalScheduled2 obInternationalScheduled2) {
+        return obInternationalScheduled2 == null ? null : (new OBInternationalScheduled1())
+                .creditorAccount(obInternationalScheduled2.getCreditorAccount())
+                .debtorAccount(obInternationalScheduled2.getDebtorAccount())
+                .endToEndIdentification(obInternationalScheduled2.getEndToEndIdentification())
+                .instructedAmount(obInternationalScheduled2.getInstructedAmount())
+                .instructionIdentification(obInternationalScheduled2.getInstructionIdentification())
+                .localInstrument(obInternationalScheduled2.getLocalInstrument())
+                .remittanceInformation(obInternationalScheduled2.getRemittanceInformation())
+                .chargeBearer(obInternationalScheduled2.getChargeBearer())
+                .creditor(obInternationalScheduled2.getCreditor())
+                .creditorAgent(obInternationalScheduled2.getCreditorAgent())
+                .currencyOfTransfer(obInternationalScheduled2.getCurrencyOfTransfer())
+                .exchangeRateInformation(obInternationalScheduled2.getExchangeRateInformation())
+                .instructionPriority(obInternationalScheduled2.getInstructionPriority())
+                .requestedExecutionDateTime(obInternationalScheduled2.getRequestedExecutionDateTime());
+    }
+
+    public static OBInternationalScheduled2 toOBInternationalScheduled2(OBInternationalScheduled1 obInternationalScheduled1) {
+        return obInternationalScheduled1 == null ? null : (new OBInternationalScheduled2())
+                .creditorAccount(obInternationalScheduled1.getCreditorAccount())
+                .debtorAccount(obInternationalScheduled1.getDebtorAccount())
+                .endToEndIdentification(obInternationalScheduled1.getEndToEndIdentification())
+                .instructedAmount(obInternationalScheduled1.getInstructedAmount())
+                .instructionIdentification(obInternationalScheduled1.getInstructionIdentification())
+                .localInstrument(obInternationalScheduled1.getLocalInstrument())
+                .remittanceInformation(obInternationalScheduled1.getRemittanceInformation())
+                .chargeBearer(obInternationalScheduled1.getChargeBearer())
+                .creditor(obInternationalScheduled1.getCreditor())
+                .creditorAgent(obInternationalScheduled1.getCreditorAgent())
+                .currencyOfTransfer(obInternationalScheduled1.getCurrencyOfTransfer())
+                .exchangeRateInformation(obInternationalScheduled1.getExchangeRateInformation())
+                .instructionPriority(obInternationalScheduled1.getInstructionPriority())
+                .requestedExecutionDateTime(obInternationalScheduled1.getRequestedExecutionDateTime());
+    }
+
     public static OBInternationalScheduled1 toOBInternationalScheduled1(OBWriteInternationalScheduled3DataInitiation initiation) {
         return initiation == null ? null : (new OBInternationalScheduled1())
                 .instructionIdentification(initiation.getInstructionIdentification())

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBInternationalScheduledConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBInternationalScheduledConverter.java
@@ -44,38 +44,21 @@ public class OBInternationalScheduledConverter {
 
     public static OBInternationalScheduled1 toOBInternationalScheduled1(OBInternationalScheduled2 obInternationalScheduled2) {
         return obInternationalScheduled2 == null ? null : (new OBInternationalScheduled1())
-                .creditorAccount(obInternationalScheduled2.getCreditorAccount())
-                .debtorAccount(obInternationalScheduled2.getDebtorAccount())
-                .endToEndIdentification(obInternationalScheduled2.getEndToEndIdentification())
-                .instructedAmount(obInternationalScheduled2.getInstructedAmount())
                 .instructionIdentification(obInternationalScheduled2.getInstructionIdentification())
+                .endToEndIdentification(obInternationalScheduled2.getEndToEndIdentification())
                 .localInstrument(obInternationalScheduled2.getLocalInstrument())
-                .remittanceInformation(obInternationalScheduled2.getRemittanceInformation())
+                .instructionPriority(obInternationalScheduled2.getInstructionPriority())
+                .purpose(obInternationalScheduled2.getPurpose())
                 .chargeBearer(obInternationalScheduled2.getChargeBearer())
+                .requestedExecutionDateTime(obInternationalScheduled2.getRequestedExecutionDateTime())
+                .currencyOfTransfer(obInternationalScheduled2.getCurrencyOfTransfer())
+                .instructedAmount(obInternationalScheduled2.getInstructedAmount())
+                .exchangeRateInformation(obInternationalScheduled2.getExchangeRateInformation())
+                .debtorAccount(obInternationalScheduled2.getDebtorAccount())
                 .creditor(obInternationalScheduled2.getCreditor())
                 .creditorAgent(obInternationalScheduled2.getCreditorAgent())
-                .currencyOfTransfer(obInternationalScheduled2.getCurrencyOfTransfer())
-                .exchangeRateInformation(obInternationalScheduled2.getExchangeRateInformation())
-                .instructionPriority(obInternationalScheduled2.getInstructionPriority())
-                .requestedExecutionDateTime(obInternationalScheduled2.getRequestedExecutionDateTime());
-    }
-
-    public static OBInternationalScheduled2 toOBInternationalScheduled2(OBInternationalScheduled1 obInternationalScheduled1) {
-        return obInternationalScheduled1 == null ? null : (new OBInternationalScheduled2())
-                .creditorAccount(obInternationalScheduled1.getCreditorAccount())
-                .debtorAccount(obInternationalScheduled1.getDebtorAccount())
-                .endToEndIdentification(obInternationalScheduled1.getEndToEndIdentification())
-                .instructedAmount(obInternationalScheduled1.getInstructedAmount())
-                .instructionIdentification(obInternationalScheduled1.getInstructionIdentification())
-                .localInstrument(obInternationalScheduled1.getLocalInstrument())
-                .remittanceInformation(obInternationalScheduled1.getRemittanceInformation())
-                .chargeBearer(obInternationalScheduled1.getChargeBearer())
-                .creditor(obInternationalScheduled1.getCreditor())
-                .creditorAgent(obInternationalScheduled1.getCreditorAgent())
-                .currencyOfTransfer(obInternationalScheduled1.getCurrencyOfTransfer())
-                .exchangeRateInformation(obInternationalScheduled1.getExchangeRateInformation())
-                .instructionPriority(obInternationalScheduled1.getInstructionPriority())
-                .requestedExecutionDateTime(obInternationalScheduled1.getRequestedExecutionDateTime());
+                .creditorAccount(obInternationalScheduled2.getCreditorAccount())
+                .remittanceInformation(obInternationalScheduled2.getRemittanceInformation());
     }
 
     public static OBInternationalScheduled1 toOBInternationalScheduled1(OBWriteInternationalScheduled3DataInitiation initiation) {
@@ -95,6 +78,26 @@ public class OBInternationalScheduledConverter {
                 .creditorAgent(toOBBranchAndFinancialInstitutionIdentification3(initiation.getCreditorAgent()))
                 .creditorAccount(toOBCashAccount3(initiation.getCreditorAccount()))
                 .remittanceInformation(toOBRemittanceInformation1(initiation.getRemittanceInformation()));
+    }
+
+    public static OBInternationalScheduled2 toOBInternationalScheduled2(OBInternationalScheduled1 obInternationalScheduled1) {
+        return obInternationalScheduled1 == null ? null : (new OBInternationalScheduled2())
+                .instructionIdentification(obInternationalScheduled1.getInstructionIdentification())
+                .endToEndIdentification(obInternationalScheduled1.getEndToEndIdentification())
+                .localInstrument(obInternationalScheduled1.getLocalInstrument())
+                .instructionPriority(obInternationalScheduled1.getInstructionPriority())
+                .purpose(obInternationalScheduled1.getPurpose())
+                .chargeBearer(obInternationalScheduled1.getChargeBearer())
+                .requestedExecutionDateTime(obInternationalScheduled1.getRequestedExecutionDateTime())
+                .currencyOfTransfer(obInternationalScheduled1.getCurrencyOfTransfer())
+                .instructedAmount(obInternationalScheduled1.getInstructedAmount())
+                .exchangeRateInformation(obInternationalScheduled1.getExchangeRateInformation())
+                .debtorAccount(obInternationalScheduled1.getDebtorAccount())
+                .creditor(obInternationalScheduled1.getCreditor())
+                .creditorAgent(obInternationalScheduled1.getCreditorAgent())
+                .creditorAccount(obInternationalScheduled1.getCreditorAccount())
+                .remittanceInformation(obInternationalScheduled1.getRemittanceInformation())
+                .supplementaryData(null);
     }
 
     public static OBInternationalScheduled2 toOBInternationalScheduled2(OBWriteInternationalScheduled3DataInitiation initiation) {
@@ -117,43 +120,44 @@ public class OBInternationalScheduledConverter {
                 .supplementaryData(initiation.getSupplementaryData());
     }
 
-    public static OBWriteInternationalScheduled3DataInitiation toOBWriteInternationalScheduled3DataInitiation(OBInternationalScheduled1 initiation) {
-        return initiation == null ? null : (new OBWriteInternationalScheduled3DataInitiation())
-                .instructionIdentification(initiation.getInstructionIdentification())
-                .endToEndIdentification(initiation.getEndToEndIdentification())
-                .localInstrument(initiation.getLocalInstrument())
-                .instructionPriority(toOBWriteInternationalScheduled3DataInitiationInstructionPriorityEnum(initiation.getInstructionPriority()))
-                .purpose(initiation.getPurpose())
-                .chargeBearer(initiation.getChargeBearer())
-                .requestedExecutionDateTime(initiation.getRequestedExecutionDateTime())
-                .currencyOfTransfer(initiation.getCurrencyOfTransfer())
-                .instructedAmount(toOBWriteDomestic2DataInitiationInstructedAmount(initiation.getInstructedAmount()))
-                .exchangeRateInformation(toOBWriteInternational3DataInitiationExchangeRateInformation(initiation.getExchangeRateInformation()))
-                .debtorAccount(toOBWriteDomestic2DataInitiationDebtorAccount(initiation.getDebtorAccount()))
-                .creditor(toOBWriteInternational3DataInitiationCreditor(initiation.getCreditor()))
-                .creditorAgent(toOBWriteInternational3DataInitiationCreditorAgent(initiation.getCreditorAgent()))
-                .creditorAccount(toOBWriteDomestic2DataInitiationCreditorAccount(initiation.getCreditorAccount()))
-                .remittanceInformation(toOBWriteDomestic2DataInitiationRemittanceInformation(initiation.getRemittanceInformation()));
+    public static OBWriteInternationalScheduled3DataInitiation toOBWriteInternationalScheduled3DataInitiation(OBInternationalScheduled1 obInternationalScheduled1) {
+        return obInternationalScheduled1 == null ? null : (new OBWriteInternationalScheduled3DataInitiation())
+                .instructionIdentification(obInternationalScheduled1.getInstructionIdentification())
+                .endToEndIdentification(obInternationalScheduled1.getEndToEndIdentification())
+                .localInstrument(obInternationalScheduled1.getLocalInstrument())
+                .instructionPriority(toOBWriteInternationalScheduled3DataInitiationInstructionPriorityEnum(obInternationalScheduled1.getInstructionPriority()))
+                .purpose(obInternationalScheduled1.getPurpose())
+                .chargeBearer(obInternationalScheduled1.getChargeBearer())
+                .requestedExecutionDateTime(obInternationalScheduled1.getRequestedExecutionDateTime())
+                .currencyOfTransfer(obInternationalScheduled1.getCurrencyOfTransfer())
+                .instructedAmount(toOBWriteDomestic2DataInitiationInstructedAmount(obInternationalScheduled1.getInstructedAmount()))
+                .exchangeRateInformation(toOBWriteInternational3DataInitiationExchangeRateInformation(obInternationalScheduled1.getExchangeRateInformation()))
+                .debtorAccount(toOBWriteDomestic2DataInitiationDebtorAccount(obInternationalScheduled1.getDebtorAccount()))
+                .creditor(toOBWriteInternational3DataInitiationCreditor(obInternationalScheduled1.getCreditor()))
+                .creditorAgent(toOBWriteInternational3DataInitiationCreditorAgent(obInternationalScheduled1.getCreditorAgent()))
+                .creditorAccount(toOBWriteDomestic2DataInitiationCreditorAccount(obInternationalScheduled1.getCreditorAccount()))
+                .remittanceInformation(toOBWriteDomestic2DataInitiationRemittanceInformation(obInternationalScheduled1.getRemittanceInformation()))
+                .supplementaryData(null);
     }
 
-    public static OBWriteInternationalScheduled3DataInitiation toOBWriteInternationalScheduled3DataInitiation(OBInternationalScheduled2 initiation) {
-        return initiation == null ? null : (new OBWriteInternationalScheduled3DataInitiation())
-                .instructionIdentification(initiation.getInstructionIdentification())
-                .endToEndIdentification(initiation.getEndToEndIdentification())
-                .localInstrument(initiation.getLocalInstrument())
-                .instructionPriority(toOBWriteInternationalScheduled3DataInitiationInstructionPriorityEnum(initiation.getInstructionPriority()))
-                .purpose(initiation.getPurpose())
-                .chargeBearer(initiation.getChargeBearer())
-                .requestedExecutionDateTime(initiation.getRequestedExecutionDateTime())
-                .currencyOfTransfer(initiation.getCurrencyOfTransfer())
-                .instructedAmount(toOBWriteDomestic2DataInitiationInstructedAmount(initiation.getInstructedAmount()))
-                .exchangeRateInformation(toOBWriteInternational3DataInitiationExchangeRateInformation(initiation.getExchangeRateInformation()))
-                .debtorAccount(toOBWriteDomestic2DataInitiationDebtorAccount(initiation.getDebtorAccount()))
-                .creditor(toOBWriteInternational3DataInitiationCreditor(initiation.getCreditor()))
-                .creditorAgent(toOBWriteInternational3DataInitiationCreditorAgent(initiation.getCreditorAgent()))
-                .creditorAccount(toOBWriteDomestic2DataInitiationCreditorAccount(initiation.getCreditorAccount()))
-                .remittanceInformation(toOBWriteDomestic2DataInitiationRemittanceInformation(initiation.getRemittanceInformation()))
-                .supplementaryData(initiation.getSupplementaryData());
+    public static OBWriteInternationalScheduled3DataInitiation toOBWriteInternationalScheduled3DataInitiation(OBInternationalScheduled2 obInternationalScheduled2) {
+        return obInternationalScheduled2 == null ? null : (new OBWriteInternationalScheduled3DataInitiation())
+                .instructionIdentification(obInternationalScheduled2.getInstructionIdentification())
+                .endToEndIdentification(obInternationalScheduled2.getEndToEndIdentification())
+                .localInstrument(obInternationalScheduled2.getLocalInstrument())
+                .instructionPriority(toOBWriteInternationalScheduled3DataInitiationInstructionPriorityEnum(obInternationalScheduled2.getInstructionPriority()))
+                .purpose(obInternationalScheduled2.getPurpose())
+                .chargeBearer(obInternationalScheduled2.getChargeBearer())
+                .requestedExecutionDateTime(obInternationalScheduled2.getRequestedExecutionDateTime())
+                .currencyOfTransfer(obInternationalScheduled2.getCurrencyOfTransfer())
+                .instructedAmount(toOBWriteDomestic2DataInitiationInstructedAmount(obInternationalScheduled2.getInstructedAmount()))
+                .exchangeRateInformation(toOBWriteInternational3DataInitiationExchangeRateInformation(obInternationalScheduled2.getExchangeRateInformation()))
+                .debtorAccount(toOBWriteDomestic2DataInitiationDebtorAccount(obInternationalScheduled2.getDebtorAccount()))
+                .creditor(toOBWriteInternational3DataInitiationCreditor(obInternationalScheduled2.getCreditor()))
+                .creditorAgent(toOBWriteInternational3DataInitiationCreditorAgent(obInternationalScheduled2.getCreditorAgent()))
+                .creditorAccount(toOBWriteDomestic2DataInitiationCreditorAccount(obInternationalScheduled2.getCreditorAccount()))
+                .remittanceInformation(toOBWriteDomestic2DataInitiationRemittanceInformation(obInternationalScheduled2.getRemittanceInformation()))
+                .supplementaryData(obInternationalScheduled2.getSupplementaryData());
     }
 
 }

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBInternationalScheduledConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBInternationalScheduledConverter.java
@@ -20,83 +20,104 @@
  */
 package uk.org.openbanking.datamodel.service.converter.payment;
 
-import uk.org.openbanking.datamodel.payment.*;
+import uk.org.openbanking.datamodel.payment.OBInternationalScheduled1;
+import uk.org.openbanking.datamodel.payment.OBInternationalScheduled2;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduled3DataInitiation;
+
+import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBCashAccount3;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBWriteDomestic2DataInitiationCreditorAccount;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBWriteDomestic2DataInitiationDebtorAccount;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBAmountConverter.toOBActiveOrHistoricCurrencyAndAmount;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBAmountConverter.toOBWriteDomestic2DataInitiationInstructedAmount;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBExchangeRateConverter.toOBExchangeRate1;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBExchangeRateConverter.toOBWriteInternational3DataInitiationExchangeRateInformation;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalIdentifierConverter.toOBBranchAndFinancialInstitutionIdentification3;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalIdentifierConverter.toOBPartyIdentification43;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalIdentifierConverter.toOBWriteInternational3DataInitiationCreditor;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalIdentifierConverter.toOBWriteInternational3DataInitiationCreditorAgent;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBPriorityCodeConverter.toOBPriority2Code;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBPriorityCodeConverter.toOBWriteInternationalScheduled3DataInitiationInstructionPriorityEnum;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBRemittanceInformationConverter.toOBRemittanceInformation1;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBRemittanceInformationConverter.toOBWriteDomestic2DataInitiationRemittanceInformation;
 
 public class OBInternationalScheduledConverter {
 
-    public static OBInternationalScheduled2 toOBInternationalScheduled2(OBInternationalScheduled1 obInternationalScheduled1) {
-        return new OBInternationalScheduled2()
-                .creditorAccount(obInternationalScheduled1.getCreditorAccount())
-                .debtorAccount(obInternationalScheduled1.getDebtorAccount())
-                .endToEndIdentification(obInternationalScheduled1.getEndToEndIdentification())
-                .instructedAmount(obInternationalScheduled1.getInstructedAmount())
-                .instructionIdentification(obInternationalScheduled1.getInstructionIdentification())
-                .localInstrument(obInternationalScheduled1.getLocalInstrument())
-                .remittanceInformation(obInternationalScheduled1.getRemittanceInformation())
-                .chargeBearer(obInternationalScheduled1.getChargeBearer())
-                .creditor(obInternationalScheduled1.getCreditor())
-                .creditorAgent(obInternationalScheduled1.getCreditorAgent())
-                .currencyOfTransfer(obInternationalScheduled1.getCurrencyOfTransfer())
-                .exchangeRateInformation(obInternationalScheduled1.getExchangeRateInformation())
-                .instructionPriority(obInternationalScheduled1.getInstructionPriority())
-                .requestedExecutionDateTime(obInternationalScheduled1.getRequestedExecutionDateTime())
-                ;
+    public static OBInternationalScheduled1 toOBInternationalScheduled1(OBWriteInternationalScheduled3DataInitiation initiation) {
+        return initiation == null ? null : (new OBInternationalScheduled1())
+                .instructionIdentification(initiation.getInstructionIdentification())
+                .endToEndIdentification(initiation.getEndToEndIdentification())
+                .localInstrument(initiation.getLocalInstrument())
+                .instructionPriority(toOBPriority2Code(initiation.getInstructionPriority()))
+                .purpose(initiation.getPurpose())
+                .chargeBearer(initiation.getChargeBearer())
+                .requestedExecutionDateTime(initiation.getRequestedExecutionDateTime())
+                .currencyOfTransfer(initiation.getCurrencyOfTransfer())
+                .instructedAmount(toOBActiveOrHistoricCurrencyAndAmount(initiation.getInstructedAmount()))
+                .exchangeRateInformation(toOBExchangeRate1(initiation.getExchangeRateInformation()))
+                .debtorAccount(toOBCashAccount3(initiation.getDebtorAccount()))
+                .creditor(toOBPartyIdentification43(initiation.getCreditor()))
+                .creditorAgent(toOBBranchAndFinancialInstitutionIdentification3(initiation.getCreditorAgent()))
+                .creditorAccount(toOBCashAccount3(initiation.getCreditorAccount()))
+                .remittanceInformation(toOBRemittanceInformation1(initiation.getRemittanceInformation()));
     }
 
-
-    public static OBInternationalScheduled1 toOBInternationalScheduled1(OBInternationalScheduled2 obInternationalScheduled2) {
-        return new OBInternationalScheduled1()
-                .creditorAccount(obInternationalScheduled2.getCreditorAccount())
-                .debtorAccount(obInternationalScheduled2.getDebtorAccount())
-                .endToEndIdentification(obInternationalScheduled2.getEndToEndIdentification())
-                .instructedAmount(obInternationalScheduled2.getInstructedAmount())
-                .instructionIdentification(obInternationalScheduled2.getInstructionIdentification())
-                .localInstrument(obInternationalScheduled2.getLocalInstrument())
-                .remittanceInformation(obInternationalScheduled2.getRemittanceInformation())
-                .chargeBearer(obInternationalScheduled2.getChargeBearer())
-                .creditor(obInternationalScheduled2.getCreditor())
-                .creditorAgent(obInternationalScheduled2.getCreditorAgent())
-                .currencyOfTransfer(obInternationalScheduled2.getCurrencyOfTransfer())
-                .exchangeRateInformation(obInternationalScheduled2.getExchangeRateInformation())
-                .instructionPriority(obInternationalScheduled2.getInstructionPriority())
-                .requestedExecutionDateTime(obInternationalScheduled2.getRequestedExecutionDateTime())
-                ;
+    public static OBInternationalScheduled2 toOBInternationalScheduled2(OBWriteInternationalScheduled3DataInitiation initiation) {
+        return initiation == null ? null : (new OBInternationalScheduled2())
+                .instructionIdentification(initiation.getInstructionIdentification())
+                .endToEndIdentification(initiation.getEndToEndIdentification())
+                .localInstrument(initiation.getLocalInstrument())
+                .instructionPriority(toOBPriority2Code(initiation.getInstructionPriority()))
+                .purpose(initiation.getPurpose())
+                .chargeBearer(initiation.getChargeBearer())
+                .requestedExecutionDateTime(initiation.getRequestedExecutionDateTime())
+                .currencyOfTransfer(initiation.getCurrencyOfTransfer())
+                .instructedAmount(toOBActiveOrHistoricCurrencyAndAmount(initiation.getInstructedAmount()))
+                .exchangeRateInformation(toOBExchangeRate1(initiation.getExchangeRateInformation()))
+                .debtorAccount(toOBCashAccount3(initiation.getDebtorAccount()))
+                .creditor(toOBPartyIdentification43(initiation.getCreditor()))
+                .creditorAgent(toOBBranchAndFinancialInstitutionIdentification3(initiation.getCreditorAgent()))
+                .creditorAccount(toOBCashAccount3(initiation.getCreditorAccount()))
+                .remittanceInformation(toOBRemittanceInformation1(initiation.getRemittanceInformation()))
+                .supplementaryData(initiation.getSupplementaryData());
     }
 
-    public static OBWriteInternationalScheduledConsent2 toOBWriteInternationalScheduledConsent2(OBWriteInternationalScheduledConsent1 obWriteInternationalScheduledConsent1) {
-        return new OBWriteInternationalScheduledConsent2()
-                .data(new OBWriteDataInternationalScheduledConsent2()
-                        .authorisation(obWriteInternationalScheduledConsent1.getData().getAuthorisation())
-                        .initiation(toOBInternationalScheduled2(obWriteInternationalScheduledConsent1.getData().getInitiation()))
-                )
-                .risk(obWriteInternationalScheduledConsent1.getRisk());
+    public static OBWriteInternationalScheduled3DataInitiation toOBWriteInternationalScheduled3DataInitiation(OBInternationalScheduled1 initiation) {
+        return initiation == null ? null : (new OBWriteInternationalScheduled3DataInitiation())
+                .instructionIdentification(initiation.getInstructionIdentification())
+                .endToEndIdentification(initiation.getEndToEndIdentification())
+                .localInstrument(initiation.getLocalInstrument())
+                .instructionPriority(toOBWriteInternationalScheduled3DataInitiationInstructionPriorityEnum(initiation.getInstructionPriority()))
+                .purpose(initiation.getPurpose())
+                .chargeBearer(initiation.getChargeBearer())
+                .requestedExecutionDateTime(initiation.getRequestedExecutionDateTime())
+                .currencyOfTransfer(initiation.getCurrencyOfTransfer())
+                .instructedAmount(toOBWriteDomestic2DataInitiationInstructedAmount(initiation.getInstructedAmount()))
+                .exchangeRateInformation(toOBWriteInternational3DataInitiationExchangeRateInformation(initiation.getExchangeRateInformation()))
+                .debtorAccount(toOBWriteDomestic2DataInitiationDebtorAccount(initiation.getDebtorAccount()))
+                .creditor(toOBWriteInternational3DataInitiationCreditor(initiation.getCreditor()))
+                .creditorAgent(toOBWriteInternational3DataInitiationCreditorAgent(initiation.getCreditorAgent()))
+                .creditorAccount(toOBWriteDomestic2DataInitiationCreditorAccount(initiation.getCreditorAccount()))
+                .remittanceInformation(toOBWriteDomestic2DataInitiationRemittanceInformation(initiation.getRemittanceInformation()));
     }
 
-    public static OBWriteInternationalScheduledConsent1 toOBWriteInternationalScheduledConsent1(OBWriteInternationalScheduledConsent2 obWriteInternationalScheduledConsent2) {
-        return new OBWriteInternationalScheduledConsent1()
-                .data(new OBWriteDataInternationalScheduledConsent1()
-                        .authorisation(obWriteInternationalScheduledConsent2.getData().getAuthorisation())
-                        .initiation(toOBInternationalScheduled1(obWriteInternationalScheduledConsent2.getData().getInitiation()))
-                )
-                .risk(obWriteInternationalScheduledConsent2.getRisk());
-    }
-
-    public static OBWriteInternationalScheduled2 toOBWriteInternationalScheduled2(OBWriteInternationalScheduled1 obWriteInternationalScheduled1) {
-        return new OBWriteInternationalScheduled2()
-                .data(new OBWriteDataInternationalScheduled2()
-                        .consentId(obWriteInternationalScheduled1.getData().getConsentId())
-                        .initiation(toOBInternationalScheduled2(obWriteInternationalScheduled1.getData().getInitiation()))
-                )
-                .risk(obWriteInternationalScheduled1.getRisk());
-    }
-
-    public static OBWriteInternationalScheduled1 toOBWriteInternationalScheduled1(OBWriteInternationalScheduled2 obWriteInternationalScheduled2) {
-        return new OBWriteInternationalScheduled1()
-                .data(new OBWriteDataInternationalScheduled1()
-                        .consentId(obWriteInternationalScheduled2.getData().getConsentId())
-                        .initiation(toOBInternationalScheduled1(obWriteInternationalScheduled2.getData().getInitiation()))
-                )
-                .risk(obWriteInternationalScheduled2.getRisk());
+    public static OBWriteInternationalScheduled3DataInitiation toOBWriteInternationalScheduled3DataInitiation(OBInternationalScheduled2 initiation) {
+        return initiation == null ? null : (new OBWriteInternationalScheduled3DataInitiation())
+                .instructionIdentification(initiation.getInstructionIdentification())
+                .endToEndIdentification(initiation.getEndToEndIdentification())
+                .localInstrument(initiation.getLocalInstrument())
+                .instructionPriority(toOBWriteInternationalScheduled3DataInitiationInstructionPriorityEnum(initiation.getInstructionPriority()))
+                .purpose(initiation.getPurpose())
+                .chargeBearer(initiation.getChargeBearer())
+                .requestedExecutionDateTime(initiation.getRequestedExecutionDateTime())
+                .currencyOfTransfer(initiation.getCurrencyOfTransfer())
+                .instructedAmount(toOBWriteDomestic2DataInitiationInstructedAmount(initiation.getInstructedAmount()))
+                .exchangeRateInformation(toOBWriteInternational3DataInitiationExchangeRateInformation(initiation.getExchangeRateInformation()))
+                .debtorAccount(toOBWriteDomestic2DataInitiationDebtorAccount(initiation.getDebtorAccount()))
+                .creditor(toOBWriteInternational3DataInitiationCreditor(initiation.getCreditor()))
+                .creditorAgent(toOBWriteInternational3DataInitiationCreditorAgent(initiation.getCreditorAgent()))
+                .creditorAccount(toOBWriteDomestic2DataInitiationCreditorAccount(initiation.getCreditorAccount()))
+                .remittanceInformation(toOBWriteDomestic2DataInitiationRemittanceInformation(initiation.getRemittanceInformation()))
+                .supplementaryData(initiation.getSupplementaryData());
     }
 
 }

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBInternationalStandingOrderConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBInternationalStandingOrderConverter.java
@@ -20,81 +20,113 @@
  */
 package uk.org.openbanking.datamodel.service.converter.payment;
 
-import uk.org.openbanking.datamodel.payment.*;
+import uk.org.openbanking.datamodel.payment.OBInternationalStandingOrder1;
+import uk.org.openbanking.datamodel.payment.OBInternationalStandingOrder2;
+import uk.org.openbanking.datamodel.payment.OBInternationalStandingOrder3;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrder4DataInitiation;
+
+import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBCashAccount3;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBCashAccountCreditor3;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBCashAccountDebtor4;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBWriteDomesticStandingOrder3DataInitiationDebtorAccount;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBWriteInternationalStandingOrder4DataInitiationCreditorAccount;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBAmountConverter.toOBActiveOrHistoricCurrencyAndAmount;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBAmountConverter.toOBDomestic2InstructedAmount;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBAmountConverter.toOBWriteDomestic2DataInitiationInstructedAmount;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalIdentifierConverter.toOBBranchAndFinancialInstitutionIdentification3;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalIdentifierConverter.toOBBranchAndFinancialInstitutionIdentification6;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalIdentifierConverter.toOBPartyIdentification43;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalIdentifierConverter.toOBWriteInternational3DataInitiationCreditor;
 
 public class OBInternationalStandingOrderConverter {
 
-    public static OBInternationalStandingOrder2 toOBInternationalStandingOrder2(OBInternationalStandingOrder1 obInternationalStandingOrder1) {
-        return new OBInternationalStandingOrder2()
-                .chargeBearer(obInternationalStandingOrder1.getChargeBearer())
-                .creditor(obInternationalStandingOrder1.getCreditor())
-                .creditorAccount(obInternationalStandingOrder1.getCreditorAccount())
-                .creditorAgent(obInternationalStandingOrder1.getCreditorAgent())
-                .currencyOfTransfer(obInternationalStandingOrder1.getCurrencyOfTransfer())
-                .debtorAccount(obInternationalStandingOrder1.getDebtorAccount())
-                .finalPaymentDateTime(obInternationalStandingOrder1.getFinalPaymentDateTime())
-                .firstPaymentDateTime(obInternationalStandingOrder1.getFirstPaymentDateTime())
-                .frequency(obInternationalStandingOrder1.getFrequency())
-                .instructedAmount(obInternationalStandingOrder1.getInstructedAmount())
-                .numberOfPayments(obInternationalStandingOrder1.getNumberOfPayments())
-                .purpose(obInternationalStandingOrder1.getPurpose())
-                .reference(obInternationalStandingOrder1.getReference())
-                ;
+    public static OBInternationalStandingOrder1 toOBInternationalStandingOrder1(OBWriteInternationalStandingOrder4DataInitiation initiation) {
+        return initiation == null ? null : (new OBInternationalStandingOrder1())
+                .frequency(initiation.getFrequency())
+                .reference(initiation.getReference())
+                .numberOfPayments(initiation.getNumberOfPayments())
+                .firstPaymentDateTime(initiation.getFirstPaymentDateTime())
+                .finalPaymentDateTime(initiation.getFinalPaymentDateTime())
+                .purpose(initiation.getPurpose())
+                .chargeBearer(initiation.getChargeBearer())
+                .currencyOfTransfer(initiation.getCurrencyOfTransfer())
+                .instructedAmount(toOBActiveOrHistoricCurrencyAndAmount(initiation.getInstructedAmount()))
+                .debtorAccount(toOBCashAccount3(initiation.getDebtorAccount()))
+                .creditor(toOBPartyIdentification43(initiation.getCreditor()))
+                .creditorAgent(toOBBranchAndFinancialInstitutionIdentification3(initiation.getCreditorAgent()))
+                .creditorAccount(toOBCashAccount3(initiation.getCreditorAccount()));
+    }
+
+    public static OBInternationalStandingOrder2 toOBInternationalStandingOrder2(OBWriteInternationalStandingOrder4DataInitiation initiation) {
+        return initiation == null ? null : (new OBInternationalStandingOrder2())
+                .frequency(initiation.getFrequency())
+                .reference(initiation.getReference())
+                .numberOfPayments(initiation.getNumberOfPayments())
+                .firstPaymentDateTime(initiation.getFirstPaymentDateTime())
+                .finalPaymentDateTime(initiation.getFinalPaymentDateTime())
+                .purpose(initiation.getPurpose())
+                .chargeBearer(initiation.getChargeBearer())
+                .currencyOfTransfer(initiation.getCurrencyOfTransfer())
+                .instructedAmount(toOBActiveOrHistoricCurrencyAndAmount(initiation.getInstructedAmount()))
+                .debtorAccount(toOBCashAccount3(initiation.getDebtorAccount()))
+                .creditor(toOBPartyIdentification43(initiation.getCreditor()))
+                .creditorAgent(toOBBranchAndFinancialInstitutionIdentification3(initiation.getCreditorAgent()))
+                .creditorAccount(toOBCashAccount3(initiation.getCreditorAccount()))
+                .supplementaryData(initiation.getSupplementaryData());
+    }
+
+    public static OBInternationalStandingOrder3 toOBInternationalStandingOrder3(OBWriteInternationalStandingOrder4DataInitiation initiation) {
+        return initiation == null ? null : (new OBInternationalStandingOrder3())
+                .frequency(initiation.getFrequency())
+                .reference(initiation.getReference())
+                .numberOfPayments(initiation.getNumberOfPayments())
+                .firstPaymentDateTime(initiation.getFirstPaymentDateTime())
+                .finalPaymentDateTime(initiation.getFinalPaymentDateTime())
+                .purpose(initiation.getPurpose())
+                .chargeBearer(initiation.getChargeBearer())
+                .currencyOfTransfer(initiation.getCurrencyOfTransfer())
+                .instructedAmount(toOBDomestic2InstructedAmount(initiation.getInstructedAmount()))
+                .debtorAccount(toOBCashAccountDebtor4(initiation.getDebtorAccount()))
+                .creditor(toOBPartyIdentification43(initiation.getCreditor()))
+                .creditorAgent(toOBBranchAndFinancialInstitutionIdentification6(initiation.getCreditorAgent()))
+                .creditorAccount(toOBCashAccountCreditor3(initiation.getCreditorAccount()))
+                .supplementaryData(initiation.getSupplementaryData());
+    }
+
+    public static OBWriteInternationalStandingOrder4DataInitiation toOBWriteInternationalStandingOrder4DataInitiation(OBInternationalStandingOrder2 initiation) {
+        return initiation == null ? null : (new OBWriteInternationalStandingOrder4DataInitiation())
+                .frequency(initiation.getFrequency())
+                .reference(initiation.getReference())
+                .numberOfPayments(initiation.getNumberOfPayments())
+                .firstPaymentDateTime(initiation.getFirstPaymentDateTime())
+                .finalPaymentDateTime(initiation.getFinalPaymentDateTime())
+                .purpose(initiation.getPurpose())
+                .chargeBearer(initiation.getChargeBearer())
+                .currencyOfTransfer(initiation.getCurrencyOfTransfer())
+                .instructedAmount(toOBWriteDomestic2DataInitiationInstructedAmount(initiation.getInstructedAmount()))
+                .debtorAccount(toOBWriteDomesticStandingOrder3DataInitiationDebtorAccount(initiation.getDebtorAccount()))
+                .creditor(toOBWriteInternational3DataInitiationCreditor(initiation.getCreditor()))
+                .creditorAgent(OBInternationalIdentifierConverter.toOBWriteInternationalStandingOrder4DataInitiationCreditorAgent(initiation.getCreditorAgent()))
+                .creditorAccount(toOBWriteInternationalStandingOrder4DataInitiationCreditorAccount(initiation.getCreditorAccount()))
+                .supplementaryData(initiation.getSupplementaryData());
     }
 
 
-    public static OBInternationalStandingOrder1 toOBInternationalStandingOrder1(OBInternationalStandingOrder2 obInternationalStandingOrder2) {
-        return new OBInternationalStandingOrder1()
-                .chargeBearer(obInternationalStandingOrder2.getChargeBearer())
-                .creditor(obInternationalStandingOrder2.getCreditor())
-                .creditorAccount(obInternationalStandingOrder2.getCreditorAccount())
-                .creditorAgent(obInternationalStandingOrder2.getCreditorAgent())
-                .currencyOfTransfer(obInternationalStandingOrder2.getCurrencyOfTransfer())
-                .debtorAccount(obInternationalStandingOrder2.getDebtorAccount())
-                .finalPaymentDateTime(obInternationalStandingOrder2.getFinalPaymentDateTime())
-                .firstPaymentDateTime(obInternationalStandingOrder2.getFirstPaymentDateTime())
-                .frequency(obInternationalStandingOrder2.getFrequency())
-                .instructedAmount(obInternationalStandingOrder2.getInstructedAmount())
-                .numberOfPayments(obInternationalStandingOrder2.getNumberOfPayments())
-                .purpose(obInternationalStandingOrder2.getPurpose())
-                .reference(obInternationalStandingOrder2.getReference())
-                ;
+    public static OBWriteInternationalStandingOrder4DataInitiation toOBWriteInternationalStandingOrder4DataInitiation(OBInternationalStandingOrder3 initiation) {
+        return initiation == null ? null : (new OBWriteInternationalStandingOrder4DataInitiation())
+                .frequency(initiation.getFrequency())
+                .reference(initiation.getReference())
+                .numberOfPayments(initiation.getNumberOfPayments())
+                .firstPaymentDateTime(initiation.getFirstPaymentDateTime())
+                .finalPaymentDateTime(initiation.getFinalPaymentDateTime())
+                .purpose(initiation.getPurpose())
+                .chargeBearer(initiation.getChargeBearer())
+                .currencyOfTransfer(initiation.getCurrencyOfTransfer())
+                .instructedAmount(toOBWriteDomestic2DataInitiationInstructedAmount(initiation.getInstructedAmount()))
+                .debtorAccount(toOBWriteDomesticStandingOrder3DataInitiationDebtorAccount(initiation.getDebtorAccount()))
+                .creditor(toOBWriteInternational3DataInitiationCreditor(initiation.getCreditor()))
+                .creditorAgent(OBInternationalIdentifierConverter.toOBWriteInternationalStandingOrder4DataInitiationCreditorAgent(initiation.getCreditorAgent()))
+                .creditorAccount(toOBWriteInternationalStandingOrder4DataInitiationCreditorAccount(initiation.getCreditorAccount()))
+                .supplementaryData(initiation.getSupplementaryData());
     }
-
-    public static OBWriteInternationalStandingOrderConsent2 toOBWriteInternationalStandingOrderConsent2(OBWriteInternationalStandingOrderConsent1 obWriteInternationalStandingOrderConsent1) {
-        return new OBWriteInternationalStandingOrderConsent2()
-                .data(new OBWriteDataInternationalStandingOrderConsent2()
-                        .authorisation(obWriteInternationalStandingOrderConsent1.getData().getAuthorisation())
-                        .initiation(toOBInternationalStandingOrder2(obWriteInternationalStandingOrderConsent1.getData().getInitiation()))
-                )
-                .risk(obWriteInternationalStandingOrderConsent1.getRisk());
-    }
-
-    public static OBWriteInternationalStandingOrderConsent1 toOBWriteInternationalStandingOrderConsent1(OBWriteInternationalStandingOrderConsent2 obWriteInternationalStandingOrderConsent2) {
-        return new OBWriteInternationalStandingOrderConsent1()
-                .data(new OBWriteDataInternationalStandingOrderConsent1()
-                        .authorisation(obWriteInternationalStandingOrderConsent2.getData().getAuthorisation())
-                        .initiation(toOBInternationalStandingOrder1(obWriteInternationalStandingOrderConsent2.getData().getInitiation()))
-                )
-                .risk(obWriteInternationalStandingOrderConsent2.getRisk());
-    }
-
-    public static OBWriteInternationalStandingOrder2 toOBWriteInternationalStandingOrder2(OBWriteInternationalStandingOrder1 obWriteInternationalStandingOrder1) {
-        return new OBWriteInternationalStandingOrder2()
-                .data(new OBWriteDataInternationalStandingOrder2()
-                        .consentId(obWriteInternationalStandingOrder1.getData().getConsentId())
-                        .initiation(toOBInternationalStandingOrder2(obWriteInternationalStandingOrder1.getData().getInitiation()))
-                )
-                .risk(obWriteInternationalStandingOrder1.getRisk());
-    }
-
-    public static OBWriteInternationalStandingOrder1 toOBWriteInternationalStandingOrder1(OBWriteInternationalStandingOrder2 obWriteInternationalStandingOrder2) {
-        return new OBWriteInternationalStandingOrder1()
-                .data(new OBWriteDataInternationalStandingOrder1()
-                        .consentId(obWriteInternationalStandingOrder2.getData().getConsentId())
-                        .initiation(toOBInternationalStandingOrder1(obWriteInternationalStandingOrder2.getData().getInitiation()))
-                )
-                .risk(obWriteInternationalStandingOrder2.getRisk());
-    }
-
 }

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBInternationalStandingOrderConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBInternationalStandingOrderConverter.java
@@ -40,39 +40,76 @@ import static uk.org.openbanking.datamodel.service.converter.payment.OBInternati
 
 public class OBInternationalStandingOrderConverter {
 
-    public static OBInternationalStandingOrder2 toOBInternationalStandingOrder2(OBInternationalStandingOrder1 obInternationalStandingOrder1) {
-        return (new OBInternationalStandingOrder2())
-                .chargeBearer(obInternationalStandingOrder1.getChargeBearer())
-                .creditor(obInternationalStandingOrder1.getCreditor())
-                .creditorAccount(obInternationalStandingOrder1.getCreditorAccount())
-                .creditorAgent(obInternationalStandingOrder1.getCreditorAgent())
-                .currencyOfTransfer(obInternationalStandingOrder1.getCurrencyOfTransfer())
-                .debtorAccount(obInternationalStandingOrder1.getDebtorAccount())
-                .finalPaymentDateTime(obInternationalStandingOrder1.getFinalPaymentDateTime())
-                .firstPaymentDateTime(obInternationalStandingOrder1.getFirstPaymentDateTime())
-                .frequency(obInternationalStandingOrder1.getFrequency())
-                .instructedAmount(obInternationalStandingOrder1.getInstructedAmount())
-                .numberOfPayments(obInternationalStandingOrder1.getNumberOfPayments())
-                .purpose(obInternationalStandingOrder1.getPurpose())
-                .reference(obInternationalStandingOrder1.getReference());
-    }
-
     public static OBInternationalStandingOrder1 toOBInternationalStandingOrder1(OBInternationalStandingOrder2 obInternationalStandingOrder2) {
         return (new OBInternationalStandingOrder1())
-                .chargeBearer(obInternationalStandingOrder2.getChargeBearer())
-                .creditor(obInternationalStandingOrder2.getCreditor())
-                .creditorAccount(obInternationalStandingOrder2.getCreditorAccount())
-                .creditorAgent(obInternationalStandingOrder2.getCreditorAgent())
-                .currencyOfTransfer(obInternationalStandingOrder2.getCurrencyOfTransfer())
-                .debtorAccount(obInternationalStandingOrder2.getDebtorAccount())
-                .finalPaymentDateTime(obInternationalStandingOrder2.getFinalPaymentDateTime())
-                .firstPaymentDateTime(obInternationalStandingOrder2.getFirstPaymentDateTime())
                 .frequency(obInternationalStandingOrder2.getFrequency())
-                .instructedAmount(obInternationalStandingOrder2.getInstructedAmount())
+                .reference(obInternationalStandingOrder2.getReference())
                 .numberOfPayments(obInternationalStandingOrder2.getNumberOfPayments())
+                .firstPaymentDateTime(obInternationalStandingOrder2.getFirstPaymentDateTime())
+                .finalPaymentDateTime(obInternationalStandingOrder2.getFinalPaymentDateTime())
                 .purpose(obInternationalStandingOrder2.getPurpose())
-                .reference(obInternationalStandingOrder2.getReference());
+                .chargeBearer(obInternationalStandingOrder2.getChargeBearer())
+                .currencyOfTransfer(obInternationalStandingOrder2.getCurrencyOfTransfer())
+                .instructedAmount(obInternationalStandingOrder2.getInstructedAmount())
+                .debtorAccount(obInternationalStandingOrder2.getDebtorAccount())
+                .creditor(obInternationalStandingOrder2.getCreditor())
+                .creditorAgent(obInternationalStandingOrder2.getCreditorAgent())
+                .creditorAccount(obInternationalStandingOrder2.getCreditorAccount());
     }
+
+    public static OBInternationalStandingOrder1 toOBInternationalStandingOrder1(OBInternationalStandingOrder3 obInternationalStandingOrder3) {
+        return (new OBInternationalStandingOrder1())
+                .frequency(obInternationalStandingOrder3.getFrequency())
+                .reference(obInternationalStandingOrder3.getReference())
+                .numberOfPayments(obInternationalStandingOrder3.getNumberOfPayments())
+                .firstPaymentDateTime(obInternationalStandingOrder3.getFirstPaymentDateTime())
+                .finalPaymentDateTime(obInternationalStandingOrder3.getFinalPaymentDateTime())
+                .purpose(obInternationalStandingOrder3.getPurpose())
+                .chargeBearer(obInternationalStandingOrder3.getChargeBearer())
+                .currencyOfTransfer(obInternationalStandingOrder3.getCurrencyOfTransfer())
+                .instructedAmount(toOBActiveOrHistoricCurrencyAndAmount(obInternationalStandingOrder3.getInstructedAmount()))
+                .debtorAccount(toOBCashAccount3(obInternationalStandingOrder3.getDebtorAccount()))
+                .creditor(obInternationalStandingOrder3.getCreditor())
+                .creditorAgent(toOBBranchAndFinancialInstitutionIdentification3(obInternationalStandingOrder3.getCreditorAgent()))
+                .creditorAccount(toOBCashAccount3(obInternationalStandingOrder3.getCreditorAccount()));
+    }
+
+    public static OBInternationalStandingOrder2 toOBInternationalStandingOrder2(OBInternationalStandingOrder1 obInternationalStandingOrder1) {
+        return (new OBInternationalStandingOrder2())
+                .frequency(obInternationalStandingOrder1.getFrequency())
+                .reference(obInternationalStandingOrder1.getReference())
+                .numberOfPayments(obInternationalStandingOrder1.getNumberOfPayments())
+                .firstPaymentDateTime(obInternationalStandingOrder1.getFirstPaymentDateTime())
+                .finalPaymentDateTime(obInternationalStandingOrder1.getFinalPaymentDateTime())
+                .purpose(obInternationalStandingOrder1.getPurpose())
+                .chargeBearer(obInternationalStandingOrder1.getChargeBearer())
+                .currencyOfTransfer(obInternationalStandingOrder1.getCurrencyOfTransfer())
+                .instructedAmount(obInternationalStandingOrder1.getInstructedAmount())
+                .debtorAccount(obInternationalStandingOrder1.getDebtorAccount())
+                .creditor(obInternationalStandingOrder1.getCreditor())
+                .creditorAgent(obInternationalStandingOrder1.getCreditorAgent())
+                .creditorAccount(obInternationalStandingOrder1.getCreditorAccount())
+                .supplementaryData(null);
+    }
+
+    public static OBInternationalStandingOrder2 toOBInternationalStandingOrder2(OBInternationalStandingOrder3 obInternationalStandingOrder3) {
+        return (new OBInternationalStandingOrder2())
+                .frequency(obInternationalStandingOrder3.getFrequency())
+                .reference(obInternationalStandingOrder3.getReference())
+                .numberOfPayments(obInternationalStandingOrder3.getNumberOfPayments())
+                .firstPaymentDateTime(obInternationalStandingOrder3.getFirstPaymentDateTime())
+                .finalPaymentDateTime(obInternationalStandingOrder3.getFinalPaymentDateTime())
+                .purpose(obInternationalStandingOrder3.getPurpose())
+                .chargeBearer(obInternationalStandingOrder3.getChargeBearer())
+                .currencyOfTransfer(obInternationalStandingOrder3.getCurrencyOfTransfer())
+                .instructedAmount(toOBActiveOrHistoricCurrencyAndAmount(obInternationalStandingOrder3.getInstructedAmount()))
+                .debtorAccount(toOBCashAccount3(obInternationalStandingOrder3.getDebtorAccount()))
+                .creditor(obInternationalStandingOrder3.getCreditor())
+                .creditorAgent(toOBBranchAndFinancialInstitutionIdentification3(obInternationalStandingOrder3.getCreditorAgent()))
+                .creditorAccount(toOBCashAccount3(obInternationalStandingOrder3.getCreditorAccount()))
+                .supplementaryData(obInternationalStandingOrder3.getSupplementaryData());
+    }
+
 
     public static OBInternationalStandingOrder1 toOBInternationalStandingOrder1(OBWriteInternationalStandingOrder4DataInitiation initiation) {
         return initiation == null ? null : (new OBInternationalStandingOrder1())
@@ -127,40 +164,40 @@ public class OBInternationalStandingOrderConverter {
                 .supplementaryData(initiation.getSupplementaryData());
     }
 
-    public static OBWriteInternationalStandingOrder4DataInitiation toOBWriteInternationalStandingOrder4DataInitiation(OBInternationalStandingOrder2 initiation) {
-        return initiation == null ? null : (new OBWriteInternationalStandingOrder4DataInitiation())
-                .frequency(initiation.getFrequency())
-                .reference(initiation.getReference())
-                .numberOfPayments(initiation.getNumberOfPayments())
-                .firstPaymentDateTime(initiation.getFirstPaymentDateTime())
-                .finalPaymentDateTime(initiation.getFinalPaymentDateTime())
-                .purpose(initiation.getPurpose())
-                .chargeBearer(initiation.getChargeBearer())
-                .currencyOfTransfer(initiation.getCurrencyOfTransfer())
-                .instructedAmount(toOBWriteDomestic2DataInitiationInstructedAmount(initiation.getInstructedAmount()))
-                .debtorAccount(toOBWriteDomesticStandingOrder3DataInitiationDebtorAccount(initiation.getDebtorAccount()))
-                .creditor(toOBWriteInternational3DataInitiationCreditor(initiation.getCreditor()))
-                .creditorAgent(OBInternationalIdentifierConverter.toOBWriteInternationalStandingOrder4DataInitiationCreditorAgent(initiation.getCreditorAgent()))
-                .creditorAccount(toOBWriteInternationalStandingOrder4DataInitiationCreditorAccount(initiation.getCreditorAccount()))
-                .supplementaryData(initiation.getSupplementaryData());
+    public static OBWriteInternationalStandingOrder4DataInitiation toOBWriteInternationalStandingOrder4DataInitiation(OBInternationalStandingOrder2 obInternationalStandingOrder2) {
+        return obInternationalStandingOrder2 == null ? null : (new OBWriteInternationalStandingOrder4DataInitiation())
+                .frequency(obInternationalStandingOrder2.getFrequency())
+                .reference(obInternationalStandingOrder2.getReference())
+                .numberOfPayments(obInternationalStandingOrder2.getNumberOfPayments())
+                .firstPaymentDateTime(obInternationalStandingOrder2.getFirstPaymentDateTime())
+                .finalPaymentDateTime(obInternationalStandingOrder2.getFinalPaymentDateTime())
+                .purpose(obInternationalStandingOrder2.getPurpose())
+                .chargeBearer(obInternationalStandingOrder2.getChargeBearer())
+                .currencyOfTransfer(obInternationalStandingOrder2.getCurrencyOfTransfer())
+                .instructedAmount(toOBWriteDomestic2DataInitiationInstructedAmount(obInternationalStandingOrder2.getInstructedAmount()))
+                .debtorAccount(toOBWriteDomesticStandingOrder3DataInitiationDebtorAccount(obInternationalStandingOrder2.getDebtorAccount()))
+                .creditor(toOBWriteInternational3DataInitiationCreditor(obInternationalStandingOrder2.getCreditor()))
+                .creditorAgent(OBInternationalIdentifierConverter.toOBWriteInternationalStandingOrder4DataInitiationCreditorAgent(obInternationalStandingOrder2.getCreditorAgent()))
+                .creditorAccount(toOBWriteInternationalStandingOrder4DataInitiationCreditorAccount(obInternationalStandingOrder2.getCreditorAccount()))
+                .supplementaryData(obInternationalStandingOrder2.getSupplementaryData());
     }
 
 
-    public static OBWriteInternationalStandingOrder4DataInitiation toOBWriteInternationalStandingOrder4DataInitiation(OBInternationalStandingOrder3 initiation) {
-        return initiation == null ? null : (new OBWriteInternationalStandingOrder4DataInitiation())
-                .frequency(initiation.getFrequency())
-                .reference(initiation.getReference())
-                .numberOfPayments(initiation.getNumberOfPayments())
-                .firstPaymentDateTime(initiation.getFirstPaymentDateTime())
-                .finalPaymentDateTime(initiation.getFinalPaymentDateTime())
-                .purpose(initiation.getPurpose())
-                .chargeBearer(initiation.getChargeBearer())
-                .currencyOfTransfer(initiation.getCurrencyOfTransfer())
-                .instructedAmount(toOBWriteDomestic2DataInitiationInstructedAmount(initiation.getInstructedAmount()))
-                .debtorAccount(toOBWriteDomesticStandingOrder3DataInitiationDebtorAccount(initiation.getDebtorAccount()))
-                .creditor(toOBWriteInternational3DataInitiationCreditor(initiation.getCreditor()))
-                .creditorAgent(OBInternationalIdentifierConverter.toOBWriteInternationalStandingOrder4DataInitiationCreditorAgent(initiation.getCreditorAgent()))
-                .creditorAccount(toOBWriteInternationalStandingOrder4DataInitiationCreditorAccount(initiation.getCreditorAccount()))
-                .supplementaryData(initiation.getSupplementaryData());
+    public static OBWriteInternationalStandingOrder4DataInitiation toOBWriteInternationalStandingOrder4DataInitiation(OBInternationalStandingOrder3 obInternationalStandingOrder3) {
+        return obInternationalStandingOrder3 == null ? null : (new OBWriteInternationalStandingOrder4DataInitiation())
+                .frequency(obInternationalStandingOrder3.getFrequency())
+                .reference(obInternationalStandingOrder3.getReference())
+                .numberOfPayments(obInternationalStandingOrder3.getNumberOfPayments())
+                .firstPaymentDateTime(obInternationalStandingOrder3.getFirstPaymentDateTime())
+                .finalPaymentDateTime(obInternationalStandingOrder3.getFinalPaymentDateTime())
+                .purpose(obInternationalStandingOrder3.getPurpose())
+                .chargeBearer(obInternationalStandingOrder3.getChargeBearer())
+                .currencyOfTransfer(obInternationalStandingOrder3.getCurrencyOfTransfer())
+                .instructedAmount(toOBWriteDomestic2DataInitiationInstructedAmount(obInternationalStandingOrder3.getInstructedAmount()))
+                .debtorAccount(toOBWriteDomesticStandingOrder3DataInitiationDebtorAccount(obInternationalStandingOrder3.getDebtorAccount()))
+                .creditor(toOBWriteInternational3DataInitiationCreditor(obInternationalStandingOrder3.getCreditor()))
+                .creditorAgent(OBInternationalIdentifierConverter.toOBWriteInternationalStandingOrder4DataInitiationCreditorAgent(obInternationalStandingOrder3.getCreditorAgent()))
+                .creditorAccount(toOBWriteInternationalStandingOrder4DataInitiationCreditorAccount(obInternationalStandingOrder3.getCreditorAccount()))
+                .supplementaryData(obInternationalStandingOrder3.getSupplementaryData());
     }
 }

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBInternationalStandingOrderConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBInternationalStandingOrderConverter.java
@@ -92,6 +92,24 @@ public class OBInternationalStandingOrderConverter {
                 .supplementaryData(null);
     }
 
+    public static OBInternationalStandingOrder3 toOBInternationalStandingOrder3(OBInternationalStandingOrder2 obInternationalStandingOrder2) {
+        return obInternationalStandingOrder2 == null ? null : (new OBInternationalStandingOrder3())
+                .frequency(obInternationalStandingOrder2.getFrequency())
+                .reference(obInternationalStandingOrder2.getReference())
+                .numberOfPayments(obInternationalStandingOrder2.getNumberOfPayments())
+                .firstPaymentDateTime(obInternationalStandingOrder2.getFirstPaymentDateTime())
+                .finalPaymentDateTime(obInternationalStandingOrder2.getFinalPaymentDateTime())
+                .purpose(obInternationalStandingOrder2.getPurpose())
+                .chargeBearer(obInternationalStandingOrder2.getChargeBearer())
+                .currencyOfTransfer(obInternationalStandingOrder2.getCurrencyOfTransfer())
+                .instructedAmount(toOBDomestic2InstructedAmount(obInternationalStandingOrder2.getInstructedAmount()))
+                .debtorAccount(toOBCashAccountDebtor4(obInternationalStandingOrder2.getDebtorAccount()))
+                .creditor(obInternationalStandingOrder2.getCreditor())
+                .creditorAgent(toOBBranchAndFinancialInstitutionIdentification6(obInternationalStandingOrder2.getCreditorAgent()))
+                .creditorAccount(toOBCashAccountCreditor3(obInternationalStandingOrder2.getCreditorAccount()))
+                .supplementaryData(obInternationalStandingOrder2.getSupplementaryData());
+    }
+
     public static OBInternationalStandingOrder2 toOBInternationalStandingOrder2(OBInternationalStandingOrder3 obInternationalStandingOrder3) {
         return (new OBInternationalStandingOrder2())
                 .frequency(obInternationalStandingOrder3.getFrequency())

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBInternationalStandingOrderConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBInternationalStandingOrderConverter.java
@@ -40,6 +40,40 @@ import static uk.org.openbanking.datamodel.service.converter.payment.OBInternati
 
 public class OBInternationalStandingOrderConverter {
 
+    public static OBInternationalStandingOrder2 toOBInternationalStandingOrder2(OBInternationalStandingOrder1 obInternationalStandingOrder1) {
+        return (new OBInternationalStandingOrder2())
+                .chargeBearer(obInternationalStandingOrder1.getChargeBearer())
+                .creditor(obInternationalStandingOrder1.getCreditor())
+                .creditorAccount(obInternationalStandingOrder1.getCreditorAccount())
+                .creditorAgent(obInternationalStandingOrder1.getCreditorAgent())
+                .currencyOfTransfer(obInternationalStandingOrder1.getCurrencyOfTransfer())
+                .debtorAccount(obInternationalStandingOrder1.getDebtorAccount())
+                .finalPaymentDateTime(obInternationalStandingOrder1.getFinalPaymentDateTime())
+                .firstPaymentDateTime(obInternationalStandingOrder1.getFirstPaymentDateTime())
+                .frequency(obInternationalStandingOrder1.getFrequency())
+                .instructedAmount(obInternationalStandingOrder1.getInstructedAmount())
+                .numberOfPayments(obInternationalStandingOrder1.getNumberOfPayments())
+                .purpose(obInternationalStandingOrder1.getPurpose())
+                .reference(obInternationalStandingOrder1.getReference());
+    }
+
+    public static OBInternationalStandingOrder1 toOBInternationalStandingOrder1(OBInternationalStandingOrder2 obInternationalStandingOrder2) {
+        return (new OBInternationalStandingOrder1())
+                .chargeBearer(obInternationalStandingOrder2.getChargeBearer())
+                .creditor(obInternationalStandingOrder2.getCreditor())
+                .creditorAccount(obInternationalStandingOrder2.getCreditorAccount())
+                .creditorAgent(obInternationalStandingOrder2.getCreditorAgent())
+                .currencyOfTransfer(obInternationalStandingOrder2.getCurrencyOfTransfer())
+                .debtorAccount(obInternationalStandingOrder2.getDebtorAccount())
+                .finalPaymentDateTime(obInternationalStandingOrder2.getFinalPaymentDateTime())
+                .firstPaymentDateTime(obInternationalStandingOrder2.getFirstPaymentDateTime())
+                .frequency(obInternationalStandingOrder2.getFrequency())
+                .instructedAmount(obInternationalStandingOrder2.getInstructedAmount())
+                .numberOfPayments(obInternationalStandingOrder2.getNumberOfPayments())
+                .purpose(obInternationalStandingOrder2.getPurpose())
+                .reference(obInternationalStandingOrder2.getReference());
+    }
+
     public static OBInternationalStandingOrder1 toOBInternationalStandingOrder1(OBWriteInternationalStandingOrder4DataInitiation initiation) {
         return initiation == null ? null : (new OBInternationalStandingOrder1())
                 .frequency(initiation.getFrequency())

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBPriorityCodeConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBPriorityCodeConverter.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.datamodel.service.converter.payment;
+
+import uk.org.openbanking.datamodel.payment.OBPriority2Code;
+import uk.org.openbanking.datamodel.payment.OBWriteInternational3DataInitiation;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduled3DataInitiation;
+
+public class OBPriorityCodeConverter {
+
+    public static OBPriority2Code toOBPriority2Code(OBWriteInternational3DataInitiation.InstructionPriorityEnum instructionPriority) {
+        return instructionPriority == null ? null : OBPriority2Code.valueOf(instructionPriority.name());
+    }
+
+    public static OBPriority2Code toOBPriority2Code(OBWriteInternationalScheduled3DataInitiation.InstructionPriorityEnum instructionPriority) {
+        return instructionPriority == null ? null : OBPriority2Code.valueOf(instructionPriority.name());
+    }
+
+    public static OBWriteInternational3DataInitiation.InstructionPriorityEnum toOBWriteInternational3DataInitiationInstructionPriorityEnum(OBPriority2Code instructionPriority) {
+        return instructionPriority == null ? null : OBWriteInternational3DataInitiation.InstructionPriorityEnum.valueOf(instructionPriority.name());
+    }
+
+    public static OBWriteInternationalScheduled3DataInitiation.InstructionPriorityEnum toOBWriteInternationalScheduled3DataInitiationInstructionPriorityEnum(OBPriority2Code instructionPriority) {
+        return instructionPriority == null ? null : OBWriteInternationalScheduled3DataInitiation.InstructionPriorityEnum.valueOf(instructionPriority.name());
+    }
+
+}

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBRemittanceInformationConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBRemittanceInformationConverter.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.datamodel.service.converter.payment;
+
+import uk.org.openbanking.datamodel.payment.OBRemittanceInformation1;
+import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationRemittanceInformation;
+
+public class OBRemittanceInformationConverter {
+
+    public static OBRemittanceInformation1 toOBRemittanceInformation1(OBWriteDomestic2DataInitiationRemittanceInformation remittanceInformation) {
+        return remittanceInformation == null ? null : (new OBRemittanceInformation1())
+                .unstructured(remittanceInformation.getUnstructured())
+                .reference(remittanceInformation.getReference());
+    }
+
+    public static OBWriteDomestic2DataInitiationRemittanceInformation toOBWriteDomestic2DataInitiationRemittanceInformation(OBRemittanceInformation1 remittanceInformation) {
+        return remittanceInformation == null ? null : (new OBWriteDomestic2DataInitiationRemittanceInformation())
+                .unstructured(remittanceInformation.getUnstructured())
+                .reference(remittanceInformation.getReference());
+    }
+}

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteDomesticConsentConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteDomesticConsentConverter.java
@@ -20,12 +20,7 @@
  */
 package uk.org.openbanking.datamodel.service.converter.payment;
 
-import uk.org.openbanking.datamodel.payment.OBWriteDataDomesticConsent1;
-import uk.org.openbanking.datamodel.payment.OBWriteDataDomesticConsent2;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent1;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent2;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent3;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent3Data;
+import uk.org.openbanking.datamodel.payment.*;
 
 import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBAuthorisation1;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBDomesticConverter.toOBDomestic1;
@@ -51,6 +46,12 @@ public class OBWriteDomesticConsentConverter {
                 .risk(obWriteDomesticConsent3.getRisk());
     }
 
+    public static OBWriteDomestic2 toOBWriteDomestic2(OBWriteDomestic1 obWriteDomestic1) {
+        return (new OBWriteDomestic2())
+                .data(toOBWriteDataDomestic2(obWriteDomestic1.getData()))
+                .risk(obWriteDomestic1.getRisk());
+    }
+
     public static OBWriteDataDomesticConsent1 toOBWriteDataDomesticConsent1(OBWriteDataDomesticConsent2 data) {
         return data == null ? null : (new OBWriteDataDomesticConsent1())
                 .initiation(toOBDomestic1(data.getInitiation()))
@@ -69,4 +70,9 @@ public class OBWriteDomesticConsentConverter {
                 .authorisation(toOBAuthorisation1(data.getAuthorisation()));
     }
 
+    public static OBWriteDataDomestic2 toOBWriteDataDomestic2(OBWriteDataDomestic1 data) {
+        return data == null ? null : (new OBWriteDataDomestic2())
+                .consentId(data.getConsentId())
+                .initiation(toOBDomestic2(data.getInitiation()));
+    }
 }

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteDomesticConsentConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteDomesticConsentConverter.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.datamodel.service.converter.payment;
+
+import uk.org.openbanking.datamodel.payment.OBExternalPermissions2Code;
+import uk.org.openbanking.datamodel.payment.OBWriteDataDomesticConsent2;
+import uk.org.openbanking.datamodel.payment.OBWriteDataDomesticScheduledConsent1;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent2;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent3;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent3Data;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent1;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent3;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent3Data;
+
+import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBAuthorisation1;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBDomesticConverter.toOBDomestic2;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBDomesticScheduledConverter.toOBDomesticScheduled1;
+
+public class OBWriteDomesticConsentConverter {
+
+    public static OBWriteDomesticConsent2 toOBWriteDomesticConsent2(OBWriteDomesticConsent3 obWriteDomesticConsent3) {
+        return (new OBWriteDomesticConsent2())
+                .data(toOBWriteDataDomesticConsent2(obWriteDomesticConsent3.getData()))
+                .risk(obWriteDomesticConsent3.getRisk());
+    }
+
+    public static OBWriteDomesticScheduledConsent1 toOBWriteDomesticScheduledConsent1(OBWriteDomesticScheduledConsent3 domesticScheduledConsent3) {
+        return (new OBWriteDomesticScheduledConsent1())
+                .data(toOBWriteDataDomesticScheduledConsent1(domesticScheduledConsent3.getData()))
+                .risk(domesticScheduledConsent3.getRisk());
+    }
+
+    public static OBWriteDataDomesticConsent2 toOBWriteDataDomesticConsent2(OBWriteDomesticConsent3Data data) {
+        return data == null ? null : (new OBWriteDataDomesticConsent2())
+                .authorisation(toOBAuthorisation1(data.getAuthorisation()))
+                .initiation(toOBDomestic2(data.getInitiation()));
+    }
+
+    public static OBWriteDataDomesticScheduledConsent1 toOBWriteDataDomesticScheduledConsent1(OBWriteDomesticScheduledConsent3Data data) {
+        return (new OBWriteDataDomesticScheduledConsent1())
+                .permission(OBExternalPermissions2Code.valueOf(data.getPermission().name()))
+                .initiation(toOBDomesticScheduled1(data.getInitiation()))
+                .authorisation(toOBAuthorisation1(data.getAuthorisation()));
+    }
+
+}

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteDomesticConsentConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteDomesticConsentConverter.java
@@ -20,21 +20,30 @@
  */
 package uk.org.openbanking.datamodel.service.converter.payment;
 
-import uk.org.openbanking.datamodel.payment.OBExternalPermissions2Code;
+import uk.org.openbanking.datamodel.payment.OBWriteDataDomesticConsent1;
 import uk.org.openbanking.datamodel.payment.OBWriteDataDomesticConsent2;
-import uk.org.openbanking.datamodel.payment.OBWriteDataDomesticScheduledConsent1;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent1;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent2;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent3;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent3Data;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent1;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent3;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent3Data;
 
 import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBAuthorisation1;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBDomesticConverter.toOBDomestic1;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBDomesticConverter.toOBDomestic2;
-import static uk.org.openbanking.datamodel.service.converter.payment.OBDomesticScheduledConverter.toOBDomesticScheduled1;
 
 public class OBWriteDomesticConsentConverter {
+
+    public static OBWriteDomesticConsent2 toOBWriteDomesticConsent2(OBWriteDomesticConsent1 obWriteDomesticConsent1) {
+        return (new OBWriteDomesticConsent2())
+                .data(toOBWriteDataDomesticConsent2(obWriteDomesticConsent1.getData()))
+                .risk(obWriteDomesticConsent1.getRisk());
+    }
+
+    public static OBWriteDomesticConsent1 toOBWriteDomesticConsent1(OBWriteDomesticConsent2 obWriteDomesticConsent2) {
+        return (new OBWriteDomesticConsent1())
+                .data(toOBWriteDataDomesticConsent1(obWriteDomesticConsent2.getData()))
+                .risk(obWriteDomesticConsent2.getRisk());
+    }
 
     public static OBWriteDomesticConsent2 toOBWriteDomesticConsent2(OBWriteDomesticConsent3 obWriteDomesticConsent3) {
         return (new OBWriteDomesticConsent2())
@@ -42,23 +51,22 @@ public class OBWriteDomesticConsentConverter {
                 .risk(obWriteDomesticConsent3.getRisk());
     }
 
-    public static OBWriteDomesticScheduledConsent1 toOBWriteDomesticScheduledConsent1(OBWriteDomesticScheduledConsent3 domesticScheduledConsent3) {
-        return (new OBWriteDomesticScheduledConsent1())
-                .data(toOBWriteDataDomesticScheduledConsent1(domesticScheduledConsent3.getData()))
-                .risk(domesticScheduledConsent3.getRisk());
+    public static OBWriteDataDomesticConsent1 toOBWriteDataDomesticConsent1(OBWriteDataDomesticConsent2 data) {
+        return data == null ? null : (new OBWriteDataDomesticConsent1())
+                .authorisation(data.getAuthorisation())
+                .initiation(toOBDomestic1(data.getInitiation()));
+    }
+
+    public static OBWriteDataDomesticConsent2 toOBWriteDataDomesticConsent2(OBWriteDataDomesticConsent1 data) {
+        return data == null ? null : (new OBWriteDataDomesticConsent2())
+                .authorisation(data.getAuthorisation())
+                .initiation(toOBDomestic2(data.getInitiation()));
     }
 
     public static OBWriteDataDomesticConsent2 toOBWriteDataDomesticConsent2(OBWriteDomesticConsent3Data data) {
         return data == null ? null : (new OBWriteDataDomesticConsent2())
                 .authorisation(toOBAuthorisation1(data.getAuthorisation()))
                 .initiation(toOBDomestic2(data.getInitiation()));
-    }
-
-    public static OBWriteDataDomesticScheduledConsent1 toOBWriteDataDomesticScheduledConsent1(OBWriteDomesticScheduledConsent3Data data) {
-        return (new OBWriteDataDomesticScheduledConsent1())
-                .permission(OBExternalPermissions2Code.valueOf(data.getPermission().name()))
-                .initiation(toOBDomesticScheduled1(data.getInitiation()))
-                .authorisation(toOBAuthorisation1(data.getAuthorisation()));
     }
 
 }

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteDomesticConsentConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteDomesticConsentConverter.java
@@ -33,16 +33,16 @@ import static uk.org.openbanking.datamodel.service.converter.payment.OBDomesticC
 
 public class OBWriteDomesticConsentConverter {
 
-    public static OBWriteDomesticConsent2 toOBWriteDomesticConsent2(OBWriteDomesticConsent1 obWriteDomesticConsent1) {
-        return (new OBWriteDomesticConsent2())
-                .data(toOBWriteDataDomesticConsent2(obWriteDomesticConsent1.getData()))
-                .risk(obWriteDomesticConsent1.getRisk());
-    }
-
     public static OBWriteDomesticConsent1 toOBWriteDomesticConsent1(OBWriteDomesticConsent2 obWriteDomesticConsent2) {
         return (new OBWriteDomesticConsent1())
                 .data(toOBWriteDataDomesticConsent1(obWriteDomesticConsent2.getData()))
                 .risk(obWriteDomesticConsent2.getRisk());
+    }
+
+    public static OBWriteDomesticConsent2 toOBWriteDomesticConsent2(OBWriteDomesticConsent1 obWriteDomesticConsent1) {
+        return (new OBWriteDomesticConsent2())
+                .data(toOBWriteDataDomesticConsent2(obWriteDomesticConsent1.getData()))
+                .risk(obWriteDomesticConsent1.getRisk());
     }
 
     public static OBWriteDomesticConsent2 toOBWriteDomesticConsent2(OBWriteDomesticConsent3 obWriteDomesticConsent3) {
@@ -53,20 +53,20 @@ public class OBWriteDomesticConsentConverter {
 
     public static OBWriteDataDomesticConsent1 toOBWriteDataDomesticConsent1(OBWriteDataDomesticConsent2 data) {
         return data == null ? null : (new OBWriteDataDomesticConsent1())
-                .authorisation(data.getAuthorisation())
-                .initiation(toOBDomestic1(data.getInitiation()));
+                .initiation(toOBDomestic1(data.getInitiation()))
+                .authorisation(data.getAuthorisation());
     }
 
     public static OBWriteDataDomesticConsent2 toOBWriteDataDomesticConsent2(OBWriteDataDomesticConsent1 data) {
         return data == null ? null : (new OBWriteDataDomesticConsent2())
-                .authorisation(data.getAuthorisation())
-                .initiation(toOBDomestic2(data.getInitiation()));
+                .initiation(toOBDomestic2(data.getInitiation()))
+                .authorisation(data.getAuthorisation());
     }
 
     public static OBWriteDataDomesticConsent2 toOBWriteDataDomesticConsent2(OBWriteDomesticConsent3Data data) {
         return data == null ? null : (new OBWriteDataDomesticConsent2())
-                .authorisation(toOBAuthorisation1(data.getAuthorisation()))
-                .initiation(toOBDomestic2(data.getInitiation()));
+                .initiation(toOBDomestic2(data.getInitiation()))
+                .authorisation(toOBAuthorisation1(data.getAuthorisation()));
     }
 
 }

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteDomesticScheduledConsentConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteDomesticScheduledConsentConverter.java
@@ -20,21 +20,66 @@
  */
 package uk.org.openbanking.datamodel.service.converter.payment;
 
+import uk.org.openbanking.datamodel.payment.OBExternalPermissions2Code;
+import uk.org.openbanking.datamodel.payment.OBWriteDataDomesticScheduledConsent1;
 import uk.org.openbanking.datamodel.payment.OBWriteDataDomesticScheduledConsent2;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent1;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent2;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent3;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent3Data;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent3Data.PermissionEnum;
 
+import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBAuthorisation1;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBWriteDomesticConsent3DataAuthorisation;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBDomesticScheduledConverter.toOBDomesticScheduled1;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBDomesticScheduledConverter.toOBDomesticScheduled2;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBDomesticScheduledConverter.toOBWriteDomesticScheduled2DataInitiation;
 
 public class OBWriteDomesticScheduledConsentConverter {
+
+    public static OBWriteDomesticScheduledConsent1 toOBWriteDomesticScheduledConsent1(OBWriteDomesticScheduledConsent2 obWriteDomesticScheduledConsent2) {
+        return (new OBWriteDomesticScheduledConsent1())
+                .data(toOBWriteDataDomesticScheduledConsent1(obWriteDomesticScheduledConsent2.getData()))
+                .risk(obWriteDomesticScheduledConsent2.getRisk());
+    }
+
+    public static OBWriteDomesticScheduledConsent1 toOBWriteDomesticScheduledConsent1(OBWriteDomesticScheduledConsent3 obWriteDomesticScheduledConsent3) {
+        return (new OBWriteDomesticScheduledConsent1())
+                .data(toOBWriteDataDomesticScheduledConsent1(obWriteDomesticScheduledConsent3.getData()))
+                .risk(obWriteDomesticScheduledConsent3.getRisk());
+    }
+
+    public static OBWriteDomesticScheduledConsent2 toOBWriteDomesticScheduledConsent2(OBWriteDomesticScheduledConsent1 obWriteDomesticScheduledConsent1) {
+        return (new OBWriteDomesticScheduledConsent2())
+                .data(toOBWriteDataDomesticScheduledConsent2(obWriteDomesticScheduledConsent1.getData()))
+                .risk(obWriteDomesticScheduledConsent1.getRisk());
+    }
 
     public static OBWriteDomesticScheduledConsent3 toOBWriteDomesticScheduledConsent3(OBWriteDomesticScheduledConsent2 obWriteDomesticScheduledConsent2) {
         return (new OBWriteDomesticScheduledConsent3())
                 .data(toOBWriteDomesticScheduledConsent3Data(obWriteDomesticScheduledConsent2))
                 .risk(obWriteDomesticScheduledConsent2.getRisk());
+    }
+
+    public static OBWriteDataDomesticScheduledConsent1 toOBWriteDataDomesticScheduledConsent1(OBWriteDataDomesticScheduledConsent2 data) {
+        return (new OBWriteDataDomesticScheduledConsent1())
+                .permission(OBExternalPermissions2Code.valueOf(data.getPermission().name()))
+                .initiation(toOBDomesticScheduled1(data.getInitiation()))
+                .authorisation(data.getAuthorisation());
+    }
+
+    public static OBWriteDataDomesticScheduledConsent1 toOBWriteDataDomesticScheduledConsent1(OBWriteDomesticScheduledConsent3Data data) {
+        return (new OBWriteDataDomesticScheduledConsent1())
+                .permission(OBExternalPermissions2Code.valueOf(data.getPermission().name()))
+                .initiation(toOBDomesticScheduled1(data.getInitiation()))
+                .authorisation(toOBAuthorisation1(data.getAuthorisation()));
+    }
+
+    public static OBWriteDataDomesticScheduledConsent2 toOBWriteDataDomesticScheduledConsent2(OBWriteDataDomesticScheduledConsent1 data) {
+        return (new OBWriteDataDomesticScheduledConsent2())
+                .permission(OBExternalPermissions2Code.valueOf(data.getPermission().name()))
+                .initiation(toOBDomesticScheduled2(data.getInitiation()))
+                .authorisation(data.getAuthorisation());
     }
 
     public static OBWriteDomesticScheduledConsent3Data toOBWriteDomesticScheduledConsent3Data(OBWriteDomesticScheduledConsent2 obWriteDomesticScheduledConsent2) {

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteDomesticScheduledConsentConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteDomesticScheduledConsentConverter.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.datamodel.service.converter.payment;
+
+import uk.org.openbanking.datamodel.payment.OBWriteDataDomesticScheduledConsent2;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent2;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent3;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent3Data;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent3Data.PermissionEnum;
+
+import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBWriteDomesticConsent3DataAuthorisation;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBDomesticScheduledConverter.toOBWriteDomesticScheduled2DataInitiation;
+
+public class OBWriteDomesticScheduledConsentConverter {
+
+    public static OBWriteDomesticScheduledConsent3 toOBWriteDomesticScheduledConsent3(OBWriteDomesticScheduledConsent2 obWriteDomesticScheduledConsent2) {
+        return (new OBWriteDomesticScheduledConsent3())
+                .data(toOBWriteDomesticScheduledConsent3Data(obWriteDomesticScheduledConsent2))
+                .risk(obWriteDomesticScheduledConsent2.getRisk());
+    }
+
+    public static OBWriteDomesticScheduledConsent3Data toOBWriteDomesticScheduledConsent3Data(OBWriteDomesticScheduledConsent2 obWriteDomesticScheduledConsent2) {
+        return obWriteDomesticScheduledConsent2.getData() == null ? null : (new OBWriteDomesticScheduledConsent3Data())
+                .permission(toPermissionEnum(obWriteDomesticScheduledConsent2.getData()))
+                .initiation(toOBWriteDomesticScheduled2DataInitiation(obWriteDomesticScheduledConsent2.getData().getInitiation()))
+                .authorisation(toOBWriteDomesticConsent3DataAuthorisation(obWriteDomesticScheduledConsent2.getData().getAuthorisation()));
+    }
+
+    public static PermissionEnum toPermissionEnum(OBWriteDataDomesticScheduledConsent2 data) {
+        return data.getPermission() == null ? null : PermissionEnum.valueOf(data.getPermission().name());
+    }
+
+}

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteDomesticScheduledConsentConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteDomesticScheduledConsentConverter.java
@@ -57,36 +57,36 @@ public class OBWriteDomesticScheduledConsentConverter {
 
     public static OBWriteDomesticScheduledConsent3 toOBWriteDomesticScheduledConsent3(OBWriteDomesticScheduledConsent2 obWriteDomesticScheduledConsent2) {
         return (new OBWriteDomesticScheduledConsent3())
-                .data(toOBWriteDomesticScheduledConsent3Data(obWriteDomesticScheduledConsent2))
+                .data(toOBWriteDomesticScheduledConsent3Data(obWriteDomesticScheduledConsent2.getData()))
                 .risk(obWriteDomesticScheduledConsent2.getRisk());
     }
 
     public static OBWriteDataDomesticScheduledConsent1 toOBWriteDataDomesticScheduledConsent1(OBWriteDataDomesticScheduledConsent2 data) {
-        return (new OBWriteDataDomesticScheduledConsent1())
+        return data == null ? null : (new OBWriteDataDomesticScheduledConsent1())
                 .permission(OBExternalPermissions2Code.valueOf(data.getPermission().name()))
                 .initiation(toOBDomesticScheduled1(data.getInitiation()))
                 .authorisation(data.getAuthorisation());
     }
 
     public static OBWriteDataDomesticScheduledConsent1 toOBWriteDataDomesticScheduledConsent1(OBWriteDomesticScheduledConsent3Data data) {
-        return (new OBWriteDataDomesticScheduledConsent1())
+        return data == null ? null : (new OBWriteDataDomesticScheduledConsent1())
                 .permission(OBExternalPermissions2Code.valueOf(data.getPermission().name()))
                 .initiation(toOBDomesticScheduled1(data.getInitiation()))
                 .authorisation(toOBAuthorisation1(data.getAuthorisation()));
     }
 
     public static OBWriteDataDomesticScheduledConsent2 toOBWriteDataDomesticScheduledConsent2(OBWriteDataDomesticScheduledConsent1 data) {
-        return (new OBWriteDataDomesticScheduledConsent2())
+        return data == null ? null : (new OBWriteDataDomesticScheduledConsent2())
                 .permission(OBExternalPermissions2Code.valueOf(data.getPermission().name()))
                 .initiation(toOBDomesticScheduled2(data.getInitiation()))
                 .authorisation(data.getAuthorisation());
     }
 
-    public static OBWriteDomesticScheduledConsent3Data toOBWriteDomesticScheduledConsent3Data(OBWriteDomesticScheduledConsent2 obWriteDomesticScheduledConsent2) {
-        return obWriteDomesticScheduledConsent2.getData() == null ? null : (new OBWriteDomesticScheduledConsent3Data())
-                .permission(toPermissionEnum(obWriteDomesticScheduledConsent2.getData()))
-                .initiation(toOBWriteDomesticScheduled2DataInitiation(obWriteDomesticScheduledConsent2.getData().getInitiation()))
-                .authorisation(toOBWriteDomesticConsent3DataAuthorisation(obWriteDomesticScheduledConsent2.getData().getAuthorisation()));
+    public static OBWriteDomesticScheduledConsent3Data toOBWriteDomesticScheduledConsent3Data(OBWriteDataDomesticScheduledConsent2 data) {
+        return data == null ? null : (new OBWriteDomesticScheduledConsent3Data())
+                .permission(toPermissionEnum(data))
+                .initiation(toOBWriteDomesticScheduled2DataInitiation(data.getInitiation()))
+                .authorisation(toOBWriteDomesticConsent3DataAuthorisation(data.getAuthorisation()));
     }
 
     public static PermissionEnum toPermissionEnum(OBWriteDataDomesticScheduledConsent2 data) {

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteDomesticScheduledConsentConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteDomesticScheduledConsentConverter.java
@@ -20,13 +20,7 @@
  */
 package uk.org.openbanking.datamodel.service.converter.payment;
 
-import uk.org.openbanking.datamodel.payment.OBExternalPermissions2Code;
-import uk.org.openbanking.datamodel.payment.OBWriteDataDomesticScheduledConsent1;
-import uk.org.openbanking.datamodel.payment.OBWriteDataDomesticScheduledConsent2;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent1;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent2;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent3;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent3Data;
+import uk.org.openbanking.datamodel.payment.*;
 import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent3Data.PermissionEnum;
 
 import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBAuthorisation1;
@@ -61,6 +55,12 @@ public class OBWriteDomesticScheduledConsentConverter {
                 .risk(obWriteDomesticScheduledConsent2.getRisk());
     }
 
+    public static OBWriteDomesticScheduled2 toOBWriteDomesticScheduled2(OBWriteDomesticScheduled1 obWriteDomesticScheduled1) {
+        return (new OBWriteDomesticScheduled2())
+                .data(toOBWriteDataDomesticScheduled2(obWriteDomesticScheduled1.getData()))
+                .risk(obWriteDomesticScheduled1.getRisk());
+    }
+
     public static OBWriteDataDomesticScheduledConsent1 toOBWriteDataDomesticScheduledConsent1(OBWriteDataDomesticScheduledConsent2 data) {
         return data == null ? null : (new OBWriteDataDomesticScheduledConsent1())
                 .permission(OBExternalPermissions2Code.valueOf(data.getPermission().name()))
@@ -87,6 +87,12 @@ public class OBWriteDomesticScheduledConsentConverter {
                 .permission(toPermissionEnum(data))
                 .initiation(toOBWriteDomesticScheduled2DataInitiation(data.getInitiation()))
                 .authorisation(toOBWriteDomesticConsent3DataAuthorisation(data.getAuthorisation()));
+    }
+
+    public static OBWriteDataDomesticScheduled2 toOBWriteDataDomesticScheduled2(OBWriteDataDomesticScheduled1 data) {
+        return data == null ? null : (new OBWriteDataDomesticScheduled2())
+                .consentId(data.getConsentId())
+                .initiation(toOBDomesticScheduled2(data.getInitiation()));
     }
 
     public static PermissionEnum toPermissionEnum(OBWriteDataDomesticScheduledConsent2 data) {

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteDomesticStandingOrderConsentConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteDomesticStandingOrderConsentConverter.java
@@ -47,6 +47,19 @@ public class OBWriteDomesticStandingOrderConsentConverter {
                 .risk(obWriteDomesticStandingOrderConsent2.getRisk());
     }
 
+    public static OBWriteDomesticStandingOrderConsent1 toOBWriteDomesticStandingOrderConsent1(OBWriteDomesticStandingOrderConsent3 obWriteDomesticStandingOrderConsent3) {
+        return (new OBWriteDomesticStandingOrderConsent1())
+                .data(toOBWriteDataDomesticStandingOrderConsent1(obWriteDomesticStandingOrderConsent3.getData()))
+                .risk(obWriteDomesticStandingOrderConsent3.getRisk());
+    }
+
+    public static OBWriteDomesticStandingOrderConsent2 toOBWriteDomesticStandingOrderConsent2(OBWriteDomesticStandingOrderConsent3 domesticStandingOrderConsent) {
+        return (new OBWriteDomesticStandingOrderConsent2())
+                .data(toOBWriteDataDomesticStandingOrderConsent2(domesticStandingOrderConsent.getData()))
+                .risk(domesticStandingOrderConsent.getRisk());
+
+    }
+
     public static OBWriteDomesticStandingOrderConsent2 toOBWriteDomesticStandingOrderConsent2(OBWriteDomesticStandingOrderConsent1 obWriteDomesticStandingOrderConsent1) {
         return (new OBWriteDomesticStandingOrderConsent2())
                 .data(toOBWriteDataDomesticStandingOrderConsent2(obWriteDomesticStandingOrderConsent1.getData()))
@@ -78,7 +91,21 @@ public class OBWriteDomesticStandingOrderConsentConverter {
                 .authorisation(data.getAuthorisation());
     }
 
+    public static OBWriteDataDomesticStandingOrderConsent1 toOBWriteDataDomesticStandingOrderConsent1(OBWriteDataDomesticStandingOrderConsent3 data) {
+        return data == null ? null : (new OBWriteDataDomesticStandingOrderConsent1())
+                .permission(data.getPermission())
+                .initiation(toOBDomesticStandingOrder1(data.getInitiation()))
+                .authorisation(data.getAuthorisation());
+    }
+
     public static OBWriteDataDomesticStandingOrderConsent2 toOBWriteDataDomesticStandingOrderConsent2(OBWriteDataDomesticStandingOrderConsent1 data) {
+        return data == null ? null : (new OBWriteDataDomesticStandingOrderConsent2())
+                .permission(data.getPermission())
+                .initiation(toOBDomesticStandingOrder2(data.getInitiation()))
+                .authorisation(data.getAuthorisation());
+    }
+
+    public static OBWriteDataDomesticStandingOrderConsent2 toOBWriteDataDomesticStandingOrderConsent2(OBWriteDataDomesticStandingOrderConsent3 data) {
         return data == null ? null : (new OBWriteDataDomesticStandingOrderConsent2())
                 .permission(data.getPermission())
                 .initiation(toOBDomesticStandingOrder2(data.getInitiation()))

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteDomesticStandingOrderConsentConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteDomesticStandingOrderConsentConverter.java
@@ -20,21 +20,69 @@
  */
 package uk.org.openbanking.datamodel.service.converter.payment;
 
-import uk.org.openbanking.datamodel.payment.OBExternalPermissions2Code;
-import uk.org.openbanking.datamodel.payment.OBWriteDataDomesticStandingOrderConsent3;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent3;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent4;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent4Data;
+import uk.org.openbanking.datamodel.payment.*;
 
 import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBAuthorisation1;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBDomesticStandingOrderConverter.toOBDomesticStandingOrder1;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBDomesticStandingOrderConverter.toOBDomesticStandingOrder2;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBDomesticStandingOrderConverter.toOBDomesticStandingOrder3;
 
 public class OBWriteDomesticStandingOrderConsentConverter {
+
+    public static OBWriteDomesticStandingOrder1 toOBWriteDomesticStandingOrder1(OBWriteDomesticStandingOrder2 obWriteDomesticStandingOrder2) {
+        return (new OBWriteDomesticStandingOrder1())
+                .data(toOBWriteDataDomesticStandingOrder1(obWriteDomesticStandingOrder2.getData()))
+                .risk(obWriteDomesticStandingOrder2.getRisk());
+    }
+
+    public static OBWriteDomesticStandingOrder2 toOBWriteDomesticStandingOrder2(OBWriteDomesticStandingOrder1 obWriteDomesticStandingOrder1) {
+        return (new OBWriteDomesticStandingOrder2())
+                .data(toOBWriteDataDomesticStandingOrder2(obWriteDomesticStandingOrder1.getData()))
+                .risk(obWriteDomesticStandingOrder1.getRisk());
+    }
+
+    public static OBWriteDomesticStandingOrderConsent1 toOBWriteDomesticStandingOrderConsent1(OBWriteDomesticStandingOrderConsent2 obWriteDomesticStandingOrderConsent2) {
+        return (new OBWriteDomesticStandingOrderConsent1())
+                .data(toOBWriteDataDomesticStandingOrderConsent1(obWriteDomesticStandingOrderConsent2.getData()))
+                .risk(obWriteDomesticStandingOrderConsent2.getRisk());
+    }
+
+    public static OBWriteDomesticStandingOrderConsent2 toOBWriteDomesticStandingOrderConsent2(OBWriteDomesticStandingOrderConsent1 obWriteDomesticStandingOrderConsent1) {
+        return (new OBWriteDomesticStandingOrderConsent2())
+                .data(toOBWriteDataDomesticStandingOrderConsent2(obWriteDomesticStandingOrderConsent1.getData()))
+                .risk(obWriteDomesticStandingOrderConsent1.getRisk());
+    }
 
     public static OBWriteDomesticStandingOrderConsent3 toOBWriteDomesticStandingOrderConsent3(OBWriteDomesticStandingOrderConsent4 obWriteDomesticStandingOrderConsent4) {
         return (new OBWriteDomesticStandingOrderConsent3())
                 .data(toOBWriteDataDomesticStandingOrderConsent3(obWriteDomesticStandingOrderConsent4.getData()))
                 .risk(obWriteDomesticStandingOrderConsent4.getRisk());
+    }
+
+    public static OBWriteDataDomesticStandingOrder1 toOBWriteDataDomesticStandingOrder1(OBWriteDataDomesticStandingOrder2 data) {
+        return data == null ? null : (new OBWriteDataDomesticStandingOrder1())
+                .consentId(data.getConsentId())
+                .initiation(toOBDomesticStandingOrder1(data.getInitiation()));
+    }
+
+    public static OBWriteDataDomesticStandingOrder2 toOBWriteDataDomesticStandingOrder2(OBWriteDataDomesticStandingOrder1 data) {
+        return data == null ? null : (new OBWriteDataDomesticStandingOrder2())
+                .consentId(data.getConsentId())
+                .initiation(toOBDomesticStandingOrder2(data.getInitiation()));
+    }
+
+    public static OBWriteDataDomesticStandingOrderConsent1 toOBWriteDataDomesticStandingOrderConsent1(OBWriteDataDomesticStandingOrderConsent2 data) {
+        return data == null ? null : (new OBWriteDataDomesticStandingOrderConsent1())
+                .permission(data.getPermission())
+                .initiation(toOBDomesticStandingOrder1(data.getInitiation()))
+                .authorisation(data.getAuthorisation());
+    }
+
+    public static OBWriteDataDomesticStandingOrderConsent2 toOBWriteDataDomesticStandingOrderConsent2(OBWriteDataDomesticStandingOrderConsent1 data) {
+        return data == null ? null : (new OBWriteDataDomesticStandingOrderConsent2())
+                .permission(data.getPermission())
+                .initiation(toOBDomesticStandingOrder2(data.getInitiation()))
+                .authorisation(data.getAuthorisation());
     }
 
     public static OBWriteDataDomesticStandingOrderConsent3 toOBWriteDataDomesticStandingOrderConsent3(OBWriteDomesticStandingOrderConsent4Data data) {
@@ -44,7 +92,7 @@ public class OBWriteDomesticStandingOrderConsentConverter {
                 .authorisation(toOBAuthorisation1(data.getAuthorisation()));
     }
 
-    private static OBExternalPermissions2Code toOBExternalPermissions2Code(OBWriteDomesticStandingOrderConsent4Data data) {
+    public static OBExternalPermissions2Code toOBExternalPermissions2Code(OBWriteDomesticStandingOrderConsent4Data data) {
         return data.getPermission() == null ? null : OBExternalPermissions2Code.valueOf(data.getPermission().name());
     }
 }

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteDomesticStandingOrderConsentConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteDomesticStandingOrderConsentConverter.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.datamodel.service.converter.payment;
+
+import uk.org.openbanking.datamodel.payment.OBExternalPermissions2Code;
+import uk.org.openbanking.datamodel.payment.OBWriteDataDomesticStandingOrderConsent3;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent3;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent4;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent4Data;
+
+import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBAuthorisation1;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBDomesticStandingOrderConverter.toOBDomesticStandingOrder3;
+
+public class OBWriteDomesticStandingOrderConsentConverter {
+
+    public static OBWriteDomesticStandingOrderConsent3 toOBWriteDomesticStandingOrderConsent3(OBWriteDomesticStandingOrderConsent4 obWriteDomesticStandingOrderConsent4) {
+        return (new OBWriteDomesticStandingOrderConsent3())
+                .data(toOBWriteDataDomesticStandingOrderConsent3(obWriteDomesticStandingOrderConsent4.getData()))
+                .risk(obWriteDomesticStandingOrderConsent4.getRisk());
+    }
+
+    public static OBWriteDataDomesticStandingOrderConsent3 toOBWriteDataDomesticStandingOrderConsent3(OBWriteDomesticStandingOrderConsent4Data data) {
+        return data == null ? null : (new OBWriteDataDomesticStandingOrderConsent3())
+                .permission(toOBExternalPermissions2Code(data))
+                .initiation(toOBDomesticStandingOrder3(data.getInitiation()))
+                .authorisation(toOBAuthorisation1(data.getAuthorisation()));
+    }
+
+    private static OBExternalPermissions2Code toOBExternalPermissions2Code(OBWriteDomesticStandingOrderConsent4Data data) {
+        return data.getPermission() == null ? null : OBExternalPermissions2Code.valueOf(data.getPermission().name());
+    }
+}

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteDomesticStandingOrderConsentConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteDomesticStandingOrderConsentConverter.java
@@ -41,6 +41,12 @@ public class OBWriteDomesticStandingOrderConsentConverter {
                 .risk(obWriteDomesticStandingOrder1.getRisk());
     }
 
+    public static OBWriteDomesticStandingOrder3 toOBWriteDomesticStandingOrder3(OBWriteDomesticStandingOrder2 obWriteDomesticStandingOrder2) {
+        return (new OBWriteDomesticStandingOrder3())
+                .data(toOBWriteDataDomesticStandingOrder3(obWriteDomesticStandingOrder2.getData()))
+                .risk(obWriteDomesticStandingOrder2.getRisk());
+    }
+
     public static OBWriteDomesticStandingOrderConsent1 toOBWriteDomesticStandingOrderConsent1(OBWriteDomesticStandingOrderConsent2 obWriteDomesticStandingOrderConsent2) {
         return (new OBWriteDomesticStandingOrderConsent1())
                 .data(toOBWriteDataDomesticStandingOrderConsent1(obWriteDomesticStandingOrderConsent2.getData()))
@@ -66,6 +72,12 @@ public class OBWriteDomesticStandingOrderConsentConverter {
                 .risk(obWriteDomesticStandingOrderConsent1.getRisk());
     }
 
+    public static OBWriteDomesticStandingOrderConsent3 toOBWriteDomesticStandingOrderConsent3(OBWriteDomesticStandingOrderConsent2 obWriteDomesticStandingOrderConsent2) {
+        return (new OBWriteDomesticStandingOrderConsent3())
+                .data(toOBWriteDataDomesticStandingOrderConsent3(obWriteDomesticStandingOrderConsent2.getData()))
+                .risk(obWriteDomesticStandingOrderConsent2.getRisk());
+    }
+
     public static OBWriteDomesticStandingOrderConsent3 toOBWriteDomesticStandingOrderConsent3(OBWriteDomesticStandingOrderConsent4 obWriteDomesticStandingOrderConsent4) {
         return (new OBWriteDomesticStandingOrderConsent3())
                 .data(toOBWriteDataDomesticStandingOrderConsent3(obWriteDomesticStandingOrderConsent4.getData()))
@@ -82,6 +94,12 @@ public class OBWriteDomesticStandingOrderConsentConverter {
         return data == null ? null : (new OBWriteDataDomesticStandingOrder2())
                 .consentId(data.getConsentId())
                 .initiation(toOBDomesticStandingOrder2(data.getInitiation()));
+    }
+
+    public static OBWriteDataDomesticStandingOrder3 toOBWriteDataDomesticStandingOrder3(OBWriteDataDomesticStandingOrder2 data) {
+        return data == null ? null : (new OBWriteDataDomesticStandingOrder3())
+                .consentId(data.getConsentId())
+                .initiation(toOBDomesticStandingOrder3(data.getInitiation()));
     }
 
     public static OBWriteDataDomesticStandingOrderConsent1 toOBWriteDataDomesticStandingOrderConsent1(OBWriteDataDomesticStandingOrderConsent2 data) {
@@ -109,6 +127,13 @@ public class OBWriteDomesticStandingOrderConsentConverter {
         return data == null ? null : (new OBWriteDataDomesticStandingOrderConsent2())
                 .permission(data.getPermission())
                 .initiation(toOBDomesticStandingOrder2(data.getInitiation()))
+                .authorisation(data.getAuthorisation());
+    }
+
+    public static OBWriteDataDomesticStandingOrderConsent3 toOBWriteDataDomesticStandingOrderConsent3(OBWriteDataDomesticStandingOrderConsent2 data) {
+        return data == null ? null : (new OBWriteDataDomesticStandingOrderConsent3())
+                .permission(data.getPermission())
+                .initiation(toOBDomesticStandingOrder3(data.getInitiation()))
                 .authorisation(data.getAuthorisation());
     }
 

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteFileConsentConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteFileConsentConverter.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.datamodel.service.converter.payment;
+
+import uk.org.openbanking.datamodel.payment.OBWriteDataFileConsent2;
+import uk.org.openbanking.datamodel.payment.OBWriteFileConsent2;
+import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3;
+import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3Data;
+
+import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBAuthorisation1;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBFileConverter.toOBFile2;
+
+public class OBWriteFileConsentConverter {
+
+    public static OBWriteFileConsent2 toOBWriteFileConsent2(OBWriteFileConsent3 obWriteFileConsent3) {
+        return (new OBWriteFileConsent2())
+                .data(toOBWriteDataFileConsent2(obWriteFileConsent3.getData()));
+    }
+
+    public static OBWriteDataFileConsent2 toOBWriteDataFileConsent2(OBWriteFileConsent3Data data) {
+        return data == null ? null : (new OBWriteDataFileConsent2())
+                .initiation(toOBFile2(data.getInitiation()))
+                .authorisation(toOBAuthorisation1(data.getAuthorisation()));
+    }
+
+}

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteFileConsentConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteFileConsentConverter.java
@@ -20,25 +20,59 @@
  */
 package uk.org.openbanking.datamodel.service.converter.payment;
 
+import uk.org.openbanking.datamodel.payment.OBWriteDataFileConsent1;
 import uk.org.openbanking.datamodel.payment.OBWriteDataFileConsent2;
+import uk.org.openbanking.datamodel.payment.OBWriteFileConsent1;
 import uk.org.openbanking.datamodel.payment.OBWriteFileConsent2;
 import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3;
 import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3Data;
 
 import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBAuthorisation1;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBWriteDomesticConsent3DataAuthorisation;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBFileConverter.toOBFile1;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBFileConverter.toOBFile2;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBFileConverter.toOBWriteFile2DataInitiation;
 
 public class OBWriteFileConsentConverter {
+
+    public static OBWriteFileConsent1 toOBWriteFileConsent1(OBWriteFileConsent2 obWriteFileConsent2) {
+        return (new OBWriteFileConsent1())
+                .data(toOBWriteDataFileConsent1(obWriteFileConsent2.getData()));
+    }
+
+    public static OBWriteFileConsent2 toOBWriteFileConsent2(OBWriteFileConsent1 obWriteFileConsent1) {
+        return (new OBWriteFileConsent2())
+                .data(toOBWriteDataFileConsent2(obWriteFileConsent1.getData()));
+    }
 
     public static OBWriteFileConsent2 toOBWriteFileConsent2(OBWriteFileConsent3 obWriteFileConsent3) {
         return (new OBWriteFileConsent2())
                 .data(toOBWriteDataFileConsent2(obWriteFileConsent3.getData()));
     }
 
+    public static OBWriteDataFileConsent1 toOBWriteDataFileConsent1(OBWriteDataFileConsent2 data) {
+        return data == null ? null : (new OBWriteDataFileConsent1())
+                .initiation(toOBFile1(data.getInitiation()))
+                .authorisation(data.getAuthorisation());
+    }
+
+    public static OBWriteDataFileConsent2 toOBWriteDataFileConsent2(OBWriteDataFileConsent1 data) {
+        return data == null ? null : (new OBWriteDataFileConsent2())
+                .initiation(toOBFile2(data.getInitiation()))
+                .authorisation(data.getAuthorisation());
+    }
+
     public static OBWriteDataFileConsent2 toOBWriteDataFileConsent2(OBWriteFileConsent3Data data) {
         return data == null ? null : (new OBWriteDataFileConsent2())
                 .initiation(toOBFile2(data.getInitiation()))
                 .authorisation(toOBAuthorisation1(data.getAuthorisation()));
+    }
+
+    public static OBWriteFileConsent3Data toOBWriteFileConsent3Data(OBWriteDataFileConsent2 data) {
+        return data == null ? null : (new OBWriteFileConsent3Data())
+                .initiation(toOBWriteFile2DataInitiation(data.getInitiation()))
+                .authorisation(toOBWriteDomesticConsent3DataAuthorisation(data.getAuthorisation()))
+                .scASupportData(null);
     }
 
 }

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteFileConsentConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteFileConsentConverter.java
@@ -20,12 +20,7 @@
  */
 package uk.org.openbanking.datamodel.service.converter.payment;
 
-import uk.org.openbanking.datamodel.payment.OBWriteDataFileConsent1;
-import uk.org.openbanking.datamodel.payment.OBWriteDataFileConsent2;
-import uk.org.openbanking.datamodel.payment.OBWriteFileConsent1;
-import uk.org.openbanking.datamodel.payment.OBWriteFileConsent2;
-import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3;
-import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3Data;
+import uk.org.openbanking.datamodel.payment.*;
 
 import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBAuthorisation1;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBWriteDomesticConsent3DataAuthorisation;
@@ -50,6 +45,11 @@ public class OBWriteFileConsentConverter {
                 .data(toOBWriteDataFileConsent2(obWriteFileConsent3.getData()));
     }
 
+    public static OBWriteFile2 toOBWriteFile2(OBWriteFile1 obWriteFile1) {
+        return (new OBWriteFile2())
+                .data(toOBWriteDataFile2(obWriteFile1.getData()));
+    }
+
     public static OBWriteDataFileConsent1 toOBWriteDataFileConsent1(OBWriteDataFileConsent2 data) {
         return data == null ? null : (new OBWriteDataFileConsent1())
                 .initiation(toOBFile1(data.getInitiation()))
@@ -66,6 +66,12 @@ public class OBWriteFileConsentConverter {
         return data == null ? null : (new OBWriteDataFileConsent2())
                 .initiation(toOBFile2(data.getInitiation()))
                 .authorisation(toOBAuthorisation1(data.getAuthorisation()));
+    }
+
+    public static OBWriteDataFile2 toOBWriteDataFile2(OBWriteDataFile1 data) {
+        return data == null ? null : (new OBWriteDataFile2())
+                .consentId(data.getConsentId())
+                .initiation(toOBFile2(data.getInitiation()));
     }
 
     public static OBWriteFileConsent3Data toOBWriteFileConsent3Data(OBWriteDataFileConsent2 data) {

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteInternationalConsentConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteInternationalConsentConverter.java
@@ -47,12 +47,6 @@ public class OBWriteInternationalConsentConverter {
                 .risk(obWriteInternational2.getRisk());
     }
 
-    public static OBWriteDataInternational1 toOBWriteDataInternational1(OBWriteDataInternational2 data) {
-        return data == null ? null : (new OBWriteDataInternational1())
-                .consentId(data.getConsentId())
-                .initiation(toOBInternational1(data.getInitiation()));
-    }
-
     public static OBWriteInternational2 toOBWriteInternational2(OBWriteInternational1 obWriteInternational1) {
         return (new OBWriteInternational2())
                 .data(toOBWriteDataInternational2(obWriteInternational1.getData()))
@@ -63,6 +57,12 @@ public class OBWriteInternationalConsentConverter {
         return (new OBWriteInternationalConsent4())
                 .data(toOBWriteInternationalConsent4Data(obWriteInternationalConsent2.getData()))
                 .risk(obWriteInternationalConsent2.getRisk());
+    }
+
+    public static OBWriteDataInternational1 toOBWriteDataInternational1(OBWriteDataInternational2 data) {
+        return data == null ? null : (new OBWriteDataInternational1())
+                .consentId(data.getConsentId())
+                .initiation(toOBInternational1(data.getInitiation()));
     }
 
     public static OBWriteDataInternational2 toOBWriteDataInternational2(OBWriteDataInternational1 data) {

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteInternationalConsentConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteInternationalConsentConverter.java
@@ -20,15 +20,44 @@
  */
 package uk.org.openbanking.datamodel.service.converter.payment;
 
-import uk.org.openbanking.datamodel.payment.OBWriteDataInternationalConsent2;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent2;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent4;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent4Data;
+import uk.org.openbanking.datamodel.payment.*;
 
 import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBWriteDomesticConsent3DataAuthorisation;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalConverter.toOBInternational1;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalConverter.toOBInternational2;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalConverter.toOBWriteInternational3DataInitiation;
 
 public class OBWriteInternationalConsentConverter {
+
+    public static OBWriteInternationalConsent1 toOBWriteInternationalConsent1(OBWriteInternationalConsent2 obWriteInternationalConsent2) {
+        return (new OBWriteInternationalConsent1())
+                .data(toOBWriteDataInternationalConsent1(obWriteInternationalConsent2.getData()))
+                .risk(obWriteInternationalConsent2.getRisk());
+    }
+
+    public static OBWriteInternationalConsent2 toOBWriteInternationalConsent2(OBWriteInternationalConsent1 obWriteInternationalConsent1) {
+        return (new OBWriteInternationalConsent2())
+                .data(toOBWriteDataInternationalConsent2(obWriteInternationalConsent1.getData()))
+                .risk(obWriteInternationalConsent1.getRisk());
+    }
+
+    public static OBWriteInternational1 toOBWriteInternational1(OBWriteInternational2 obWriteInternational2) {
+        return (new OBWriteInternational1())
+                .data(toOBWriteDataInternational1(obWriteInternational2.getData()))
+                .risk(obWriteInternational2.getRisk());
+    }
+
+    public static OBWriteDataInternational1 toOBWriteDataInternational1(OBWriteDataInternational2 data) {
+        return data == null ? null : (new OBWriteDataInternational1())
+                .consentId(data.getConsentId())
+                .initiation(toOBInternational1(data.getInitiation()));
+    }
+
+    public static OBWriteInternational2 toOBWriteInternational2(OBWriteInternational1 obWriteInternational1) {
+        return (new OBWriteInternational2())
+                .data(toOBWriteDataInternational2(obWriteInternational1.getData()))
+                .risk(obWriteInternational1.getRisk());
+    }
 
     public static OBWriteInternationalConsent4 toOBWriteInternationalConsent4(OBWriteInternationalConsent2 obWriteInternationalConsent2) {
         return (new OBWriteInternationalConsent4())
@@ -36,9 +65,28 @@ public class OBWriteInternationalConsentConverter {
                 .risk(obWriteInternationalConsent2.getRisk());
     }
 
+    public static OBWriteDataInternational2 toOBWriteDataInternational2(OBWriteDataInternational1 data) {
+        return data == null ? null : (new OBWriteDataInternational2())
+                .consentId(data.getConsentId())
+                .initiation(toOBInternational2(data.getInitiation()));
+    }
+
+    public static OBWriteDataInternationalConsent1 toOBWriteDataInternationalConsent1(OBWriteDataInternationalConsent2 data) {
+        return data == null ? null : (new OBWriteDataInternationalConsent1())
+                .authorisation(data.getAuthorisation())
+                .initiation(toOBInternational1(data.getInitiation()));
+    }
+
+    public static OBWriteDataInternationalConsent2 toOBWriteDataInternationalConsent2(OBWriteDataInternationalConsent1 data) {
+        return data == null ? null : (new OBWriteDataInternationalConsent2())
+                .authorisation(data.getAuthorisation())
+                .initiation(toOBInternational2(data.getInitiation()));
+    }
+
     public static OBWriteInternationalConsent4Data toOBWriteInternationalConsent4Data(OBWriteDataInternationalConsent2 data) {
         return data == null ? null : (new OBWriteInternationalConsent4Data())
                 .initiation(toOBWriteInternational3DataInitiation(data.getInitiation()))
-                .authorisation(toOBWriteDomesticConsent3DataAuthorisation(data.getAuthorisation()));
+                .authorisation(toOBWriteDomesticConsent3DataAuthorisation(data.getAuthorisation()))
+                .scASupportData(null);
     }
 }

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteInternationalConsentConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteInternationalConsentConverter.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.datamodel.service.converter.payment;
+
+import uk.org.openbanking.datamodel.payment.OBWriteDataInternationalConsent2;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent2;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent4;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent4Data;
+
+import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBWriteDomesticConsent3DataAuthorisation;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalConverter.toOBWriteInternational3DataInitiation;
+
+public class OBWriteInternationalConsentConverter {
+
+    public static OBWriteInternationalConsent4 toOBWriteInternationalConsent4(OBWriteInternationalConsent2 obWriteInternationalConsent2) {
+        return (new OBWriteInternationalConsent4())
+                .data(toOBWriteInternationalConsent4Data(obWriteInternationalConsent2.getData()))
+                .risk(obWriteInternationalConsent2.getRisk());
+    }
+
+    public static OBWriteInternationalConsent4Data toOBWriteInternationalConsent4Data(OBWriteDataInternationalConsent2 data) {
+        return data == null ? null : (new OBWriteInternationalConsent4Data())
+                .initiation(toOBWriteInternational3DataInitiation(data.getInitiation()))
+                .authorisation(toOBWriteDomesticConsent3DataAuthorisation(data.getAuthorisation()));
+    }
+}

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteInternationalScheduledConsentConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteInternationalScheduledConsentConverter.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.datamodel.service.converter.payment;
+
+import uk.org.openbanking.datamodel.payment.OBExternalPermissions2Code;
+import uk.org.openbanking.datamodel.payment.OBWriteDataInternationalScheduledConsent1;
+import uk.org.openbanking.datamodel.payment.OBWriteDataInternationalScheduledConsent2;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent1;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent2;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent4;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent4Data;
+
+import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBAuthorisation1;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBWriteDomesticConsent3DataAuthorisation;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalScheduledConverter.toOBInternationalScheduled1;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalScheduledConverter.toOBWriteInternationalScheduled3DataInitiation;
+
+public class OBWriteInternationalScheduledConsentConverter {
+
+    public static OBWriteInternationalScheduledConsent1 toOBWriteInternationalScheduledConsent1(OBWriteInternationalScheduledConsent4 obWriteInternationalScheduledConsent4) {
+        return (new OBWriteInternationalScheduledConsent1()
+                .data(toOBWriteDataInternationalScheduledConsent1(obWriteInternationalScheduledConsent4.getData()))
+                .risk(obWriteInternationalScheduledConsent4.getRisk())
+        );
+    }
+
+    public static OBWriteInternationalScheduledConsent4 toOBWriteInternationalScheduledConsent4(OBWriteInternationalScheduledConsent1 obWriteInternationalScheduledConsent1) {
+        return (new OBWriteInternationalScheduledConsent4())
+                .data(toOBWriteInternationalScheduledConsent4Data(obWriteInternationalScheduledConsent1.getData()))
+                .risk(obWriteInternationalScheduledConsent1.getRisk());
+    }
+
+    public static OBWriteInternationalScheduledConsent4 toOBWriteInternationalScheduledConsent4(OBWriteInternationalScheduledConsent2 obWriteInternationalScheduledConsent2) {
+        return (new OBWriteInternationalScheduledConsent4())
+                .data(toOBWriteInternationalScheduledConsent4Data(obWriteInternationalScheduledConsent2.getData()))
+                .risk(obWriteInternationalScheduledConsent2.getRisk());
+    }
+
+    public static OBWriteDataInternationalScheduledConsent1 toOBWriteDataInternationalScheduledConsent1(OBWriteInternationalScheduledConsent4Data data) {
+        return data == null ? null : (new OBWriteDataInternationalScheduledConsent1())
+                .permission(toOBExternalPermissions2Code(data.getPermission()))
+                .initiation(toOBInternationalScheduled1(data.getInitiation()))
+                .authorisation(toOBAuthorisation1(data.getAuthorisation()));
+    }
+
+    public static OBWriteInternationalScheduledConsent4Data toOBWriteInternationalScheduledConsent4Data(OBWriteDataInternationalScheduledConsent1 data) {
+        return data == null ? null : (new OBWriteInternationalScheduledConsent4Data())
+                .permission(toPermissionEnum(data.getPermission()))
+                .initiation(toOBWriteInternationalScheduled3DataInitiation(data.getInitiation()))
+                .authorisation(toOBWriteDomesticConsent3DataAuthorisation(data.getAuthorisation()));
+    }
+
+    public static OBWriteInternationalScheduledConsent4Data toOBWriteInternationalScheduledConsent4Data(OBWriteDataInternationalScheduledConsent2 data) {
+        return data == null ? null : (new OBWriteInternationalScheduledConsent4Data())
+                .permission(toPermissionEnum(data.getPermission()))
+                .initiation(toOBWriteInternationalScheduled3DataInitiation(data.getInitiation()))
+                .authorisation(toOBWriteDomesticConsent3DataAuthorisation(data.getAuthorisation()));
+    }
+
+    public static OBWriteInternationalScheduledConsent4Data.PermissionEnum toPermissionEnum(OBExternalPermissions2Code permission) {
+        return permission == null ? null : OBWriteInternationalScheduledConsent4Data.PermissionEnum.valueOf(permission.name());
+    }
+
+    public static OBExternalPermissions2Code toOBExternalPermissions2Code(OBWriteInternationalScheduledConsent4Data.PermissionEnum permission) {
+        return permission == null ? null : OBExternalPermissions2Code.valueOf(permission.name());
+    }
+}

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteInternationalScheduledConsentConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteInternationalScheduledConsentConverter.java
@@ -20,20 +20,39 @@
  */
 package uk.org.openbanking.datamodel.service.converter.payment;
 
-import uk.org.openbanking.datamodel.payment.OBExternalPermissions2Code;
-import uk.org.openbanking.datamodel.payment.OBWriteDataInternationalScheduledConsent1;
-import uk.org.openbanking.datamodel.payment.OBWriteDataInternationalScheduledConsent2;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent1;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent2;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent4;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent4Data;
+import uk.org.openbanking.datamodel.payment.*;
 
 import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBAuthorisation1;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBWriteDomesticConsent3DataAuthorisation;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalScheduledConverter.toOBInternationalScheduled1;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalScheduledConverter.toOBInternationalScheduled2;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalScheduledConverter.toOBWriteInternationalScheduled3DataInitiation;
 
 public class OBWriteInternationalScheduledConsentConverter {
+
+    public static OBWriteInternationalScheduledConsent2 toOBWriteInternationalScheduledConsent2(OBWriteInternationalScheduledConsent1 obWriteInternationalScheduledConsent1) {
+        return (new OBWriteInternationalScheduledConsent2())
+                .data(toOBWriteDataInternationalScheduledConsent2(obWriteInternationalScheduledConsent1.getData()))
+                .risk(obWriteInternationalScheduledConsent1.getRisk());
+    }
+
+    public static OBWriteInternationalScheduledConsent1 toOBWriteInternationalScheduledConsent1(OBWriteInternationalScheduledConsent2 obWriteInternationalScheduledConsent2) {
+        return (new OBWriteInternationalScheduledConsent1())
+                .data(toOBWriteDataInternationalScheduledConsent1(obWriteInternationalScheduledConsent2.getData()))
+                .risk(obWriteInternationalScheduledConsent2.getRisk());
+    }
+
+    public static OBWriteInternationalScheduled2 toOBWriteInternationalScheduled2(OBWriteInternationalScheduled1 obWriteInternationalScheduled1) {
+        return (new OBWriteInternationalScheduled2())
+                .data(toOBWriteDataInternationalScheduled2(obWriteInternationalScheduled1.getData()))
+                .risk(obWriteInternationalScheduled1.getRisk());
+    }
+
+    public static OBWriteInternationalScheduled1 toOBWriteInternationalScheduled1(OBWriteInternationalScheduled2 obWriteInternationalScheduled2) {
+        return (new OBWriteInternationalScheduled1())
+                .data(toOBWriteDataInternationalScheduled1(obWriteInternationalScheduled2.getData()))
+                .risk(obWriteInternationalScheduled2.getRisk());
+    }
 
     public static OBWriteInternationalScheduledConsent1 toOBWriteInternationalScheduledConsent1(OBWriteInternationalScheduledConsent4 obWriteInternationalScheduledConsent4) {
         return (new OBWriteInternationalScheduledConsent1()
@@ -54,6 +73,25 @@ public class OBWriteInternationalScheduledConsentConverter {
                 .risk(obWriteInternationalScheduledConsent2.getRisk());
     }
 
+    public static OBWriteDataInternationalScheduled1 toOBWriteDataInternationalScheduled1(OBWriteDataInternationalScheduled2 data) {
+        return data == null ? null : (new OBWriteDataInternationalScheduled1())
+                .consentId(data.getConsentId())
+                .initiation(toOBInternationalScheduled1(data.getInitiation()));
+    }
+
+    public static OBWriteDataInternationalScheduled2 toOBWriteDataInternationalScheduled2(OBWriteDataInternationalScheduled1 data) {
+        return data == null ? null : (new OBWriteDataInternationalScheduled2())
+                .consentId(data.getConsentId())
+                .initiation(toOBInternationalScheduled2(data.getInitiation()));
+    }
+
+    public static OBWriteDataInternationalScheduledConsent1 toOBWriteDataInternationalScheduledConsent1(OBWriteDataInternationalScheduledConsent2 data) {
+        return data == null ? null : (new OBWriteDataInternationalScheduledConsent1())
+                .permission(data.getPermission())
+                .initiation(toOBInternationalScheduled1(data.getInitiation()))
+                .authorisation(data.getAuthorisation());
+    }
+
     public static OBWriteDataInternationalScheduledConsent1 toOBWriteDataInternationalScheduledConsent1(OBWriteInternationalScheduledConsent4Data data) {
         return data == null ? null : (new OBWriteDataInternationalScheduledConsent1())
                 .permission(toOBExternalPermissions2Code(data.getPermission()))
@@ -61,18 +99,27 @@ public class OBWriteInternationalScheduledConsentConverter {
                 .authorisation(toOBAuthorisation1(data.getAuthorisation()));
     }
 
+    public static OBWriteDataInternationalScheduledConsent2 toOBWriteDataInternationalScheduledConsent2(OBWriteDataInternationalScheduledConsent1 data) {
+        return data == null ? null : (new OBWriteDataInternationalScheduledConsent2())
+                .permission(data.getPermission())
+                .initiation(toOBInternationalScheduled2(data.getInitiation()))
+                .authorisation(data.getAuthorisation());
+    }
+
     public static OBWriteInternationalScheduledConsent4Data toOBWriteInternationalScheduledConsent4Data(OBWriteDataInternationalScheduledConsent1 data) {
         return data == null ? null : (new OBWriteInternationalScheduledConsent4Data())
                 .permission(toPermissionEnum(data.getPermission()))
                 .initiation(toOBWriteInternationalScheduled3DataInitiation(data.getInitiation()))
-                .authorisation(toOBWriteDomesticConsent3DataAuthorisation(data.getAuthorisation()));
+                .authorisation(toOBWriteDomesticConsent3DataAuthorisation(data.getAuthorisation()))
+                .scASupportData(null);
     }
 
     public static OBWriteInternationalScheduledConsent4Data toOBWriteInternationalScheduledConsent4Data(OBWriteDataInternationalScheduledConsent2 data) {
         return data == null ? null : (new OBWriteInternationalScheduledConsent4Data())
                 .permission(toPermissionEnum(data.getPermission()))
                 .initiation(toOBWriteInternationalScheduled3DataInitiation(data.getInitiation()))
-                .authorisation(toOBWriteDomesticConsent3DataAuthorisation(data.getAuthorisation()));
+                .authorisation(toOBWriteDomesticConsent3DataAuthorisation(data.getAuthorisation()))
+                .scASupportData(null);
     }
 
     public static OBWriteInternationalScheduledConsent4Data.PermissionEnum toPermissionEnum(OBExternalPermissions2Code permission) {

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteInternationalScheduledConsentConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteInternationalScheduledConsentConverter.java
@@ -30,22 +30,22 @@ import static uk.org.openbanking.datamodel.service.converter.payment.OBInternati
 
 public class OBWriteInternationalScheduledConsentConverter {
 
-    public static OBWriteInternationalScheduledConsent2 toOBWriteInternationalScheduledConsent2(OBWriteInternationalScheduledConsent1 obWriteInternationalScheduledConsent1) {
-        return (new OBWriteInternationalScheduledConsent2())
-                .data(toOBWriteDataInternationalScheduledConsent2(obWriteInternationalScheduledConsent1.getData()))
-                .risk(obWriteInternationalScheduledConsent1.getRisk());
-    }
-
     public static OBWriteInternationalScheduledConsent1 toOBWriteInternationalScheduledConsent1(OBWriteInternationalScheduledConsent2 obWriteInternationalScheduledConsent2) {
         return (new OBWriteInternationalScheduledConsent1())
                 .data(toOBWriteDataInternationalScheduledConsent1(obWriteInternationalScheduledConsent2.getData()))
                 .risk(obWriteInternationalScheduledConsent2.getRisk());
     }
 
-    public static OBWriteInternationalScheduled2 toOBWriteInternationalScheduled2(OBWriteInternationalScheduled1 obWriteInternationalScheduled1) {
-        return (new OBWriteInternationalScheduled2())
-                .data(toOBWriteDataInternationalScheduled2(obWriteInternationalScheduled1.getData()))
-                .risk(obWriteInternationalScheduled1.getRisk());
+    public static OBWriteInternationalScheduledConsent1 toOBWriteInternationalScheduledConsent1(OBWriteInternationalScheduledConsent4 obWriteInternationalScheduledConsent4) {
+        return (new OBWriteInternationalScheduledConsent1()
+                .data(toOBWriteDataInternationalScheduledConsent1(obWriteInternationalScheduledConsent4.getData()))
+                .risk(obWriteInternationalScheduledConsent4.getRisk()));
+    }
+
+    public static OBWriteInternationalScheduledConsent2 toOBWriteInternationalScheduledConsent2(OBWriteInternationalScheduledConsent1 obWriteInternationalScheduledConsent1) {
+        return (new OBWriteInternationalScheduledConsent2())
+                .data(toOBWriteDataInternationalScheduledConsent2(obWriteInternationalScheduledConsent1.getData()))
+                .risk(obWriteInternationalScheduledConsent1.getRisk());
     }
 
     public static OBWriteInternationalScheduled1 toOBWriteInternationalScheduled1(OBWriteInternationalScheduled2 obWriteInternationalScheduled2) {
@@ -54,11 +54,10 @@ public class OBWriteInternationalScheduledConsentConverter {
                 .risk(obWriteInternationalScheduled2.getRisk());
     }
 
-    public static OBWriteInternationalScheduledConsent1 toOBWriteInternationalScheduledConsent1(OBWriteInternationalScheduledConsent4 obWriteInternationalScheduledConsent4) {
-        return (new OBWriteInternationalScheduledConsent1()
-                .data(toOBWriteDataInternationalScheduledConsent1(obWriteInternationalScheduledConsent4.getData()))
-                .risk(obWriteInternationalScheduledConsent4.getRisk())
-        );
+    public static OBWriteInternationalScheduled2 toOBWriteInternationalScheduled2(OBWriteInternationalScheduled1 obWriteInternationalScheduled1) {
+        return (new OBWriteInternationalScheduled2())
+                .data(toOBWriteDataInternationalScheduled2(obWriteInternationalScheduled1.getData()))
+                .risk(obWriteInternationalScheduled1.getRisk());
     }
 
     public static OBWriteInternationalScheduledConsent4 toOBWriteInternationalScheduledConsent4(OBWriteInternationalScheduledConsent1 obWriteInternationalScheduledConsent1) {

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteInternationalStandingOrderConsentConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteInternationalStandingOrderConsentConverter.java
@@ -26,6 +26,7 @@ import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderCon
 import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBWriteDomesticConsent3DataAuthorisation;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalStandingOrderConverter.toOBInternationalStandingOrder1;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalStandingOrderConverter.toOBInternationalStandingOrder2;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalStandingOrderConverter.toOBInternationalStandingOrder3;
 
 public class OBWriteInternationalStandingOrderConsentConverter {
 
@@ -53,15 +54,21 @@ public class OBWriteInternationalStandingOrderConsentConverter {
                 .risk(obWriteInternationalStandingOrderConsent3.getRisk());
     }
 
+    public static OBWriteInternationalStandingOrder1 toOBWriteInternationalStandingOrder1(OBWriteInternationalStandingOrder2 obWriteInternationalStandingOrder2) {
+        return (new OBWriteInternationalStandingOrder1())
+                .data(toOBWriteDataInternationalStandingOrder1(obWriteInternationalStandingOrder2.getData()))
+                .risk(obWriteInternationalStandingOrder2.getRisk());
+    }
+
     public static OBWriteInternationalStandingOrder2 toOBWriteInternationalStandingOrder2(OBWriteInternationalStandingOrder1 obWriteInternationalStandingOrder1) {
         return (new OBWriteInternationalStandingOrder2())
                 .data(toOBWriteDataInternationalStandingOrder2(obWriteInternationalStandingOrder1.getData()))
                 .risk(obWriteInternationalStandingOrder1.getRisk());
     }
 
-    public static OBWriteInternationalStandingOrder1 toOBWriteInternationalStandingOrder1(OBWriteInternationalStandingOrder2 obWriteInternationalStandingOrder2) {
-        return (new OBWriteInternationalStandingOrder1())
-                .data(toOBWriteDataInternationalStandingOrder1(obWriteInternationalStandingOrder2.getData()))
+    public static OBWriteInternationalStandingOrder3 toOBWriteInternationalStandingOrder3(OBWriteInternationalStandingOrder2 obWriteInternationalStandingOrder2) {
+        return (new OBWriteInternationalStandingOrder3())
+                .data(toOBWriteDataInternationalStandingOrder3(obWriteInternationalStandingOrder2.getData()))
                 .risk(obWriteInternationalStandingOrder2.getRisk());
     }
 
@@ -87,6 +94,12 @@ public class OBWriteInternationalStandingOrderConsentConverter {
         return data == null ? null : (new OBWriteDataInternationalStandingOrder2())
                 .consentId(data.getConsentId())
                 .initiation(toOBInternationalStandingOrder2(data.getInitiation()));
+    }
+
+    public static OBWriteDataInternationalStandingOrder3 toOBWriteDataInternationalStandingOrder3(OBWriteDataInternationalStandingOrder2 data) {
+        return data == null ? null : (new OBWriteDataInternationalStandingOrder3())
+                .consentId(data.getConsentId())
+                .initiation(toOBInternationalStandingOrder3(data.getInitiation()));
     }
 
     public static OBWriteDataInternationalStandingOrderConsent1 toOBWriteDataInternationalStandingOrderConsent1(OBWriteDataInternationalStandingOrderConsent2 data) {

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteInternationalStandingOrderConsentConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteInternationalStandingOrderConsentConverter.java
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.datamodel.service.converter.payment;
+
+import uk.org.openbanking.datamodel.payment.OBExternalPermissions2Code;
+import uk.org.openbanking.datamodel.payment.OBWriteDataInternationalStandingOrderConsent2;
+import uk.org.openbanking.datamodel.payment.OBWriteDataInternationalStandingOrderConsent3;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent2;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent3;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent5;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent5Data;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent5Data.PermissionEnum;
+
+import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBWriteDomesticConsent3DataAuthorisation;
+
+public class OBWriteInternationalStandingOrderConsentConverter {
+
+    public static OBWriteInternationalStandingOrderConsent5 toOBWriteInternationalStandingOrderConsent5(OBWriteInternationalStandingOrderConsent2 consent2) {
+        return (new OBWriteInternationalStandingOrderConsent5())
+                .data(toOBWriteInternationalStandingOrderConsent5Data(consent2.getData()))
+                .risk(consent2.getRisk());
+    }
+
+    public static OBWriteInternationalStandingOrderConsent5 toOBWriteInternationalStandingOrderConsent5(OBWriteInternationalStandingOrderConsent3 consent3) {
+        return (new OBWriteInternationalStandingOrderConsent5())
+                .data(toOBWriteInternationalStandingOrderConsent5Data(consent3.getData()))
+                .risk(consent3.getRisk());
+    }
+
+    public static OBWriteInternationalStandingOrderConsent5Data toOBWriteInternationalStandingOrderConsent5Data(OBWriteDataInternationalStandingOrderConsent2 data) {
+        return data == null ? null : (new OBWriteInternationalStandingOrderConsent5Data())
+                .permission(toPermissionEnum(data.getPermission()))
+                .initiation(OBInternationalStandingOrderConverter.toOBWriteInternationalStandingOrder4DataInitiation(data.getInitiation()))
+                .authorisation(toOBWriteDomesticConsent3DataAuthorisation(data.getAuthorisation()));
+    }
+
+    public static OBWriteInternationalStandingOrderConsent5Data toOBWriteInternationalStandingOrderConsent5Data(OBWriteDataInternationalStandingOrderConsent3 data) {
+        return data == null ? null : (new OBWriteInternationalStandingOrderConsent5Data())
+                .permission(toPermissionEnum(data.getPermission()))
+                .initiation(OBInternationalStandingOrderConverter.toOBWriteInternationalStandingOrder4DataInitiation(data.getInitiation()))
+                .authorisation(toOBWriteDomesticConsent3DataAuthorisation(data.getAuthorisation()));
+    }
+
+    public static PermissionEnum toPermissionEnum(OBExternalPermissions2Code permission) {
+        return permission == null ? null : PermissionEnum.valueOf(permission.name());
+    }
+
+
+    public static OBExternalPermissions2Code toOBExternalPermissions2Code(PermissionEnum permission) {
+        return permission == null ? null : OBExternalPermissions2Code.valueOf(permission.name());
+    }
+}

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteInternationalStandingOrderConsentConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteInternationalStandingOrderConsentConverter.java
@@ -20,18 +20,38 @@
  */
 package uk.org.openbanking.datamodel.service.converter.payment;
 
-import uk.org.openbanking.datamodel.payment.OBExternalPermissions2Code;
-import uk.org.openbanking.datamodel.payment.OBWriteDataInternationalStandingOrderConsent2;
-import uk.org.openbanking.datamodel.payment.OBWriteDataInternationalStandingOrderConsent3;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent2;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent3;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent5;
-import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent5Data;
+import uk.org.openbanking.datamodel.payment.*;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrderConsent5Data.PermissionEnum;
 
 import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBWriteDomesticConsent3DataAuthorisation;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalStandingOrderConverter.toOBInternationalStandingOrder1;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalStandingOrderConverter.toOBInternationalStandingOrder2;
 
 public class OBWriteInternationalStandingOrderConsentConverter {
+
+    public static OBWriteInternationalStandingOrderConsent2 toOBWriteInternationalStandingOrderConsent2(OBWriteInternationalStandingOrderConsent1 obWriteInternationalStandingOrderConsent1) {
+        return (new OBWriteInternationalStandingOrderConsent2())
+                .data(toOBWriteDataInternationalStandingOrderConsent2(obWriteInternationalStandingOrderConsent1.getData()))
+                .risk(obWriteInternationalStandingOrderConsent1.getRisk());
+    }
+
+    public static OBWriteInternationalStandingOrderConsent1 toOBWriteInternationalStandingOrderConsent1(OBWriteInternationalStandingOrderConsent2 obWriteInternationalStandingOrderConsent2) {
+        return (new OBWriteInternationalStandingOrderConsent1())
+                .data(toOBWriteDataInternationalStandingOrderConsent1(obWriteInternationalStandingOrderConsent2.getData()))
+                .risk(obWriteInternationalStandingOrderConsent2.getRisk());
+    }
+
+    public static OBWriteInternationalStandingOrder2 toOBWriteInternationalStandingOrder2(OBWriteInternationalStandingOrder1 obWriteInternationalStandingOrder1) {
+        return (new OBWriteInternationalStandingOrder2())
+                .data(toOBWriteDataInternationalStandingOrder2(obWriteInternationalStandingOrder1.getData()))
+                .risk(obWriteInternationalStandingOrder1.getRisk());
+    }
+
+    public static OBWriteInternationalStandingOrder1 toOBWriteInternationalStandingOrder1(OBWriteInternationalStandingOrder2 obWriteInternationalStandingOrder2) {
+        return (new OBWriteInternationalStandingOrder1())
+                .data(toOBWriteDataInternationalStandingOrder1(obWriteInternationalStandingOrder2.getData()))
+                .risk(obWriteInternationalStandingOrder2.getRisk());
+    }
 
     public static OBWriteInternationalStandingOrderConsent5 toOBWriteInternationalStandingOrderConsent5(OBWriteInternationalStandingOrderConsent2 consent2) {
         return (new OBWriteInternationalStandingOrderConsent5())
@@ -43,6 +63,32 @@ public class OBWriteInternationalStandingOrderConsentConverter {
         return (new OBWriteInternationalStandingOrderConsent5())
                 .data(toOBWriteInternationalStandingOrderConsent5Data(consent3.getData()))
                 .risk(consent3.getRisk());
+    }
+
+    public static OBWriteDataInternationalStandingOrder1 toOBWriteDataInternationalStandingOrder1(OBWriteDataInternationalStandingOrder2 data) {
+        return data == null ? null : (new OBWriteDataInternationalStandingOrder1())
+                .consentId(data.getConsentId())
+                .initiation(toOBInternationalStandingOrder1(data.getInitiation()));
+    }
+
+    public static OBWriteDataInternationalStandingOrder2 toOBWriteDataInternationalStandingOrder2(OBWriteDataInternationalStandingOrder1 data) {
+        return data == null ? null : (new OBWriteDataInternationalStandingOrder2())
+                .consentId(data.getConsentId())
+                .initiation(toOBInternationalStandingOrder2(data.getInitiation()));
+    }
+
+    public static OBWriteDataInternationalStandingOrderConsent1 toOBWriteDataInternationalStandingOrderConsent1(OBWriteDataInternationalStandingOrderConsent2 data) {
+        return data == null ? null : (new OBWriteDataInternationalStandingOrderConsent1())
+                .permission(data.getPermission())
+                .initiation(toOBInternationalStandingOrder1(data.getInitiation()))
+                .authorisation(data.getAuthorisation());
+    }
+
+    public static OBWriteDataInternationalStandingOrderConsent2 toOBWriteDataInternationalStandingOrderConsent2(OBWriteDataInternationalStandingOrderConsent1 data) {
+        return data == null ? null : (new OBWriteDataInternationalStandingOrderConsent2())
+                .permission(data.getPermission())
+                .initiation(toOBInternationalStandingOrder2(data.getInitiation()))
+                .authorisation(data.getAuthorisation());
     }
 
     public static OBWriteInternationalStandingOrderConsent5Data toOBWriteInternationalStandingOrderConsent5Data(OBWriteDataInternationalStandingOrderConsent2 data) {

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteInternationalStandingOrderConsentConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteInternationalStandingOrderConsentConverter.java
@@ -29,16 +29,28 @@ import static uk.org.openbanking.datamodel.service.converter.payment.OBInternati
 
 public class OBWriteInternationalStandingOrderConsentConverter {
 
-    public static OBWriteInternationalStandingOrderConsent2 toOBWriteInternationalStandingOrderConsent2(OBWriteInternationalStandingOrderConsent1 obWriteInternationalStandingOrderConsent1) {
-        return (new OBWriteInternationalStandingOrderConsent2())
-                .data(toOBWriteDataInternationalStandingOrderConsent2(obWriteInternationalStandingOrderConsent1.getData()))
-                .risk(obWriteInternationalStandingOrderConsent1.getRisk());
+    public static OBWriteInternationalStandingOrderConsent1 toOBWriteInternationalStandingOrderConsent1(OBWriteInternationalStandingOrderConsent3 obWriteInternationalStandingOrderConsent3) {
+        return (new OBWriteInternationalStandingOrderConsent1())
+                .data(toOBWriteDataInternationalStandingOrderConsent1(obWriteInternationalStandingOrderConsent3.getData()))
+                .risk(obWriteInternationalStandingOrderConsent3.getRisk());
     }
 
     public static OBWriteInternationalStandingOrderConsent1 toOBWriteInternationalStandingOrderConsent1(OBWriteInternationalStandingOrderConsent2 obWriteInternationalStandingOrderConsent2) {
         return (new OBWriteInternationalStandingOrderConsent1())
                 .data(toOBWriteDataInternationalStandingOrderConsent1(obWriteInternationalStandingOrderConsent2.getData()))
                 .risk(obWriteInternationalStandingOrderConsent2.getRisk());
+    }
+
+    public static OBWriteInternationalStandingOrderConsent2 toOBWriteInternationalStandingOrderConsent2(OBWriteInternationalStandingOrderConsent1 obWriteInternationalStandingOrderConsent1) {
+        return (new OBWriteInternationalStandingOrderConsent2())
+                .data(toOBWriteDataInternationalStandingOrderConsent2(obWriteInternationalStandingOrderConsent1.getData()))
+                .risk(obWriteInternationalStandingOrderConsent1.getRisk());
+    }
+
+    public static OBWriteInternationalStandingOrderConsent2 toOBWriteInternationalStandingOrderConsent2(OBWriteInternationalStandingOrderConsent3 obWriteInternationalStandingOrderConsent3) {
+        return (new OBWriteInternationalStandingOrderConsent2())
+                .data(toOBWriteDataInternationalStandingOrderConsent2(obWriteInternationalStandingOrderConsent3.getData()))
+                .risk(obWriteInternationalStandingOrderConsent3.getRisk());
     }
 
     public static OBWriteInternationalStandingOrder2 toOBWriteInternationalStandingOrder2(OBWriteInternationalStandingOrder1 obWriteInternationalStandingOrder1) {
@@ -81,6 +93,20 @@ public class OBWriteInternationalStandingOrderConsentConverter {
         return data == null ? null : (new OBWriteDataInternationalStandingOrderConsent1())
                 .permission(data.getPermission())
                 .initiation(toOBInternationalStandingOrder1(data.getInitiation()))
+                .authorisation(data.getAuthorisation());
+    }
+
+    public static OBWriteDataInternationalStandingOrderConsent1 toOBWriteDataInternationalStandingOrderConsent1(OBWriteDataInternationalStandingOrderConsent3 data) {
+        return data == null ? null : (new OBWriteDataInternationalStandingOrderConsent1())
+                .permission(data.getPermission())
+                .initiation(toOBInternationalStandingOrder1(data.getInitiation()))
+                .authorisation(data.getAuthorisation());
+    }
+
+    public static OBWriteDataInternationalStandingOrderConsent2 toOBWriteDataInternationalStandingOrderConsent2(OBWriteDataInternationalStandingOrderConsent3 data) {
+        return data == null ? null : (new OBWriteDataInternationalStandingOrderConsent2())
+                .permission(data.getPermission())
+                .initiation(toOBInternationalStandingOrder2(data.getInitiation()))
                 .authorisation(data.getAuthorisation());
     }
 

--- a/src/test/java/uk/org/openbanking/datamodel/service/converter/account/OBExternalAccountIdentificationConverterTest.java
+++ b/src/test/java/uk/org/openbanking/datamodel/service/converter/account/OBExternalAccountIdentificationConverterTest.java
@@ -18,7 +18,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package uk.org.openbanking.datamodel.service.converter;
+package uk.org.openbanking.datamodel.service.converter.account;
 
 import org.junit.Test;
 import uk.org.openbanking.datamodel.account.OBExternalAccountIdentification3Code;

--- a/src/test/java/uk/org/openbanking/datamodel/service/converter/payment/OBAccountConverterTest.java
+++ b/src/test/java/uk/org/openbanking/datamodel/service/converter/payment/OBAccountConverterTest.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.datamodel.service.converter.payment;
+
+import org.junit.Test;
+import uk.org.openbanking.datamodel.account.OBCashAccount3;
+import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationDebtorAccount;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBCashAccount3;
+import static uk.org.openbanking.testsupport.payment.OBAccountTestDataFactory.aValidOBWriteDomestic2DataInitiationDebtorAccount;
+
+/**
+ * Unit test for {@link OBAccountConverter}.
+ */
+public class OBAccountConverterTest {
+
+    @Test
+    public void shouldConvertToOBCashAccount3() {
+        // Given
+        OBWriteDomestic2DataInitiationDebtorAccount debtorAccount = aValidOBWriteDomestic2DataInitiationDebtorAccount();
+
+        // When
+        OBCashAccount3 obCashAccount3 = toOBCashAccount3(debtorAccount);
+
+        // Then
+        assertThat(obCashAccount3.getSchemeName()).isEqualTo(debtorAccount.getSchemeName());
+        assertThat(obCashAccount3.getIdentification()).isEqualTo(debtorAccount.getIdentification());
+        assertThat(obCashAccount3.getName()).isEqualTo(debtorAccount.getName());
+        assertThat(obCashAccount3.getSecondaryIdentification()).isEqualTo(debtorAccount.getSecondaryIdentification());
+    }
+
+    @Test
+    public void shouldConvertToOBCashAccount3GivenNullField() {
+        // Given
+        OBWriteDomestic2DataInitiationDebtorAccount debtorAccount = aValidOBWriteDomestic2DataInitiationDebtorAccount();
+        debtorAccount.secondaryIdentification(null);
+
+        // When
+        OBCashAccount3 obCashAccount3 = toOBCashAccount3(debtorAccount);
+
+        // Then
+        assertThat(obCashAccount3.getSchemeName()).isEqualTo(debtorAccount.getSchemeName());
+        assertThat(obCashAccount3.getIdentification()).isEqualTo(debtorAccount.getIdentification());
+        assertThat(obCashAccount3.getName()).isEqualTo(debtorAccount.getName());
+        assertThat(obCashAccount3.getSecondaryIdentification()).isNull();
+    }
+
+    @Test
+    public void shouldNotConvertToOBCashAccount3GivenNullDebtorAccount() {
+        // Given
+        OBWriteDomestic2DataInitiationDebtorAccount debtorAccount = null;
+
+        // When
+        OBCashAccount3 obCashAccount3 = toOBCashAccount3(debtorAccount);
+
+        // Then
+        assertThat(obCashAccount3).isNull();
+    }
+}

--- a/src/test/java/uk/org/openbanking/datamodel/service/converter/payment/OBAmountConverterTest.java
+++ b/src/test/java/uk/org/openbanking/datamodel/service/converter/payment/OBAmountConverterTest.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.datamodel.service.converter.payment;
+
+import org.junit.Test;
+import uk.org.openbanking.datamodel.payment.OBActiveOrHistoricCurrencyAndAmount;
+import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstructedAmount;
+
+import static uk.org.openbanking.datamodel.service.converter.payment.OBAmountConverter.toOBActiveOrHistoricCurrencyAndAmount;
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.org.openbanking.testsupport.payment.OBAmountTestDataFactory.aValidOBWriteDomestic2DataInitiationInstructedAmount;
+
+/**
+ * Unit test for {@link OBAmountConverter}.
+ */
+public class OBAmountConverterTest {
+
+    @Test
+    public void shouldConvertToOBActiveOrHistoricCurrencyAndAmount() {
+        // Given
+        OBWriteDomestic2DataInitiationInstructedAmount sourceAmount = aValidOBWriteDomestic2DataInitiationInstructedAmount();
+
+        // When
+        OBActiveOrHistoricCurrencyAndAmount converted = toOBActiveOrHistoricCurrencyAndAmount(sourceAmount);
+
+        // Then
+        assertThat(converted.getCurrency()).isEqualTo(sourceAmount.getCurrency());
+        assertThat(converted.getAmount()).isEqualTo(sourceAmount.getAmount());
+    }
+
+    @Test
+    public void shouldNotConvertToOBActiveOrHistoricCurrencyAndAmountGivenNullAmount() {
+        // Given
+        OBWriteDomestic2DataInitiationInstructedAmount sourceAmount = null;
+
+        // When
+        OBActiveOrHistoricCurrencyAndAmount converted = toOBActiveOrHistoricCurrencyAndAmount(sourceAmount);
+
+        // Then
+        assertThat(converted).isNull();
+    }
+
+}

--- a/src/test/java/uk/org/openbanking/datamodel/service/converter/payment/OBConsentAuthorisationConverterTest.java
+++ b/src/test/java/uk/org/openbanking/datamodel/service/converter/payment/OBConsentAuthorisationConverterTest.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.datamodel.service.converter.payment;
+
+import org.junit.Test;
+import uk.org.openbanking.datamodel.payment.OBAuthorisation1;
+import uk.org.openbanking.datamodel.payment.OBExternalAuthorisation1Code;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent3DataAuthorisation;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent3DataAuthorisation.AuthorisationTypeEnum;
+
+import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBAuthorisation1;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBWriteDomesticConsent3DataAuthorisation;
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.org.openbanking.testsupport.payment.OBConsentAuthorisationTestDataFactory.aValidOBAuthorisation1;
+import static uk.org.openbanking.testsupport.payment.OBConsentAuthorisationTestDataFactory.aValidOBWriteDomesticConsent3DataAuthorisation;
+
+/**
+ * Unit test for {@link OBConsentAuthorisationConverter}.
+ */
+public class OBConsentAuthorisationConverterTest {
+
+    @Test
+    public void shouldConvertToOBWriteDomesticConsent3DataAuthorisation() {
+        // Given
+        OBAuthorisation1 obAuthorisation1 = aValidOBAuthorisation1();
+
+        // When
+        OBWriteDomesticConsent3DataAuthorisation obWriteDomesticConsent3DataAuthorisation = toOBWriteDomesticConsent3DataAuthorisation(obAuthorisation1);
+
+        // Then
+        assertThat(obWriteDomesticConsent3DataAuthorisation.getAuthorisationType()).isEqualTo(AuthorisationTypeEnum.ANY);
+        assertThat(obWriteDomesticConsent3DataAuthorisation.getCompletionDateTime()).isEqualTo(obAuthorisation1.getCompletionDateTime());
+    }
+
+
+    @Test
+    public void shouldConvertToOBAuthorisation1() {
+        // Given
+        OBWriteDomesticConsent3DataAuthorisation obWriteDomesticConsent3DataAuthorisation = aValidOBWriteDomesticConsent3DataAuthorisation();
+
+        // When
+        OBAuthorisation1 obAuthorisation1 = toOBAuthorisation1(obWriteDomesticConsent3DataAuthorisation);
+
+        // Then
+        assertThat(obAuthorisation1.getAuthorisationType()).isEqualTo(OBExternalAuthorisation1Code.ANY);
+        assertThat(obAuthorisation1.getCompletionDateTime()).isEqualTo(obWriteDomesticConsent3DataAuthorisation.getCompletionDateTime());
+    }
+
+    @Test
+    public void shouldNotConvertGivenNullOBAuthorisation1() {
+        // Given
+        OBAuthorisation1 obAuthorisation1 = null;
+
+        // When
+        OBWriteDomesticConsent3DataAuthorisation obWriteDomesticConsent3DataAuthorisation = toOBWriteDomesticConsent3DataAuthorisation(obAuthorisation1);
+
+        // Then
+        assertThat(obWriteDomesticConsent3DataAuthorisation).isNull();
+    }
+
+
+    @Test
+    public void shouldNotConvertGivenNullOBWriteDomesticConsent3DataAuthorisation() {
+        // Given
+        OBWriteDomesticConsent3DataAuthorisation obWriteDomesticConsent3DataAuthorisation = null;
+
+        // When
+        OBAuthorisation1 obAuthorisation1 = toOBAuthorisation1(obWriteDomesticConsent3DataAuthorisation);
+
+        // Then
+        assertThat(obAuthorisation1).isNull();
+    }
+
+}

--- a/src/test/java/uk/org/openbanking/datamodel/service/converter/payment/OBExchangeRateConverterTest.java
+++ b/src/test/java/uk/org/openbanking/datamodel/service/converter/payment/OBExchangeRateConverterTest.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.datamodel.service.converter.payment;
+
+import org.junit.Test;
+import uk.org.openbanking.datamodel.payment.OBExchangeRate1;
+import uk.org.openbanking.datamodel.payment.OBExchangeRate2;
+import uk.org.openbanking.datamodel.payment.OBExchangeRateType2Code;
+import uk.org.openbanking.datamodel.payment.OBWriteInternational3DataInitiationExchangeRateInformation;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse4DataExchangeRateInformation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBExchangeRateConverter.toOBExchangeRate1;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBExchangeRateConverter.toOBExchangeRate2;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBExchangeRateConverter.toOBWriteInternational3DataInitiationExchangeRateInformation;
+import static uk.org.openbanking.testsupport.payment.OBExchangeRateTestDataFactory.aValidOBExchangeRate1;
+import static uk.org.openbanking.testsupport.payment.OBExchangeRateTestDataFactory.aValidOBWriteInternational3DataInitiationExchangeRateInformation;
+import static uk.org.openbanking.testsupport.payment.OBExchangeRateTestDataFactory.aValidOBWriteInternationalConsentResponse4DataExchangeRateInformation;
+
+/**
+ * Unit test for {@link OBExchangeRateConverter}.
+ */
+public class OBExchangeRateConverterTest {
+
+    @Test
+    public void shouldConvertToOBExchangeRate1() {
+        // Given
+        OBWriteInternational3DataInitiationExchangeRateInformation sourceExchangeRate = aValidOBWriteInternational3DataInitiationExchangeRateInformation();
+
+        // When
+        OBExchangeRate1 obExchangeRate1 = toOBExchangeRate1(sourceExchangeRate);
+
+        // Then
+        assertThat(obExchangeRate1.getUnitCurrency()).isEqualTo(sourceExchangeRate.getUnitCurrency());
+        assertThat(obExchangeRate1.getExchangeRate()).isEqualTo(sourceExchangeRate.getExchangeRate());
+        assertThat(obExchangeRate1.getRateType()).isEqualTo(OBExchangeRateType2Code.INDICATIVE);
+        assertThat(obExchangeRate1.getContractIdentification()).isEqualTo(sourceExchangeRate.getContractIdentification());
+    }
+
+    @Test
+    public void shouldConvertToOBExchangeRate2() {
+        // Given
+        OBWriteInternationalConsentResponse4DataExchangeRateInformation sourceExchangeRate = aValidOBWriteInternationalConsentResponse4DataExchangeRateInformation();
+
+        // When
+        OBExchangeRate2 obExchangeRate2 = toOBExchangeRate2(sourceExchangeRate);
+
+        // Then
+        assertThat(obExchangeRate2.getUnitCurrency()).isEqualTo(sourceExchangeRate.getUnitCurrency());
+        assertThat(obExchangeRate2.getExchangeRate()).isEqualTo(sourceExchangeRate.getExchangeRate());
+        assertThat(obExchangeRate2.getRateType()).isEqualTo(OBExchangeRateType2Code.INDICATIVE);
+        assertThat(obExchangeRate2.getContractIdentification()).isEqualTo(sourceExchangeRate.getContractIdentification());
+        assertThat(obExchangeRate2.getExpirationDateTime()).isEqualTo(sourceExchangeRate.getExpirationDateTime());
+    }
+
+    @Test
+    public void shouldConvertToOBWriteInternational3DataInitiationExchangeRateInformation() {
+        // Given
+        OBExchangeRate1 sourceExchangeRate = aValidOBExchangeRate1();
+
+        // When
+        OBWriteInternational3DataInitiationExchangeRateInformation exchangeRateInformation = toOBWriteInternational3DataInitiationExchangeRateInformation(sourceExchangeRate);
+
+        // Then
+        assertThat(exchangeRateInformation.getUnitCurrency()).isEqualTo(sourceExchangeRate.getUnitCurrency());
+        assertThat(exchangeRateInformation.getExchangeRate()).isEqualTo(sourceExchangeRate.getExchangeRate());
+        assertThat(exchangeRateInformation.getRateType()).isEqualTo(OBWriteInternational3DataInitiationExchangeRateInformation.RateTypeEnum.INDICATIVE);
+        assertThat(exchangeRateInformation.getContractIdentification()).isEqualTo(sourceExchangeRate.getContractIdentification());
+    }
+
+    @Test
+    public void shouldNotConvertGivenNullOBExchangeRate1() {
+        // Given
+        OBExchangeRate1 sourceExchangeRate = null;
+
+        // When
+        OBWriteInternational3DataInitiationExchangeRateInformation exchangeRateInformation = toOBWriteInternational3DataInitiationExchangeRateInformation(sourceExchangeRate);
+
+        // Then
+        assertThat(exchangeRateInformation).isNull();
+    }
+
+    @Test
+    public void shouldNotConvertGivenNullOBWriteInternational3DataInitiationExchangeRateInformation() {
+        // Given
+        OBWriteInternational3DataInitiationExchangeRateInformation sourceExchangeRate = null;
+
+        // When
+        OBExchangeRate1 obExchangeRate1 = toOBExchangeRate1(sourceExchangeRate);
+
+        // Then
+        assertThat(obExchangeRate1).isNull();
+    }
+
+    @Test
+    public void shouldNotConvertGivenNullOBWriteInternationalConsentResponse4DataExchangeRateInformation() {
+        // Given
+        OBWriteInternationalConsentResponse4DataExchangeRateInformation sourceExchangeRate = null;
+
+        // When
+        OBExchangeRate2 obExchangeRate2 = toOBExchangeRate2(sourceExchangeRate);
+
+        // Then
+        assertThat(obExchangeRate2).isNull();
+    }
+
+}

--- a/src/test/java/uk/org/openbanking/datamodel/service/converter/payment/OBInternationalIdentifierConverterTest.java
+++ b/src/test/java/uk/org/openbanking/datamodel/service/converter/payment/OBInternationalIdentifierConverterTest.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.datamodel.service.converter.payment;
+
+import org.junit.Test;
+import uk.org.openbanking.datamodel.payment.OBBranchAndFinancialInstitutionIdentification3;
+import uk.org.openbanking.datamodel.payment.OBWriteInternational3DataInitiationCreditorAgent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalIdentifierConverter.toOBWriteInternational3DataInitiationCreditorAgent;
+import static uk.org.openbanking.testsupport.payment.OBInternationalIdentifierTestDataFactory.aValidOBBranchAndFinancialInstitutionIdentification3;
+
+/**
+ * Unit test for {@link OBInternationalIdentifierConverter}.
+ */
+public class OBInternationalIdentifierConverterTest {
+
+    @Test
+    public void shouldConvertToOBWriteInternational3DataInitiationCreditorAgent() {
+        // Given
+        OBBranchAndFinancialInstitutionIdentification3 sourceIdentification = aValidOBBranchAndFinancialInstitutionIdentification3();
+
+        // When
+        OBWriteInternational3DataInitiationCreditorAgent converted = toOBWriteInternational3DataInitiationCreditorAgent(sourceIdentification);
+
+        // Then
+        assertThat(converted.getSchemeName()).isEqualTo(sourceIdentification.getSchemeName());
+        assertThat(converted.getIdentification()).isEqualTo(sourceIdentification.getIdentification());
+        assertThat(converted.getName()).isEqualTo(sourceIdentification.getName());
+        assertThat(converted.getPostalAddress()).isEqualTo(sourceIdentification.getPostalAddress());
+    }
+
+    @Test
+    public void shouldNotConvertToOBWriteInternational3DataInitiationCreditorAgentGivenNull() {
+        // Given
+        OBBranchAndFinancialInstitutionIdentification3 sourceIdentification = null;
+
+        // When
+        OBWriteInternational3DataInitiationCreditorAgent converted = toOBWriteInternational3DataInitiationCreditorAgent(sourceIdentification);
+
+        // Then
+        assertThat(converted).isNull();
+    }
+
+}

--- a/src/test/java/uk/org/openbanking/datamodel/service/converter/payment/OBRemittanceInformationConverterTest.java
+++ b/src/test/java/uk/org/openbanking/datamodel/service/converter/payment/OBRemittanceInformationConverterTest.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.datamodel.service.converter.payment;
+
+import org.junit.Test;
+import uk.org.openbanking.datamodel.payment.OBRemittanceInformation1;
+import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationRemittanceInformation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBRemittanceInformationConverter.toOBRemittanceInformation1;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBRemittanceInformationConverter.toOBWriteDomestic2DataInitiationRemittanceInformation;
+import static uk.org.openbanking.testsupport.payment.OBRemittanceInformationTestDataFactory.aValidOBRemittanceInformation1;
+import static uk.org.openbanking.testsupport.payment.OBRemittanceInformationTestDataFactory.aValidOBWriteDomestic2DataInitiationRemittanceInformation;
+
+/**
+ * Unit test for {@link OBRemittanceInformationConverter}.
+ */
+public class OBRemittanceInformationConverterTest {
+
+    @Test
+    public void shouldConvertToOBRemittanceInformation1() {
+        // Given
+        OBWriteDomestic2DataInitiationRemittanceInformation source = aValidOBWriteDomestic2DataInitiationRemittanceInformation();
+
+        // When
+        OBRemittanceInformation1 converted = toOBRemittanceInformation1(source);
+
+        // Then
+        assertThat(converted.getReference()).isEqualTo(source.getReference());
+        assertThat(converted.getUnstructured()).isEqualTo(source.getUnstructured());
+    }
+
+    @Test
+    public void shouldConvertToOBWriteDomestic2DataInitiationRemittanceInformation() {
+        // Given
+        OBRemittanceInformation1 source = aValidOBRemittanceInformation1();
+
+        // When
+        OBWriteDomestic2DataInitiationRemittanceInformation converted = toOBWriteDomestic2DataInitiationRemittanceInformation(source);
+
+        // Then
+        assertThat(converted.getReference()).isEqualTo(source.getReference());
+        assertThat(converted.getUnstructured()).isEqualTo(source.getUnstructured());
+    }
+
+    @Test
+    public void shouldNotConvertToOBRemittanceInformation1GivenNull() {
+        // Given
+        OBWriteDomestic2DataInitiationRemittanceInformation source = null;
+
+        // When
+        OBRemittanceInformation1 converted = toOBRemittanceInformation1(source);
+
+        // Then
+        assertThat(converted).isNull();
+    }
+
+    @Test
+    public void shouldNotConvertToOBWriteDomestic2DataInitiationRemittanceInformationGivenNull() {
+        // Given
+        OBRemittanceInformation1 source = null;
+
+        // When
+        OBWriteDomestic2DataInitiationRemittanceInformation converted = toOBWriteDomestic2DataInitiationRemittanceInformation(source);
+
+        // Then
+        assertThat(converted).isNull();
+    }
+
+}

--- a/src/test/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteDomesticConsentConverterTest.java
+++ b/src/test/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteDomesticConsentConverterTest.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.datamodel.service.converter.payment;
+
+import org.junit.Test;
+import uk.org.openbanking.datamodel.account.OBCashAccount3;
+import uk.org.openbanking.datamodel.payment.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteDomesticConsentConverter.toOBWriteDomesticConsent2;
+import static uk.org.openbanking.testsupport.payment.OBWriteDomesticConsentTestDataFactory.aValidOBWriteDomesticConsent3;
+
+/**
+ * Unit test for {@link OBWriteDomesticConsentConverter}.
+ */
+public class OBWriteDomesticConsentConverterTest {
+
+    @Test
+    public void shouldConvertToOBWriteDomesticConsent2() {
+        // Given
+        OBWriteDomesticConsent3 obWriteDomesticConsent3 = aValidOBWriteDomesticConsent3();
+        OBWriteDataDomesticConsent2 expectedData = expectedObWriteDataDomesticConsent2(obWriteDomesticConsent3.getData());
+
+        // When
+        OBWriteDomesticConsent2 obWriteDomesticConsent2 = toOBWriteDomesticConsent2(obWriteDomesticConsent3);
+
+        // Then
+        assertThat(obWriteDomesticConsent2.getData()).isEqualTo(expectedData);
+        assertThat(obWriteDomesticConsent2.getRisk()).isEqualTo(obWriteDomesticConsent3.getRisk());
+    }
+
+    private OBWriteDataDomesticConsent2 expectedObWriteDataDomesticConsent2(OBWriteDomesticConsent3Data data) {
+        return (new OBWriteDataDomesticConsent2())
+                .initiation(expectedObDomestic2(data.getInitiation()))
+                .authorisation(expectedObAuthorisation1(data.getAuthorisation()));
+    }
+
+    private OBDomestic2 expectedObDomestic2(OBWriteDomestic2DataInitiation initiation) {
+        return (new OBDomestic2())
+                .instructionIdentification(initiation.getInstructionIdentification())
+                .endToEndIdentification(initiation.getEndToEndIdentification())
+                .localInstrument(initiation.getLocalInstrument())
+                .instructedAmount((new OBActiveOrHistoricCurrencyAndAmount())
+                        .currency(initiation.getInstructedAmount().getCurrency())
+                        .amount(initiation.getInstructedAmount().getAmount()))
+                .debtorAccount((new OBCashAccount3())
+                        .schemeName(initiation.getDebtorAccount().getSchemeName())
+                        .identification(initiation.getDebtorAccount().getIdentification())
+                        .name(initiation.getDebtorAccount().getName())
+                        .secondaryIdentification(initiation.getDebtorAccount().getSecondaryIdentification()))
+                .creditorAccount((new OBCashAccount3())
+                        .schemeName(initiation.getCreditorAccount().getSchemeName())
+                        .identification(initiation.getCreditorAccount().getIdentification())
+                        .name(initiation.getCreditorAccount().getName())
+                        .secondaryIdentification(initiation.getCreditorAccount().getSecondaryIdentification()))
+                .creditorPostalAddress(initiation.getCreditorPostalAddress())
+                .remittanceInformation((new OBRemittanceInformation1())
+                        .unstructured(initiation.getRemittanceInformation().getUnstructured())
+                        .reference(initiation.getRemittanceInformation().getReference()))
+                .supplementaryData(new OBSupplementaryData1());
+    }
+
+    private OBAuthorisation1 expectedObAuthorisation1(OBWriteDomesticConsent3DataAuthorisation authorisation) {
+        return (new OBAuthorisation1())
+                .authorisationType(OBExternalAuthorisation1Code.valueOf(authorisation.getAuthorisationType().name()))
+                .completionDateTime(authorisation.getCompletionDateTime());
+    }
+}

--- a/src/test/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteDomesticScheduledConsentConverterTest.java
+++ b/src/test/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteDomesticScheduledConsentConverterTest.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.datamodel.service.converter.payment;
+
+import org.junit.Test;
+import uk.org.openbanking.datamodel.payment.*;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent3DataAuthorisation.AuthorisationTypeEnum;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteDomesticScheduledConsentConverter.toOBWriteDomesticScheduledConsent3;
+import static uk.org.openbanking.testsupport.payment.OBWriteDomesticScheduledConsentTestDataFactory.aValidOBWriteDomesticScheduledConsent2;
+
+/**
+ * Unit test for {@link OBWriteDomesticScheduledConsentConverter}.
+ */
+public class OBWriteDomesticScheduledConsentConverterTest {
+
+    @Test
+    public void shouldConvertToOBWriteDomesticScheduledConsent3() {
+        // Given
+        OBWriteDomesticScheduledConsent2 source = aValidOBWriteDomesticScheduledConsent2();
+        OBWriteDomesticScheduledConsent3Data expectedData = expectedOBWriteDomesticScheduledConsent3Data(source.getData());
+
+        // When
+        OBWriteDomesticScheduledConsent3 converted = toOBWriteDomesticScheduledConsent3(source);
+
+        // Then
+        assertThat(converted.getData()).isEqualTo(expectedData);
+        assertThat(converted.getRisk()).isEqualTo(source.getRisk());
+    }
+
+    private OBWriteDomesticScheduledConsent3Data expectedOBWriteDomesticScheduledConsent3Data(OBWriteDataDomesticScheduledConsent2 data) {
+        return (new OBWriteDomesticScheduledConsent3Data())
+                .permission(OBWriteDomesticScheduledConsent3Data.PermissionEnum.CREATE)
+                .initiation(expectedOBWriteDomesticScheduled2DataInitiation(data.getInitiation()))
+                .authorisation(expectedOBWriteDomesticConsent3DataAuthorisation(data.getAuthorisation()))
+                .scASupportData(null);
+    }
+
+    private OBWriteDomesticScheduled2DataInitiation expectedOBWriteDomesticScheduled2DataInitiation(OBDomesticScheduled2 initiation) {
+        return (new OBWriteDomesticScheduled2DataInitiation())
+                .instructionIdentification(initiation.getInstructionIdentification())
+                .endToEndIdentification(initiation.getEndToEndIdentification())
+                .localInstrument(initiation.getLocalInstrument())
+                .requestedExecutionDateTime(initiation.getRequestedExecutionDateTime())
+                .instructedAmount((new OBWriteDomestic2DataInitiationInstructedAmount())
+                        .currency(initiation.getInstructedAmount().getCurrency())
+                        .amount(initiation.getInstructedAmount().getAmount()))
+                .debtorAccount((new OBWriteDomestic2DataInitiationDebtorAccount())
+                        .schemeName(initiation.getDebtorAccount().getSchemeName())
+                        .identification(initiation.getDebtorAccount().getIdentification())
+                        .name(initiation.getDebtorAccount().getName())
+                        .secondaryIdentification(initiation.getDebtorAccount().getSecondaryIdentification()))
+                .creditorAccount((new OBWriteDomestic2DataInitiationCreditorAccount())
+                        .schemeName(initiation.getCreditorAccount().getSchemeName())
+                        .identification(initiation.getCreditorAccount().getIdentification())
+                        .name(initiation.getCreditorAccount().getName())
+                        .secondaryIdentification(initiation.getCreditorAccount().getSecondaryIdentification()))
+                .creditorPostalAddress(initiation.getCreditorPostalAddress())
+                .remittanceInformation((new OBWriteDomestic2DataInitiationRemittanceInformation())
+                        .reference(initiation.getRemittanceInformation().getReference())
+                        .unstructured(initiation.getRemittanceInformation().getUnstructured()))
+                .supplementaryData(initiation.getSupplementaryData());
+    }
+
+    private OBWriteDomesticConsent3DataAuthorisation expectedOBWriteDomesticConsent3DataAuthorisation(OBAuthorisation1 authorisation) {
+        return (new OBWriteDomesticConsent3DataAuthorisation())
+                .authorisationType(AuthorisationTypeEnum.valueOf(authorisation.getAuthorisationType().name()))
+                .completionDateTime(authorisation.getCompletionDateTime());
+    }
+}

--- a/src/test/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteDomesticStandingOrderConsentConverterTest.java
+++ b/src/test/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteDomesticStandingOrderConsentConverterTest.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.datamodel.service.converter.payment;
+
+import org.junit.Test;
+import uk.org.openbanking.datamodel.payment.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteDomesticStandingOrderConsentConverter.toOBWriteDomesticStandingOrderConsent3;
+import static uk.org.openbanking.testsupport.payment.OBWriteDomesticStandingOrderConsentTestDataFactory.aValidOBWriteDomesticStandingOrderConsent4;
+
+/**
+ * Unit test for {@link OBWriteDomesticStandingOrderConsentConverter}.
+ */
+public class OBWriteDomesticStandingOrderConsentConverterTest {
+
+    @Test
+    public void shouldConvertToOBWriteDomesticStandingOrderConsent3() {
+        // Given
+        OBWriteDomesticStandingOrderConsent4 source = aValidOBWriteDomesticStandingOrderConsent4();
+        OBWriteDataDomesticStandingOrderConsent3 expectedData = expectedObWriteDataDomesticStandingOrderConsent3(source.getData());
+
+        // When
+        OBWriteDomesticStandingOrderConsent3 obWriteDomesticStandingOrderConsent3 = toOBWriteDomesticStandingOrderConsent3(source);
+
+        // Then
+        assertThat(obWriteDomesticStandingOrderConsent3.getData()).isEqualTo(expectedData);
+        assertThat(obWriteDomesticStandingOrderConsent3.getRisk()).isEqualTo(source.getRisk());
+    }
+
+    private OBWriteDataDomesticStandingOrderConsent3 expectedObWriteDataDomesticStandingOrderConsent3(OBWriteDomesticStandingOrderConsent4Data data) {
+        return (new OBWriteDataDomesticStandingOrderConsent3())
+                .permission(OBExternalPermissions2Code.valueOf(data.getPermission().name()))
+                .initiation(expectedObDomesticStandingOrder3(data.getInitiation()))
+                .authorisation(expectedObAuthorisation1(data.getAuthorisation()));
+    }
+
+    private OBDomesticStandingOrder3 expectedObDomesticStandingOrder3(OBWriteDomesticStandingOrder3DataInitiation initiation) {
+        return (new OBDomesticStandingOrder3())
+                .frequency(initiation.getFrequency())
+                .reference(initiation.getReference())
+                .numberOfPayments(initiation.getNumberOfPayments())
+                .firstPaymentDateTime(initiation.getFirstPaymentDateTime())
+                .recurringPaymentDateTime(initiation.getRecurringPaymentDateTime())
+                .finalPaymentDateTime(initiation.getFinalPaymentDateTime())
+                .firstPaymentAmount((new OBDomesticStandingOrder3FirstPaymentAmount())
+                        .currency(initiation.getFirstPaymentAmount().getCurrency())
+                        .amount(initiation.getFirstPaymentAmount().getAmount()))
+                .recurringPaymentAmount((new OBDomesticStandingOrder3RecurringPaymentAmount())
+                        .currency(initiation.getRecurringPaymentAmount().getCurrency())
+                        .amount(initiation.getRecurringPaymentAmount().getAmount()))
+                .finalPaymentAmount((new OBDomesticStandingOrder3FinalPaymentAmount())
+                        .currency(initiation.getFirstPaymentAmount().getCurrency())
+                        .amount(initiation.getFirstPaymentAmount().getAmount()))
+                .debtorAccount((new OBCashAccountDebtor4())
+                        .schemeName(initiation.getDebtorAccount().getSchemeName())
+                        .identification(initiation.getDebtorAccount().getIdentification())
+                        .name(initiation.getDebtorAccount().getName())
+                        .secondaryIdentification(initiation.getDebtorAccount().getSecondaryIdentification()))
+                .creditorAccount((new OBCashAccountCreditor3())
+                        .schemeName(initiation.getCreditorAccount().getSchemeName())
+                        .identification(initiation.getCreditorAccount().getIdentification())
+                        .name(initiation.getCreditorAccount().getName())
+                        .secondaryIdentification(initiation.getCreditorAccount().getSecondaryIdentification()))
+                .supplementaryData(new OBSupplementaryData1());
+    }
+
+    private OBAuthorisation1 expectedObAuthorisation1(OBWriteDomesticConsent3DataAuthorisation authorisation) {
+        return (new OBAuthorisation1())
+                .authorisationType(OBExternalAuthorisation1Code.valueOf(authorisation.getAuthorisationType().name()))
+                .completionDateTime(authorisation.getCompletionDateTime());
+    }
+
+
+}

--- a/src/test/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteFileConsentConverterTest.java
+++ b/src/test/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteFileConsentConverterTest.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.datamodel.service.converter.payment;
+
+import org.junit.Test;
+import uk.org.openbanking.datamodel.account.OBCashAccount3;
+import uk.org.openbanking.datamodel.payment.OBAuthorisation1;
+import uk.org.openbanking.datamodel.payment.OBExternalAuthorisation1Code;
+import uk.org.openbanking.datamodel.payment.OBFile2;
+import uk.org.openbanking.datamodel.payment.OBRemittanceInformation1;
+import uk.org.openbanking.datamodel.payment.OBSupplementaryData1;
+import uk.org.openbanking.datamodel.payment.OBWriteDataFileConsent2;
+import uk.org.openbanking.datamodel.payment.OBWriteFileConsent2;
+import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3;
+import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3Data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteFileConsentConverter.toOBWriteFileConsent2;
+import static uk.org.openbanking.testsupport.payment.OBWriteFileConsentTestDataFactory.aValidOBWriteFileConsent3Data;
+
+/**
+ * Unit test for {@link OBWriteFileConsentConverter}.
+ */
+public class OBWriteFileConsentConverterTest {
+
+    @Test
+    public void shouldConvertToOBWriteDomesticConsent2() {
+        // Given
+        OBWriteFileConsent3Data data = aValidOBWriteFileConsent3Data();
+        OBWriteFileConsent3 obWriteFileConsent3 = new OBWriteFileConsent3();
+        obWriteFileConsent3.data(data);
+        OBWriteDataFileConsent2 expectedData = expectedObWriteDataFileConsent2(data);
+
+        // When
+        OBWriteFileConsent2 obWriteFileConsent2 = toOBWriteFileConsent2(obWriteFileConsent3);
+
+        // Then
+        assertThat(obWriteFileConsent2.getData()).isEqualTo(expectedData);
+    }
+
+    private OBWriteDataFileConsent2 expectedObWriteDataFileConsent2(OBWriteFileConsent3Data data) {
+        return (new OBWriteDataFileConsent2())
+                .initiation(expectedObFile2(data))
+                .authorisation(expectedObAuthorisation1(data));
+    }
+
+    private OBFile2 expectedObFile2(OBWriteFileConsent3Data data) {
+        return (new OBFile2())
+                .fileType(data.getInitiation().getFileType())
+                .fileHash(data.getInitiation().getFileHash())
+                .fileReference(data.getInitiation().getFileReference())
+                .numberOfTransactions(data.getInitiation().getNumberOfTransactions())
+                .controlSum(data.getInitiation().getControlSum())
+                .requestedExecutionDateTime(data.getInitiation().getRequestedExecutionDateTime())
+                .localInstrument(data.getInitiation().getLocalInstrument())
+                .debtorAccount((new OBCashAccount3())
+                        .schemeName(data.getInitiation().getDebtorAccount().getSchemeName())
+                        .identification(data.getInitiation().getDebtorAccount().getIdentification())
+                        .name(data.getInitiation().getDebtorAccount().getName())
+                        .secondaryIdentification(data.getInitiation().getDebtorAccount().getSecondaryIdentification()))
+                .remittanceInformation((new OBRemittanceInformation1())
+                        .unstructured(data.getInitiation().getRemittanceInformation().getUnstructured())
+                        .reference(data.getInitiation().getRemittanceInformation().getReference()))
+                .supplementaryData(new OBSupplementaryData1());
+    }
+
+    private OBAuthorisation1 expectedObAuthorisation1(OBWriteFileConsent3Data data) {
+        return (new OBAuthorisation1())
+                .authorisationType(OBExternalAuthorisation1Code.valueOf(data.getAuthorisation().getAuthorisationType().name()))
+                .completionDateTime(data.getAuthorisation().getCompletionDateTime());
+    }
+
+}

--- a/src/test/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteInternationalConsentConverterTest.java
+++ b/src/test/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteInternationalConsentConverterTest.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.datamodel.service.converter.payment;
+
+import org.junit.Test;
+import uk.org.openbanking.datamodel.payment.*;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent3DataAuthorisation.AuthorisationTypeEnum;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteInternationalConsentConverter.toOBWriteInternationalConsent4;
+import static uk.org.openbanking.testsupport.payment.OBWriteInternationalConsentTestDataFactory.aValidOBWriteInternationalConsent2;
+
+/**
+ * Unit test for {@link OBWriteInternationalConsentConverter}.
+ */
+public class OBWriteInternationalConsentConverterTest {
+
+    @Test
+    public void shouldConvertToOBWriteInternationalConsent4() {
+        // Given
+        OBWriteInternationalConsent2 source = aValidOBWriteInternationalConsent2();
+        OBWriteInternationalConsent4Data expectedData = expectedOBWriteInternationalConsent4Data(source.getData());
+
+        // When
+        OBWriteInternationalConsent4 converted = toOBWriteInternationalConsent4(source);
+
+        // Then
+        assertThat(converted.getData()).isEqualTo(expectedData);
+        assertThat(converted.getRisk()).isEqualTo(source.getRisk());
+    }
+
+    private OBWriteInternationalConsent4Data expectedOBWriteInternationalConsent4Data(OBWriteDataInternationalConsent2 data) {
+        return (new OBWriteInternationalConsent4Data())
+                .initiation(expectedOBWriteInternational3DataInitiation(data.getInitiation()))
+                .authorisation(expectedOBWriteDomesticConsent3DataAuthorisation(data.getAuthorisation()))
+                .scASupportData(null);
+    }
+
+    private OBWriteInternational3DataInitiation expectedOBWriteInternational3DataInitiation(OBInternational2 initiation) {
+        return (new OBWriteInternational3DataInitiation())
+                .instructionIdentification(initiation.getInstructionIdentification())
+                .endToEndIdentification(initiation.getEndToEndIdentification())
+                .localInstrument(initiation.getLocalInstrument())
+                .instructionPriority(OBWriteInternational3DataInitiation.InstructionPriorityEnum.valueOf(initiation.getInstructionPriority().name()))
+                .purpose(initiation.getPurpose())
+                .extendedPurpose(null)
+                .chargeBearer(initiation.getChargeBearer())
+                .currencyOfTransfer(initiation.getCurrencyOfTransfer())
+                .destinationCountryCode(null)
+                .instructedAmount((new OBWriteDomestic2DataInitiationInstructedAmount())
+                        .currency(initiation.getInstructedAmount().getCurrency())
+                        .amount(initiation.getInstructedAmount().getAmount()))
+                .exchangeRateInformation((new OBWriteInternational3DataInitiationExchangeRateInformation())
+                        .unitCurrency(initiation.getExchangeRateInformation().getUnitCurrency())
+                        .exchangeRate(initiation.getExchangeRateInformation().getExchangeRate())
+                        .rateType(OBWriteInternational3DataInitiationExchangeRateInformation.RateTypeEnum.valueOf(initiation.getExchangeRateInformation().getRateType().name()))
+                        .contractIdentification(initiation.getExchangeRateInformation().getContractIdentification()))
+                .debtorAccount((new OBWriteDomestic2DataInitiationDebtorAccount())
+                        .schemeName(initiation.getDebtorAccount().getSchemeName())
+                        .identification(initiation.getDebtorAccount().getIdentification())
+                        .name(initiation.getDebtorAccount().getName())
+                        .secondaryIdentification(initiation.getDebtorAccount().getSecondaryIdentification()))
+                .creditor((new OBWriteInternational3DataInitiationCreditor())
+                        .name(initiation.getCreditor().getName())
+                        .postalAddress(initiation.getCreditor().getPostalAddress()))
+                .creditorAgent((new OBWriteInternational3DataInitiationCreditorAgent())
+                        .schemeName(initiation.getCreditorAgent().getSchemeName())
+                        .identification(initiation.getCreditorAgent().getIdentification())
+                        .name(initiation.getCreditorAgent().getName())
+                        .postalAddress(initiation.getCreditorAgent().getPostalAddress()))
+                .creditorAccount((new OBWriteDomestic2DataInitiationCreditorAccount())
+                        .schemeName(initiation.getCreditorAccount().getSchemeName())
+                        .identification(initiation.getCreditorAccount().getIdentification())
+                        .name(initiation.getCreditorAccount().getName())
+                        .secondaryIdentification(initiation.getCreditorAccount().getSecondaryIdentification()))
+                .remittanceInformation((new OBWriteDomestic2DataInitiationRemittanceInformation())
+                        .reference(initiation.getRemittanceInformation().getReference())
+                        .unstructured(initiation.getRemittanceInformation().getUnstructured()))
+                .supplementaryData(initiation.getSupplementaryData());
+    }
+
+    private OBWriteDomesticConsent3DataAuthorisation expectedOBWriteDomesticConsent3DataAuthorisation(OBAuthorisation1 authorisation) {
+        return (new OBWriteDomesticConsent3DataAuthorisation())
+                .authorisationType(AuthorisationTypeEnum.valueOf(authorisation.getAuthorisationType().name()))
+                .completionDateTime(authorisation.getCompletionDateTime());
+    }
+}

--- a/src/test/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteInternationalScheduledConsentConverterTest.java
+++ b/src/test/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteInternationalScheduledConsentConverterTest.java
@@ -1,0 +1,245 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.datamodel.service.converter.payment;
+
+import org.junit.Test;
+import uk.org.openbanking.datamodel.account.OBCashAccount3;
+import uk.org.openbanking.datamodel.payment.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteInternationalScheduledConsentConverter.toOBWriteInternationalScheduledConsent1;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteInternationalScheduledConsentConverter.toOBWriteInternationalScheduledConsent4;
+import static uk.org.openbanking.testsupport.payment.OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent1;
+import static uk.org.openbanking.testsupport.payment.OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent2;
+import static uk.org.openbanking.testsupport.payment.OBWriteInternationalScheduledConsentTestDataFactory.aValidOBWriteInternationalScheduledConsent4;
+
+/**
+ * Unit test for {@link OBWriteInternationalScheduledConsentConverter}.
+ */
+public class OBWriteInternationalScheduledConsentConverterTest {
+
+    @Test
+    public void shouldConvertOBWriteInternationalScheduledConsent4ToOBWriteInternationalScheduledConsent1() {
+        // Given
+        OBWriteInternationalScheduledConsent4 source = aValidOBWriteInternationalScheduledConsent4();
+        OBWriteDataInternationalScheduledConsent1 expectedData = expectedOBWriteDataInternationalScheduledConsent1(source.getData());
+
+        // When
+        OBWriteInternationalScheduledConsent1 converted = toOBWriteInternationalScheduledConsent1(source);
+
+        // Then
+        assertThat(converted.getData()).isEqualTo(expectedData);
+        assertThat(converted.getRisk()).isEqualTo(source.getRisk());
+    }
+
+    @Test
+    public void shouldConvertOBWriteInternationalScheduledConsent1ToOBWriteInternationalScheduledConsent4() {
+        // Given
+        OBWriteInternationalScheduledConsent1 source = aValidOBWriteInternationalScheduledConsent1();
+        OBWriteInternationalScheduledConsent4Data expectedData = expectedOBWriteInternationalScheduledConsent4Data(source.getData());
+
+        // When
+        OBWriteInternationalScheduledConsent4 converted = toOBWriteInternationalScheduledConsent4(source);
+
+        // Then
+        assertThat(converted.getData()).isEqualTo(expectedData);
+        assertThat(converted.getRisk()).isEqualTo(source.getRisk());
+    }
+
+    @Test
+    public void shouldConvertOBWriteInternationalScheduledConsent2ToOBWriteInternationalScheduledConsent4() {
+        // Given
+        OBWriteInternationalScheduledConsent2 source = aValidOBWriteInternationalScheduledConsent2();
+        OBWriteInternationalScheduledConsent4Data expectedData = expectedOBWriteInternationalScheduledConsent4Data(source.getData());
+
+        // When
+        OBWriteInternationalScheduledConsent4 converted = toOBWriteInternationalScheduledConsent4(source);
+
+        // Then
+        assertThat(converted.getData()).isEqualTo(expectedData);
+        assertThat(converted.getRisk()).isEqualTo(source.getRisk());
+    }
+
+    private OBWriteDataInternationalScheduledConsent1 expectedOBWriteDataInternationalScheduledConsent1(OBWriteInternationalScheduledConsent4Data data) {
+        return (new OBWriteDataInternationalScheduledConsent1())
+                .permission(OBExternalPermissions2Code.CREATE)
+                .initiation(expectedOBInternationalScheduled1(data.getInitiation()))
+                .authorisation(expectedOBAuthorisation1(data.getAuthorisation()));
+    }
+
+    private OBWriteInternationalScheduledConsent4Data expectedOBWriteInternationalScheduledConsent4Data(OBWriteDataInternationalScheduledConsent1 data) {
+        return (new OBWriteInternationalScheduledConsent4Data())
+                .permission(OBWriteInternationalScheduledConsent4Data.PermissionEnum.valueOf(data.getPermission().name()))
+                .initiation(expectedOBWriteInternationalScheduled3DataInitiation(data.getInitiation()))
+                .authorisation(expectedOBWriteDomesticConsent3DataAuthorisation(data.getAuthorisation()))
+                .scASupportData(null);
+    }
+
+    private OBWriteInternationalScheduledConsent4Data expectedOBWriteInternationalScheduledConsent4Data(OBWriteDataInternationalScheduledConsent2 data) {
+        return (new OBWriteInternationalScheduledConsent4Data())
+                .permission(OBWriteInternationalScheduledConsent4Data.PermissionEnum.valueOf(data.getPermission().name()))
+                .initiation(expectedOBWriteInternationalScheduled3DataInitiation(data.getInitiation()))
+                .authorisation(expectedOBWriteDomesticConsent3DataAuthorisation(data.getAuthorisation()))
+                .scASupportData(null);
+    }
+
+    private OBInternationalScheduled1 expectedOBInternationalScheduled1(OBWriteInternationalScheduled3DataInitiation initiation) {
+        return (new OBInternationalScheduled1())
+                .instructionIdentification(initiation.getInstructionIdentification())
+                .endToEndIdentification(initiation.getEndToEndIdentification())
+                .localInstrument(initiation.getLocalInstrument())
+                .instructionPriority(OBPriority2Code.valueOf(initiation.getInstructionPriority().name()))
+                .purpose(initiation.getPurpose())
+                .chargeBearer(initiation.getChargeBearer())
+                .requestedExecutionDateTime(initiation.getRequestedExecutionDateTime())
+                .currencyOfTransfer(initiation.getCurrencyOfTransfer())
+                .instructedAmount((new OBActiveOrHistoricCurrencyAndAmount())
+                        .currency(initiation.getInstructedAmount().getCurrency())
+                        .amount(initiation.getInstructedAmount().getAmount()))
+                .exchangeRateInformation((new OBExchangeRate1())
+                        .unitCurrency(initiation.getExchangeRateInformation().getUnitCurrency())
+                        .exchangeRate(initiation.getExchangeRateInformation().getExchangeRate())
+                        .rateType(OBExchangeRateType2Code.valueOf(initiation.getExchangeRateInformation().getRateType().name()))
+                        .contractIdentification(initiation.getExchangeRateInformation().getContractIdentification()))
+                .debtorAccount((new OBCashAccount3())
+                        .schemeName(initiation.getDebtorAccount().getSchemeName())
+                        .identification(initiation.getDebtorAccount().getIdentification())
+                        .name(initiation.getDebtorAccount().getName())
+                        .secondaryIdentification(initiation.getDebtorAccount().getSecondaryIdentification()))
+                .creditor((new OBPartyIdentification43())
+                        .name(initiation.getCreditor().getName())
+                        .postalAddress(initiation.getCreditor().getPostalAddress()))
+                .creditorAgent((new OBBranchAndFinancialInstitutionIdentification3())
+                        .schemeName(initiation.getCreditorAgent().getSchemeName())
+                        .identification(initiation.getCreditorAgent().getIdentification())
+                        .name(initiation.getCreditorAgent().getName())
+                        .postalAddress(initiation.getCreditorAgent().getPostalAddress()))
+                .creditorAccount((new OBCashAccount3())
+                        .schemeName(initiation.getCreditorAccount().getSchemeName())
+                        .identification(initiation.getCreditorAccount().getIdentification())
+                        .name(initiation.getCreditorAccount().getName())
+                        .secondaryIdentification(initiation.getCreditorAccount().getSecondaryIdentification()))
+                .remittanceInformation((new OBRemittanceInformation1())
+                        .reference(initiation.getRemittanceInformation().getReference())
+                        .unstructured(initiation.getRemittanceInformation().getUnstructured()));
+    }
+
+    private OBWriteInternationalScheduled3DataInitiation expectedOBWriteInternationalScheduled3DataInitiation(OBInternationalScheduled1 initiation) {
+        return (new OBWriteInternationalScheduled3DataInitiation())
+                .instructionIdentification(initiation.getInstructionIdentification())
+                .endToEndIdentification(initiation.getEndToEndIdentification())
+                .localInstrument(initiation.getLocalInstrument())
+                .instructionPriority(OBWriteInternationalScheduled3DataInitiation.InstructionPriorityEnum.valueOf(initiation.getInstructionPriority().name()))
+                .purpose(initiation.getPurpose())
+                .extendedPurpose(null)
+                .chargeBearer(initiation.getChargeBearer())
+                .requestedExecutionDateTime(initiation.getRequestedExecutionDateTime())
+                .currencyOfTransfer(initiation.getCurrencyOfTransfer())
+                .destinationCountryCode(null)
+                .instructedAmount((new OBWriteDomestic2DataInitiationInstructedAmount())
+                        .currency(initiation.getInstructedAmount().getCurrency())
+                        .amount(initiation.getInstructedAmount().getAmount()))
+                .exchangeRateInformation((new OBWriteInternational3DataInitiationExchangeRateInformation())
+                        .unitCurrency(initiation.getExchangeRateInformation().getUnitCurrency())
+                        .exchangeRate(initiation.getExchangeRateInformation().getExchangeRate())
+                        .rateType(OBWriteInternational3DataInitiationExchangeRateInformation.RateTypeEnum.valueOf(initiation.getExchangeRateInformation().getRateType().name()))
+                        .contractIdentification(initiation.getExchangeRateInformation().getContractIdentification()))
+                .debtorAccount((new OBWriteDomestic2DataInitiationDebtorAccount())
+                        .schemeName(initiation.getDebtorAccount().getSchemeName())
+                        .identification(initiation.getDebtorAccount().getIdentification())
+                        .name(initiation.getDebtorAccount().getName())
+                        .secondaryIdentification(initiation.getDebtorAccount().getSecondaryIdentification()))
+                .creditor((new OBWriteInternational3DataInitiationCreditor())
+                        .name(initiation.getCreditor().getName())
+                        .postalAddress(initiation.getCreditor().getPostalAddress()))
+                .creditorAgent((new OBWriteInternational3DataInitiationCreditorAgent())
+                        .schemeName(initiation.getCreditorAgent().getSchemeName())
+                        .identification(initiation.getCreditorAgent().getIdentification())
+                        .name(initiation.getCreditorAgent().getName())
+                        .postalAddress(initiation.getCreditorAgent().getPostalAddress()))
+                .creditorAccount((new OBWriteDomestic2DataInitiationCreditorAccount())
+                        .schemeName(initiation.getCreditorAccount().getSchemeName())
+                        .identification(initiation.getCreditorAccount().getIdentification())
+                        .name(initiation.getCreditorAccount().getName())
+                        .secondaryIdentification(initiation.getCreditorAccount().getSecondaryIdentification()))
+                .remittanceInformation((new OBWriteDomestic2DataInitiationRemittanceInformation())
+                        .reference(initiation.getRemittanceInformation().getReference())
+                        .unstructured(initiation.getRemittanceInformation().getUnstructured()))
+                .supplementaryData(null);
+    }
+
+    private OBWriteInternationalScheduled3DataInitiation expectedOBWriteInternationalScheduled3DataInitiation(OBInternationalScheduled2 initiation) {
+        return (new OBWriteInternationalScheduled3DataInitiation())
+                .instructionIdentification(initiation.getInstructionIdentification())
+                .endToEndIdentification(initiation.getEndToEndIdentification())
+                .localInstrument(initiation.getLocalInstrument())
+                .instructionPriority(OBWriteInternationalScheduled3DataInitiation.InstructionPriorityEnum.valueOf(initiation.getInstructionPriority().name()))
+                .purpose(initiation.getPurpose())
+                .extendedPurpose(null)
+                .chargeBearer(initiation.getChargeBearer())
+                .requestedExecutionDateTime(initiation.getRequestedExecutionDateTime())
+                .currencyOfTransfer(initiation.getCurrencyOfTransfer())
+                .destinationCountryCode(null)
+                .instructedAmount((new OBWriteDomestic2DataInitiationInstructedAmount())
+                        .currency(initiation.getInstructedAmount().getCurrency())
+                        .amount(initiation.getInstructedAmount().getAmount()))
+                .exchangeRateInformation((new OBWriteInternational3DataInitiationExchangeRateInformation())
+                        .unitCurrency(initiation.getExchangeRateInformation().getUnitCurrency())
+                        .exchangeRate(initiation.getExchangeRateInformation().getExchangeRate())
+                        .rateType(OBWriteInternational3DataInitiationExchangeRateInformation.RateTypeEnum.valueOf(initiation.getExchangeRateInformation().getRateType().name()))
+                        .contractIdentification(initiation.getExchangeRateInformation().getContractIdentification()))
+                .debtorAccount((new OBWriteDomestic2DataInitiationDebtorAccount())
+                        .schemeName(initiation.getDebtorAccount().getSchemeName())
+                        .identification(initiation.getDebtorAccount().getIdentification())
+                        .name(initiation.getDebtorAccount().getName())
+                        .secondaryIdentification(initiation.getDebtorAccount().getSecondaryIdentification()))
+                .creditor((new OBWriteInternational3DataInitiationCreditor())
+                        .name(initiation.getCreditor().getName())
+                        .postalAddress(initiation.getCreditor().getPostalAddress()))
+                .creditorAgent((new OBWriteInternational3DataInitiationCreditorAgent())
+                        .schemeName(initiation.getCreditorAgent().getSchemeName())
+                        .identification(initiation.getCreditorAgent().getIdentification())
+                        .name(initiation.getCreditorAgent().getName())
+                        .postalAddress(initiation.getCreditorAgent().getPostalAddress()))
+                .creditorAccount((new OBWriteDomestic2DataInitiationCreditorAccount())
+                        .schemeName(initiation.getCreditorAccount().getSchemeName())
+                        .identification(initiation.getCreditorAccount().getIdentification())
+                        .name(initiation.getCreditorAccount().getName())
+                        .secondaryIdentification(initiation.getCreditorAccount().getSecondaryIdentification()))
+                .remittanceInformation((new OBWriteDomestic2DataInitiationRemittanceInformation())
+                        .reference(initiation.getRemittanceInformation().getReference())
+                        .unstructured(initiation.getRemittanceInformation().getUnstructured()))
+                .supplementaryData(initiation.getSupplementaryData());
+    }
+
+    private OBAuthorisation1 expectedOBAuthorisation1(OBWriteDomesticConsent3DataAuthorisation authorisation) {
+        return (new OBAuthorisation1())
+                .authorisationType(OBExternalAuthorisation1Code.valueOf(authorisation.getAuthorisationType().name()))
+                .completionDateTime(authorisation.getCompletionDateTime());
+    }
+
+    private OBWriteDomesticConsent3DataAuthorisation expectedOBWriteDomesticConsent3DataAuthorisation(OBAuthorisation1 authorisation) {
+        return (new OBWriteDomesticConsent3DataAuthorisation())
+                .authorisationType(OBWriteDomesticConsent3DataAuthorisation.AuthorisationTypeEnum.valueOf(authorisation.getAuthorisationType().name()))
+                .completionDateTime(authorisation.getCompletionDateTime());
+    }
+
+}

--- a/src/test/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteInternationalStandingOrderConsentConverterTest.java
+++ b/src/test/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteInternationalStandingOrderConsentConverterTest.java
@@ -1,0 +1,151 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.datamodel.service.converter.payment;
+
+import org.junit.Test;
+import uk.org.openbanking.datamodel.payment.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.org.openbanking.datamodel.service.converter.payment.OBWriteInternationalStandingOrderConsentConverter.toOBWriteInternationalStandingOrderConsent5;
+import static uk.org.openbanking.testsupport.payment.OBWriteInternationalStandingOrderConsentTestDataFactory.aValidOBWriteInternationalStandingOrderConsent2;
+import static uk.org.openbanking.testsupport.payment.OBWriteInternationalStandingOrderConsentTestDataFactory.aValidOBWriteInternationalStandingOrderConsent3;
+
+/**
+ * Unit test for {@link OBWriteInternationalStandingOrderConsentConverter}.
+ */
+public class OBWriteInternationalStandingOrderConsentConverterTest {
+
+    @Test
+    public void shouldConvertOBWriteInternationalStandingOrderConsent2ToOBWriteInternationalStandingOrderConsent5() {
+        // Given
+        OBWriteInternationalStandingOrderConsent2 source = aValidOBWriteInternationalStandingOrderConsent2();
+        OBWriteInternationalStandingOrderConsent5Data expectedData = expectedOBWriteInternationalStandingOrderConsent5Data(source.getData());
+
+        // When
+        OBWriteInternationalStandingOrderConsent5 converted = toOBWriteInternationalStandingOrderConsent5(source);
+
+        // Then
+        assertThat(converted.getData()).isEqualTo(expectedData);
+        assertThat(converted.getRisk()).isEqualTo(source.getRisk());
+    }
+
+    @Test
+    public void shouldConvertOBWriteInternationalStandingOrderConsent3ToOBWriteInternationalStandingOrderConsent5() {
+        // Given
+        OBWriteInternationalStandingOrderConsent3 source = aValidOBWriteInternationalStandingOrderConsent3();
+        OBWriteInternationalStandingOrderConsent5Data expectedData = expectedOBWriteInternationalStandingOrderConsent5Data(source.getData());
+
+        // When
+        OBWriteInternationalStandingOrderConsent5 converted = toOBWriteInternationalStandingOrderConsent5(source);
+
+        // Then
+        assertThat(converted.getData()).isEqualTo(expectedData);
+        assertThat(converted.getRisk()).isEqualTo(source.getRisk());
+    }
+
+    private OBWriteInternationalStandingOrderConsent5Data expectedOBWriteInternationalStandingOrderConsent5Data(OBWriteDataInternationalStandingOrderConsent2 data) {
+        return (new OBWriteInternationalStandingOrderConsent5Data())
+                .permission(OBWriteInternationalStandingOrderConsent5Data.PermissionEnum.valueOf(data.getPermission().name()))
+                .initiation(expectedOBWriteInternationalStandingOrder4DataInitiation(data.getInitiation()))
+                .authorisation(expectedOBWriteDomesticConsent3DataAuthorisation(data.getAuthorisation()));
+    }
+
+    private OBWriteInternationalStandingOrderConsent5Data expectedOBWriteInternationalStandingOrderConsent5Data(OBWriteDataInternationalStandingOrderConsent3 data) {
+        return (new OBWriteInternationalStandingOrderConsent5Data())
+                .permission(OBWriteInternationalStandingOrderConsent5Data.PermissionEnum.valueOf(data.getPermission().name()))
+                .initiation(expectedOBWriteInternationalStandingOrder4DataInitiation(data.getInitiation()))
+                .authorisation(expectedOBWriteDomesticConsent3DataAuthorisation(data.getAuthorisation()));
+    }
+
+    private OBWriteInternationalStandingOrder4DataInitiation expectedOBWriteInternationalStandingOrder4DataInitiation(OBInternationalStandingOrder2 initiation) {
+        return (new OBWriteInternationalStandingOrder4DataInitiation())
+                .frequency(initiation.getFrequency())
+                .reference(initiation.getReference())
+                .numberOfPayments(initiation.getNumberOfPayments())
+                .firstPaymentDateTime(initiation.getFirstPaymentDateTime())
+                .finalPaymentDateTime(initiation.getFinalPaymentDateTime())
+                .purpose(initiation.getPurpose())
+                .chargeBearer(initiation.getChargeBearer())
+                .currencyOfTransfer(initiation.getCurrencyOfTransfer())
+                .instructedAmount((new OBWriteDomestic2DataInitiationInstructedAmount())
+                        .currency(initiation.getInstructedAmount().getCurrency())
+                        .amount(initiation.getInstructedAmount().getAmount()))
+                .debtorAccount((new OBWriteDomesticStandingOrder3DataInitiationDebtorAccount())
+                        .schemeName(initiation.getDebtorAccount().getSchemeName())
+                        .identification(initiation.getDebtorAccount().getIdentification())
+                        .name(initiation.getDebtorAccount().getName())
+                        .secondaryIdentification(initiation.getDebtorAccount().getSecondaryIdentification()))
+                .creditor((new OBWriteInternational3DataInitiationCreditor())
+                        .name(initiation.getCreditor().getName())
+                        .postalAddress(initiation.getCreditor().getPostalAddress()))
+                .creditorAgent((new OBWriteInternationalStandingOrder4DataInitiationCreditorAgent())
+                        .schemeName(initiation.getCreditorAgent().getSchemeName())
+                        .identification(initiation.getCreditorAgent().getIdentification())
+                        .name(initiation.getCreditorAgent().getName())
+                        .postalAddress(initiation.getCreditorAgent().getPostalAddress()))
+                .creditorAccount((new OBWriteInternationalStandingOrder4DataInitiationCreditorAccount())
+                        .schemeName(initiation.getCreditorAccount().getSchemeName())
+                        .identification(initiation.getCreditorAccount().getIdentification())
+                        .name(initiation.getCreditorAccount().getName())
+                        .secondaryIdentification(initiation.getCreditorAccount().getSecondaryIdentification()))
+                .supplementaryData(initiation.getSupplementaryData());
+    }
+
+    private OBWriteInternationalStandingOrder4DataInitiation expectedOBWriteInternationalStandingOrder4DataInitiation(OBInternationalStandingOrder3 initiation) {
+        return (new OBWriteInternationalStandingOrder4DataInitiation())
+                .frequency(initiation.getFrequency())
+                .reference(initiation.getReference())
+                .numberOfPayments(initiation.getNumberOfPayments())
+                .firstPaymentDateTime(initiation.getFirstPaymentDateTime())
+                .finalPaymentDateTime(initiation.getFinalPaymentDateTime())
+                .purpose(initiation.getPurpose())
+                .chargeBearer(initiation.getChargeBearer())
+                .currencyOfTransfer(initiation.getCurrencyOfTransfer())
+                .instructedAmount((new OBWriteDomestic2DataInitiationInstructedAmount())
+                        .currency(initiation.getInstructedAmount().getCurrency())
+                        .amount(initiation.getInstructedAmount().getAmount()))
+                .debtorAccount((new OBWriteDomesticStandingOrder3DataInitiationDebtorAccount())
+                        .schemeName(initiation.getDebtorAccount().getSchemeName())
+                        .identification(initiation.getDebtorAccount().getIdentification())
+                        .name(initiation.getDebtorAccount().getName())
+                        .secondaryIdentification(initiation.getDebtorAccount().getSecondaryIdentification()))
+                .creditor((new OBWriteInternational3DataInitiationCreditor())
+                        .name(initiation.getCreditor().getName())
+                        .postalAddress(initiation.getCreditor().getPostalAddress()))
+                .creditorAgent((new OBWriteInternationalStandingOrder4DataInitiationCreditorAgent())
+                        .schemeName(initiation.getCreditorAgent().getSchemeName())
+                        .identification(initiation.getCreditorAgent().getIdentification())
+                        .name(initiation.getCreditorAgent().getName())
+                        .postalAddress(initiation.getCreditorAgent().getPostalAddress()))
+                .creditorAccount((new OBWriteInternationalStandingOrder4DataInitiationCreditorAccount())
+                        .schemeName(initiation.getCreditorAccount().getSchemeName())
+                        .identification(initiation.getCreditorAccount().getIdentification())
+                        .name(initiation.getCreditorAccount().getName())
+                        .secondaryIdentification(initiation.getCreditorAccount().getSecondaryIdentification()))
+                .supplementaryData(initiation.getSupplementaryData());
+    }
+
+    private OBWriteDomesticConsent3DataAuthorisation expectedOBWriteDomesticConsent3DataAuthorisation(OBAuthorisation1 authorisation) {
+        return (new OBWriteDomesticConsent3DataAuthorisation())
+                .authorisationType(OBWriteDomesticConsent3DataAuthorisation.AuthorisationTypeEnum.valueOf(authorisation.getAuthorisationType().name()))
+                .completionDateTime(authorisation.getCompletionDateTime());
+    }
+}

--- a/src/test/java/uk/org/openbanking/testsupport/payment/OBAccountTestDataFactory.java
+++ b/src/test/java/uk/org/openbanking/testsupport/payment/OBAccountTestDataFactory.java
@@ -1,0 +1,91 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.testsupport.payment;
+
+import uk.org.openbanking.datamodel.account.OBCashAccount3;
+import uk.org.openbanking.datamodel.payment.OBCashAccountCreditor3;
+import uk.org.openbanking.datamodel.payment.OBCashAccountDebtor4;
+import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationCreditorAccount;
+import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationDebtorAccount;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3DataInitiationCreditorAccount;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3DataInitiationDebtorAccount;
+
+/**
+ * Test data factory for various OB account types.
+ */
+public class OBAccountTestDataFactory {
+
+    public static OBWriteDomestic2DataInitiationCreditorAccount aValidOBWriteDomestic2DataInitiationCreditorAccount() {
+        return (new OBWriteDomestic2DataInitiationCreditorAccount())
+                .schemeName("UK.OBIE.SortCodeAccountNumber")
+                .identification("08080021325698")
+                .name("Mr Tim Burgess")
+                .secondaryIdentification("11");
+    }
+
+    public static OBWriteDomestic2DataInitiationDebtorAccount aValidOBWriteDomestic2DataInitiationDebtorAccount() {
+        return (new OBWriteDomestic2DataInitiationDebtorAccount())
+                .schemeName("UK.OBIE.SortCodeAccountNumber")
+                .identification("11280001234567")
+                .name("Mr Shaun Ryder")
+                .secondaryIdentification("22");
+    }
+
+    public static OBWriteDomesticStandingOrder3DataInitiationCreditorAccount aValidOBWriteDomesticStandingOrder3DataInitiationCreditorAccount() {
+        return (new OBWriteDomesticStandingOrder3DataInitiationCreditorAccount())
+                .schemeName("UK.OBIE.SortCodeAccountNumber")
+                .identification("18080021325694")
+                .name("Mr Ian Brown")
+                .secondaryIdentification("33");
+    }
+
+    public static OBWriteDomesticStandingOrder3DataInitiationDebtorAccount aValidOBWriteDomesticStandingOrder3DataInitiationDebtorAccount() {
+        return (new OBWriteDomesticStandingOrder3DataInitiationDebtorAccount())
+                .schemeName("UK.OBIE.SortCodeAccountNumber")
+                .identification("90611424625555")
+                .name("Mr Steven Morrissey")
+                .secondaryIdentification("44");
+    }
+
+    public static OBCashAccount3 aValidOBCashAccount3() {
+        return (new OBCashAccount3())
+                .schemeName("UK.OBIE.SortCodeAccountNumber")
+                .identification("90611424625566")
+                .name("Mr Johnny Marr")
+                .secondaryIdentification("55");
+    }
+
+    public static OBCashAccountCreditor3 aValidOBCashAccountCreditor3() {
+        return (new OBCashAccountCreditor3())
+                .schemeName("UK.OBIE.SortCodeAccountNumber")
+                .identification("18080021325677")
+                .name("Mr Stephen Holt")
+                .secondaryIdentification("66");
+    }
+
+    public static OBCashAccountDebtor4 aValidOBCashAccountDebtor4() {
+        return (new OBCashAccountDebtor4())
+                .schemeName("UK.OBIE.SortCodeAccountNumber")
+                .identification("18080021325688")
+                .name("Mr Bernard Sumner")
+                .secondaryIdentification("77");
+    }
+}

--- a/src/test/java/uk/org/openbanking/testsupport/payment/OBAmountTestDataFactory.java
+++ b/src/test/java/uk/org/openbanking/testsupport/payment/OBAmountTestDataFactory.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.testsupport.payment;
+
+import uk.org.openbanking.datamodel.payment.OBActiveOrHistoricCurrencyAndAmount;
+import uk.org.openbanking.datamodel.payment.OBDomestic2InstructedAmount;
+import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationInstructedAmount;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3DataInitiationFinalPaymentAmount;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3DataInitiationFirstPaymentAmount;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3DataInitiationRecurringPaymentAmount;
+
+/**
+ * Test data factory for the various OB classes that represent money.
+ */
+public class OBAmountTestDataFactory {
+
+    private static final String GBP = "GBP";
+    private static final String AMOUNT = "10.01";
+
+    public static OBWriteDomestic2DataInitiationInstructedAmount aValidOBWriteDomestic2DataInitiationInstructedAmount() {
+        return (new OBWriteDomestic2DataInitiationInstructedAmount())
+                .currency(GBP)
+                .amount(AMOUNT);
+    }
+
+    public static OBWriteDomesticStandingOrder3DataInitiationFinalPaymentAmount aValidOBWriteDomesticStandingOrder3DataInitiationFinalPaymentAmount() {
+        return (new OBWriteDomesticStandingOrder3DataInitiationFinalPaymentAmount())
+                .currency(GBP)
+                .amount(AMOUNT);
+    }
+
+    public static OBWriteDomesticStandingOrder3DataInitiationRecurringPaymentAmount aValidOBWriteDomesticStandingOrder3DataInitiationRecurringPaymentAmount() {
+        return (new OBWriteDomesticStandingOrder3DataInitiationRecurringPaymentAmount())
+                .currency(GBP)
+                .amount(AMOUNT);
+    }
+
+    public static OBWriteDomesticStandingOrder3DataInitiationFirstPaymentAmount aValidOBWriteDomesticStandingOrder3DataInitiationFirstPaymentAmount() {
+        return (new OBWriteDomesticStandingOrder3DataInitiationFirstPaymentAmount())
+                .currency(GBP)
+                .amount(AMOUNT);
+    }
+
+    public static OBActiveOrHistoricCurrencyAndAmount aValidOBActiveOrHistoricCurrencyAndAmount() {
+        return (new OBActiveOrHistoricCurrencyAndAmount())
+                .currency(GBP)
+                .amount(AMOUNT);
+    }
+
+    public static OBDomestic2InstructedAmount aValidOBDomestic2InstructedAmount() {
+        return (new OBDomestic2InstructedAmount())
+                .currency(GBP)
+                .amount(AMOUNT);
+    }
+}

--- a/src/test/java/uk/org/openbanking/testsupport/payment/OBConsentAuthorisationTestDataFactory.java
+++ b/src/test/java/uk/org/openbanking/testsupport/payment/OBConsentAuthorisationTestDataFactory.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.testsupport.payment;
+
+import org.joda.time.DateTime;
+import uk.org.openbanking.datamodel.payment.OBAuthorisation1;
+import uk.org.openbanking.datamodel.payment.OBExternalAuthorisation1Code;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent3DataAuthorisation;
+
+/**
+ * Test data factory for various OB consent authorisation types.
+ */
+public class OBConsentAuthorisationTestDataFactory {
+
+    public static OBAuthorisation1 aValidOBAuthorisation1() {
+        return (new OBAuthorisation1())
+                .authorisationType(OBExternalAuthorisation1Code.ANY)
+                .completionDateTime(DateTime.now());
+    }
+
+    public static OBWriteDomesticConsent3DataAuthorisation aValidOBWriteDomesticConsent3DataAuthorisation() {
+        return (new OBWriteDomesticConsent3DataAuthorisation())
+                .authorisationType(OBWriteDomesticConsent3DataAuthorisation.AuthorisationTypeEnum.ANY)
+                .completionDateTime(DateTime.now());
+    }
+}

--- a/src/test/java/uk/org/openbanking/testsupport/payment/OBExchangeRateTestDataFactory.java
+++ b/src/test/java/uk/org/openbanking/testsupport/payment/OBExchangeRateTestDataFactory.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.testsupport.payment;
+
+import org.joda.time.DateTime;
+import uk.org.openbanking.datamodel.payment.OBExchangeRate1;
+import uk.org.openbanking.datamodel.payment.OBExchangeRateType2Code;
+import uk.org.openbanking.datamodel.payment.OBWriteInternational3DataInitiationExchangeRateInformation;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsentResponse4DataExchangeRateInformation;
+
+import java.math.BigDecimal;
+
+public class OBExchangeRateTestDataFactory {
+
+    private static final String CURRENCY = "EUR";
+    private static final BigDecimal EXCHANGE_RATE = BigDecimal.valueOf(1.1);
+
+    public static OBWriteInternational3DataInitiationExchangeRateInformation aValidOBWriteInternational3DataInitiationExchangeRateInformation() {
+        return (new OBWriteInternational3DataInitiationExchangeRateInformation())
+                .unitCurrency(CURRENCY)
+                .exchangeRate(EXCHANGE_RATE)
+                .rateType(OBWriteInternational3DataInitiationExchangeRateInformation.RateTypeEnum.INDICATIVE)
+                .contractIdentification("Contract ID");
+    }
+
+    public static OBWriteInternationalConsentResponse4DataExchangeRateInformation aValidOBWriteInternationalConsentResponse4DataExchangeRateInformation() {
+        return (new OBWriteInternationalConsentResponse4DataExchangeRateInformation())
+                .unitCurrency(CURRENCY)
+                .exchangeRate(EXCHANGE_RATE)
+                .rateType(OBWriteInternationalConsentResponse4DataExchangeRateInformation.RateTypeEnum.INDICATIVE)
+                .contractIdentification("Contract ID")
+                .expirationDateTime(DateTime.now());
+    }
+
+    public static OBExchangeRate1 aValidOBExchangeRate1() {
+        return (new OBExchangeRate1())
+                .unitCurrency(CURRENCY)
+                .exchangeRate(EXCHANGE_RATE)
+                .rateType(OBExchangeRateType2Code.INDICATIVE)
+                .contractIdentification("Contract ID");
+    }
+}

--- a/src/test/java/uk/org/openbanking/testsupport/payment/OBInternationalIdentifierTestDataFactory.java
+++ b/src/test/java/uk/org/openbanking/testsupport/payment/OBInternationalIdentifierTestDataFactory.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.testsupport.payment;
+
+import uk.org.openbanking.datamodel.payment.OBBranchAndFinancialInstitutionIdentification3;
+import uk.org.openbanking.datamodel.payment.OBBranchAndFinancialInstitutionIdentification6;
+import uk.org.openbanking.datamodel.payment.OBPartyIdentification43;
+import uk.org.openbanking.datamodel.payment.OBWriteInternational3DataInitiationCreditor;
+import uk.org.openbanking.datamodel.payment.OBWriteInternational3DataInitiationCreditorAgent;
+
+import static uk.org.openbanking.testsupport.payment.OBPostalAddress6TestDataFactory.aValidOBPostalAddress6;
+
+public class OBInternationalIdentifierTestDataFactory {
+
+    public static OBBranchAndFinancialInstitutionIdentification3 aValidOBBranchAndFinancialInstitutionIdentification3() {
+        return (new OBBranchAndFinancialInstitutionIdentification3())
+                .schemeName("UK.OBIE.SortCodeAccountNumber")
+                .identification("40400411270111")
+                .name("Creditor Agent Name")
+                .postalAddress(aValidOBPostalAddress6());
+    }
+
+    public static OBBranchAndFinancialInstitutionIdentification6 aValidOBBranchAndFinancialInstitutionIdentification6() {
+        return (new OBBranchAndFinancialInstitutionIdentification6())
+                .schemeName("UK.OBIE.SortCodeAccountNumber")
+                .identification("40400411270111")
+                .name("Creditor Agent Name")
+                .postalAddress(aValidOBPostalAddress6());
+    }
+
+    public static OBWriteInternational3DataInitiationCreditorAgent aValidOBWriteInternational3DataInitiationCreditorAgent() {
+        return (new OBWriteInternational3DataInitiationCreditorAgent())
+                .schemeName("UK.OBIE.SortCodeAccountNumber")
+                .identification("40400411270111")
+                .name("Creditor Agent Name")
+                .postalAddress(aValidOBPostalAddress6());
+    }
+
+    public static OBPartyIdentification43 aValidOBPartyIdentification43() {
+        return (new OBPartyIdentification43())
+                .name("Creditor Name")
+                .postalAddress(aValidOBPostalAddress6());
+    }
+
+    public static OBWriteInternational3DataInitiationCreditor aValidOBWriteInternational3DataInitiationCreditor() {
+        return (new OBWriteInternational3DataInitiationCreditor())
+                .name("Creditor Name")
+                .postalAddress(aValidOBPostalAddress6());
+    }
+}

--- a/src/test/java/uk/org/openbanking/testsupport/payment/OBPostalAddress6TestDataFactory.java
+++ b/src/test/java/uk/org/openbanking/testsupport/payment/OBPostalAddress6TestDataFactory.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.testsupport.payment;
+
+import uk.org.openbanking.datamodel.payment.OBAddressTypeCode;
+import uk.org.openbanking.datamodel.payment.OBPostalAddress6;
+
+/**
+ * Test data factory for {@link OBPostalAddress6}.
+ */
+public class OBPostalAddress6TestDataFactory {
+
+    public static OBPostalAddress6 aValidOBPostalAddress6() {
+        return (new OBPostalAddress6())
+                .addressType(OBAddressTypeCode.RESIDENTIAL)
+                .buildingNumber("1")
+                .streetName("The Mall")
+                .postCode("WC1 1AB")
+                .townName("London")
+                .country("UK");
+    }
+}

--- a/src/test/java/uk/org/openbanking/testsupport/payment/OBRemittanceInformationTestDataFactory.java
+++ b/src/test/java/uk/org/openbanking/testsupport/payment/OBRemittanceInformationTestDataFactory.java
@@ -1,0 +1,42 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.testsupport.payment;
+
+import uk.org.openbanking.datamodel.payment.OBRemittanceInformation1;
+import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiationRemittanceInformation;
+
+/**
+ * Test data factory for the various OB classes representing payment remittance information.
+ */
+public class OBRemittanceInformationTestDataFactory {
+
+    public static OBWriteDomestic2DataInitiationRemittanceInformation aValidOBWriteDomestic2DataInitiationRemittanceInformation() {
+        return (new OBWriteDomestic2DataInitiationRemittanceInformation())
+                .unstructured("Internal ops code 5120103")
+                .reference("FRESCO-037");
+    }
+
+    public static OBRemittanceInformation1 aValidOBRemittanceInformation1() {
+        return (new OBRemittanceInformation1())
+                .unstructured("Internal ops code 5120103")
+                .reference("FRESCO-037");
+    }
+}

--- a/src/test/java/uk/org/openbanking/testsupport/payment/OBWriteDomesticConsentTestDataFactory.java
+++ b/src/test/java/uk/org/openbanking/testsupport/payment/OBWriteDomesticConsentTestDataFactory.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.testsupport.payment;
+
+import uk.org.openbanking.datamodel.payment.OBRisk1;
+import uk.org.openbanking.datamodel.payment.OBSupplementaryData1;
+import uk.org.openbanking.datamodel.payment.OBWriteDomestic2DataInitiation;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent3;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticConsent3Data;
+
+import static uk.org.openbanking.testsupport.payment.OBAccountTestDataFactory.aValidOBWriteDomestic2DataInitiationCreditorAccount;
+import static uk.org.openbanking.testsupport.payment.OBAccountTestDataFactory.aValidOBWriteDomestic2DataInitiationDebtorAccount;
+import static uk.org.openbanking.testsupport.payment.OBAmountTestDataFactory.aValidOBWriteDomestic2DataInitiationInstructedAmount;
+import static uk.org.openbanking.testsupport.payment.OBConsentAuthorisationTestDataFactory.aValidOBWriteDomesticConsent3DataAuthorisation;
+import static uk.org.openbanking.testsupport.payment.OBPostalAddress6TestDataFactory.aValidOBPostalAddress6;
+import static uk.org.openbanking.testsupport.payment.OBRemittanceInformationTestDataFactory.aValidOBWriteDomestic2DataInitiationRemittanceInformation;
+
+/**
+ * Test data factory for the various "OBWriteDomesticConsent" classes.
+ */
+public class OBWriteDomesticConsentTestDataFactory {
+
+    public static OBWriteDomesticConsent3 aValidOBWriteDomesticConsent3() {
+        return (new OBWriteDomesticConsent3())
+                .data(aValidOBWriteDomesticConsent3Data())
+                .risk(new OBRisk1());
+    }
+
+    public static OBWriteDomesticConsent3Data aValidOBWriteDomesticConsent3Data() {
+        return (new OBWriteDomesticConsent3Data())
+                .initiation(aValidOBWriteDomestic2DataInitiation())
+                .authorisation(aValidOBWriteDomesticConsent3DataAuthorisation());
+    }
+
+    public static OBWriteDomestic2DataInitiation aValidOBWriteDomestic2DataInitiation() {
+        return (new OBWriteDomestic2DataInitiation())
+                .instructionIdentification("ANSM020")
+                .endToEndIdentification("FRESCO.21302.GFX.01")
+                .localInstrument("UK.OBIE.BACS")
+                .instructedAmount(aValidOBWriteDomestic2DataInitiationInstructedAmount())
+                .debtorAccount(aValidOBWriteDomestic2DataInitiationDebtorAccount())
+                .creditorAccount(aValidOBWriteDomestic2DataInitiationCreditorAccount())
+                .creditorPostalAddress(aValidOBPostalAddress6())
+                .remittanceInformation(aValidOBWriteDomestic2DataInitiationRemittanceInformation())
+                .supplementaryData(new OBSupplementaryData1());
+    }
+}

--- a/src/test/java/uk/org/openbanking/testsupport/payment/OBWriteDomesticScheduledConsentTestDataFactory.java
+++ b/src/test/java/uk/org/openbanking/testsupport/payment/OBWriteDomesticScheduledConsentTestDataFactory.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.testsupport.payment;
+
+import org.joda.time.DateTime;
+import uk.org.openbanking.datamodel.payment.OBDomesticScheduled2;
+import uk.org.openbanking.datamodel.payment.OBExternalPermissions2Code;
+import uk.org.openbanking.datamodel.payment.OBRisk1;
+import uk.org.openbanking.datamodel.payment.OBSupplementaryData1;
+import uk.org.openbanking.datamodel.payment.OBWriteDataDomesticScheduledConsent2;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent2;
+
+import static uk.org.openbanking.testsupport.payment.OBAccountTestDataFactory.aValidOBCashAccount3;
+import static uk.org.openbanking.testsupport.payment.OBAmountTestDataFactory.aValidOBActiveOrHistoricCurrencyAndAmount;
+import static uk.org.openbanking.testsupport.payment.OBConsentAuthorisationTestDataFactory.aValidOBAuthorisation1;
+import static uk.org.openbanking.testsupport.payment.OBPostalAddress6TestDataFactory.aValidOBPostalAddress6;
+import static uk.org.openbanking.testsupport.payment.OBRemittanceInformationTestDataFactory.aValidOBRemittanceInformation1;
+
+/**
+ * Test data factory for the various "OBWriteDomesticScheduledConsent" classes.
+ */
+public class OBWriteDomesticScheduledConsentTestDataFactory {
+
+    public static OBWriteDomesticScheduledConsent2 aValidOBWriteDomesticScheduledConsent2() {
+        return (new OBWriteDomesticScheduledConsent2())
+                .data(aValidOBWriteDataDomesticScheduledConsent2())
+                .risk(new OBRisk1());
+    }
+
+    public static OBWriteDataDomesticScheduledConsent2 aValidOBWriteDataDomesticScheduledConsent2() {
+        return (new OBWriteDataDomesticScheduledConsent2())
+                .permission(OBExternalPermissions2Code.CREATE)
+                .initiation(aValidOBDomesticScheduled2())
+                .authorisation(aValidOBAuthorisation1());
+    }
+
+    public static OBDomesticScheduled2 aValidOBDomesticScheduled2() {
+        return (new OBDomesticScheduled2())
+                .instructionIdentification("ANSM021")
+                .endToEndIdentification("FRESCO.21302.GFX.02")
+                .localInstrument("UK.OBIE.CHAPS")
+                .requestedExecutionDateTime(DateTime.now())
+                .instructedAmount(aValidOBActiveOrHistoricCurrencyAndAmount())
+                .debtorAccount(aValidOBCashAccount3())
+                .creditorAccount(aValidOBCashAccount3())
+                .creditorPostalAddress(aValidOBPostalAddress6())
+                .remittanceInformation(aValidOBRemittanceInformation1())
+                .supplementaryData(new OBSupplementaryData1());
+    }
+
+}

--- a/src/test/java/uk/org/openbanking/testsupport/payment/OBWriteDomesticStandingOrderConsentTestDataFactory.java
+++ b/src/test/java/uk/org/openbanking/testsupport/payment/OBWriteDomesticStandingOrderConsentTestDataFactory.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.testsupport.payment;
+
+import org.joda.time.DateTime;
+import uk.org.openbanking.datamodel.payment.OBRisk1;
+import uk.org.openbanking.datamodel.payment.OBSupplementaryData1;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrder3DataInitiation;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent4;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent4Data;
+import uk.org.openbanking.datamodel.payment.OBWriteDomesticStandingOrderConsent4Data.PermissionEnum;
+
+import static org.joda.time.DateTime.now;
+import static uk.org.openbanking.testsupport.payment.OBAccountTestDataFactory.aValidOBWriteDomesticStandingOrder3DataInitiationCreditorAccount;
+import static uk.org.openbanking.testsupport.payment.OBAccountTestDataFactory.aValidOBWriteDomesticStandingOrder3DataInitiationDebtorAccount;
+import static uk.org.openbanking.testsupport.payment.OBAmountTestDataFactory.aValidOBWriteDomesticStandingOrder3DataInitiationFinalPaymentAmount;
+import static uk.org.openbanking.testsupport.payment.OBAmountTestDataFactory.aValidOBWriteDomesticStandingOrder3DataInitiationFirstPaymentAmount;
+import static uk.org.openbanking.testsupport.payment.OBAmountTestDataFactory.aValidOBWriteDomesticStandingOrder3DataInitiationRecurringPaymentAmount;
+import static uk.org.openbanking.testsupport.payment.OBConsentAuthorisationTestDataFactory.aValidOBWriteDomesticConsent3DataAuthorisation;
+
+/**
+ * Test data factory for the various "OBWriteDomesticStandingOrderConsent" classes.
+ */
+public class OBWriteDomesticStandingOrderConsentTestDataFactory {
+
+    public static OBWriteDomesticStandingOrderConsent4 aValidOBWriteDomesticStandingOrderConsent4() {
+        return (new OBWriteDomesticStandingOrderConsent4())
+                .data(aValidOBWriteDomesticStandingOrderConsent4Data())
+                .risk(new OBRisk1());
+    }
+
+    public static OBWriteDomesticStandingOrderConsent4Data aValidOBWriteDomesticStandingOrderConsent4Data() {
+        return (new OBWriteDomesticStandingOrderConsent4Data())
+                .permission(PermissionEnum.CREATE)
+                .initiation(aValidOBWriteDomesticStandingOrder3DataInitiation())
+                .authorisation(aValidOBWriteDomesticConsent3DataAuthorisation());
+    }
+
+    public static OBWriteDomesticStandingOrder3DataInitiation aValidOBWriteDomesticStandingOrder3DataInitiation() {
+        DateTime now = now();
+        return (new OBWriteDomesticStandingOrder3DataInitiation())
+                .frequency("EvryWorkgDay")
+                .reference("Ipsum Non Arcu Inc.")
+                .numberOfPayments("1")
+                .firstPaymentDateTime(now)
+                .recurringPaymentDateTime(now)
+                .finalPaymentDateTime(now)
+                .firstPaymentAmount(aValidOBWriteDomesticStandingOrder3DataInitiationFirstPaymentAmount())
+                .recurringPaymentAmount(aValidOBWriteDomesticStandingOrder3DataInitiationRecurringPaymentAmount())
+                .finalPaymentAmount(aValidOBWriteDomesticStandingOrder3DataInitiationFinalPaymentAmount())
+                .debtorAccount(aValidOBWriteDomesticStandingOrder3DataInitiationDebtorAccount())
+                .creditorAccount(aValidOBWriteDomesticStandingOrder3DataInitiationCreditorAccount())
+                .supplementaryData(new OBSupplementaryData1());
+    }
+}

--- a/src/test/java/uk/org/openbanking/testsupport/payment/OBWriteFileConsentTestDataFactory.java
+++ b/src/test/java/uk/org/openbanking/testsupport/payment/OBWriteFileConsentTestDataFactory.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.testsupport.payment;
+
+import org.joda.time.DateTime;
+import uk.org.openbanking.datamodel.payment.OBSupplementaryData1;
+import uk.org.openbanking.datamodel.payment.OBWriteFile2DataInitiation;
+import uk.org.openbanking.datamodel.payment.OBWriteFileConsent3Data;
+
+import java.math.BigDecimal;
+
+import static uk.org.openbanking.testsupport.payment.OBAccountTestDataFactory.aValidOBWriteDomestic2DataInitiationDebtorAccount;
+import static uk.org.openbanking.testsupport.payment.OBConsentAuthorisationTestDataFactory.aValidOBWriteDomesticConsent3DataAuthorisation;
+import static uk.org.openbanking.testsupport.payment.OBRemittanceInformationTestDataFactory.aValidOBWriteDomestic2DataInitiationRemittanceInformation;
+
+/**
+ * Test data factory for the {@link OBWriteFileConsent3Data}.
+ */
+public class OBWriteFileConsentTestDataFactory {
+
+    public static OBWriteFileConsent3Data aValidOBWriteFileConsent3Data() {
+        DateTime now = DateTime.now();
+        return (new OBWriteFileConsent3Data())
+                .initiation((new OBWriteFile2DataInitiation())
+                        .fileType("UK.OBIE.pain.001.001.08")
+                        .fileHash("m5ah/h1UjLvJYMxqAoZmj9dKdjZnsGNm+yMkJp/KuqQ")
+                        .fileReference("GB2OK238")
+                        .numberOfTransactions("1")
+                        .controlSum(BigDecimal.ONE)
+                        .requestedExecutionDateTime(now)
+                        .localInstrument("UK.OBIE.CHAPS")
+                        .debtorAccount(aValidOBWriteDomestic2DataInitiationDebtorAccount())
+                        .remittanceInformation(aValidOBWriteDomestic2DataInitiationRemittanceInformation())
+                        .supplementaryData(new OBSupplementaryData1()))
+                .authorisation(aValidOBWriteDomesticConsent3DataAuthorisation());
+    }
+}

--- a/src/test/java/uk/org/openbanking/testsupport/payment/OBWriteInternationalConsentTestDataFactory.java
+++ b/src/test/java/uk/org/openbanking/testsupport/payment/OBWriteInternationalConsentTestDataFactory.java
@@ -1,0 +1,74 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.testsupport.payment;
+
+import uk.org.openbanking.datamodel.payment.OBChargeBearerType1Code;
+import uk.org.openbanking.datamodel.payment.OBInternational2;
+import uk.org.openbanking.datamodel.payment.OBPriority2Code;
+import uk.org.openbanking.datamodel.payment.OBRisk1;
+import uk.org.openbanking.datamodel.payment.OBSupplementaryData1;
+import uk.org.openbanking.datamodel.payment.OBWriteDataInternationalConsent2;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalConsent2;
+
+import static uk.org.openbanking.testsupport.payment.OBAccountTestDataFactory.aValidOBCashAccount3;
+import static uk.org.openbanking.testsupport.payment.OBAmountTestDataFactory.aValidOBActiveOrHistoricCurrencyAndAmount;
+import static uk.org.openbanking.testsupport.payment.OBConsentAuthorisationTestDataFactory.aValidOBAuthorisation1;
+import static uk.org.openbanking.testsupport.payment.OBExchangeRateTestDataFactory.aValidOBExchangeRate1;
+import static uk.org.openbanking.testsupport.payment.OBInternationalIdentifierTestDataFactory.aValidOBBranchAndFinancialInstitutionIdentification3;
+import static uk.org.openbanking.testsupport.payment.OBInternationalIdentifierTestDataFactory.aValidOBPartyIdentification43;
+import static uk.org.openbanking.testsupport.payment.OBRemittanceInformationTestDataFactory.aValidOBRemittanceInformation1;
+
+/**
+ * Test data factory for the various "OBWriteInternationalConsent" classes.
+ */
+public class OBWriteInternationalConsentTestDataFactory {
+
+    public static OBWriteInternationalConsent2 aValidOBWriteInternationalConsent2() {
+        return (new OBWriteInternationalConsent2())
+                .data(aValidOBWriteDataInternationalConsent2())
+                .risk(new OBRisk1());
+    }
+
+    public static OBWriteDataInternationalConsent2 aValidOBWriteDataInternationalConsent2() {
+        return (new OBWriteDataInternationalConsent2())
+                .initiation(aValidOBInternational2())
+                .authorisation(aValidOBAuthorisation1());
+    }
+
+    public static OBInternational2 aValidOBInternational2() {
+        return (new OBInternational2())
+                .instructionIdentification("ANSM020")
+                .endToEndIdentification("FRESCO.21302.GFX.01")
+                .localInstrument("UK.OBIE.BACS")
+                .instructionPriority(OBPriority2Code.NORMAL)
+                .purpose("CDCD")
+                .chargeBearer(OBChargeBearerType1Code.SHARED)
+                .currencyOfTransfer("USD")
+                .instructedAmount(aValidOBActiveOrHistoricCurrencyAndAmount())
+                .exchangeRateInformation(aValidOBExchangeRate1())
+                .debtorAccount(aValidOBCashAccount3())
+                .creditor(aValidOBPartyIdentification43())
+                .creditorAgent(aValidOBBranchAndFinancialInstitutionIdentification3())
+                .creditorAccount(aValidOBCashAccount3())
+                .remittanceInformation(aValidOBRemittanceInformation1())
+                .supplementaryData(new OBSupplementaryData1());
+    }
+}

--- a/src/test/java/uk/org/openbanking/testsupport/payment/OBWriteInternationalScheduledConsentTestDataFactory.java
+++ b/src/test/java/uk/org/openbanking/testsupport/payment/OBWriteInternationalScheduledConsentTestDataFactory.java
@@ -1,0 +1,146 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.testsupport.payment;
+
+import org.joda.time.DateTime;
+import uk.org.openbanking.datamodel.payment.*;
+import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduledConsent4Data.PermissionEnum;
+
+import static uk.org.openbanking.testsupport.payment.OBAccountTestDataFactory.aValidOBCashAccount3;
+import static uk.org.openbanking.testsupport.payment.OBAccountTestDataFactory.aValidOBWriteDomestic2DataInitiationCreditorAccount;
+import static uk.org.openbanking.testsupport.payment.OBAccountTestDataFactory.aValidOBWriteDomestic2DataInitiationDebtorAccount;
+import static uk.org.openbanking.testsupport.payment.OBAmountTestDataFactory.aValidOBActiveOrHistoricCurrencyAndAmount;
+import static uk.org.openbanking.testsupport.payment.OBAmountTestDataFactory.aValidOBWriteDomestic2DataInitiationInstructedAmount;
+import static uk.org.openbanking.testsupport.payment.OBConsentAuthorisationTestDataFactory.aValidOBAuthorisation1;
+import static uk.org.openbanking.testsupport.payment.OBConsentAuthorisationTestDataFactory.aValidOBWriteDomesticConsent3DataAuthorisation;
+import static uk.org.openbanking.testsupport.payment.OBExchangeRateTestDataFactory.aValidOBExchangeRate1;
+import static uk.org.openbanking.testsupport.payment.OBExchangeRateTestDataFactory.aValidOBWriteInternational3DataInitiationExchangeRateInformation;
+import static uk.org.openbanking.testsupport.payment.OBInternationalIdentifierTestDataFactory.aValidOBBranchAndFinancialInstitutionIdentification3;
+import static uk.org.openbanking.testsupport.payment.OBInternationalIdentifierTestDataFactory.aValidOBPartyIdentification43;
+import static uk.org.openbanking.testsupport.payment.OBInternationalIdentifierTestDataFactory.aValidOBWriteInternational3DataInitiationCreditor;
+import static uk.org.openbanking.testsupport.payment.OBInternationalIdentifierTestDataFactory.aValidOBWriteInternational3DataInitiationCreditorAgent;
+import static uk.org.openbanking.testsupport.payment.OBRemittanceInformationTestDataFactory.aValidOBRemittanceInformation1;
+import static uk.org.openbanking.testsupport.payment.OBRemittanceInformationTestDataFactory.aValidOBWriteDomestic2DataInitiationRemittanceInformation;
+
+/**
+ * Test data factory for the various "OBWriteInternationalScheduledConsent" classes.
+ */
+public class OBWriteInternationalScheduledConsentTestDataFactory {
+
+    public static OBWriteInternationalScheduledConsent1 aValidOBWriteInternationalScheduledConsent1() {
+        return (new OBWriteInternationalScheduledConsent1())
+                .data(aValidOBWriteDataInternationalScheduledConsent1())
+                .risk(new OBRisk1());
+    }
+
+    public static OBWriteInternationalScheduledConsent2 aValidOBWriteInternationalScheduledConsent2() {
+        return (new OBWriteInternationalScheduledConsent2())
+                .data(aValidOBWriteDataInternationalScheduledConsent2())
+                .risk(new OBRisk1());
+    }
+
+    public static OBWriteInternationalScheduledConsent4 aValidOBWriteInternationalScheduledConsent4() {
+        return (new OBWriteInternationalScheduledConsent4())
+                .data(aValidOBWriteInternationalScheduledConsent4Data())
+                .risk(new OBRisk1());
+    }
+
+    public static OBWriteDataInternationalScheduledConsent1 aValidOBWriteDataInternationalScheduledConsent1() {
+        return (new OBWriteDataInternationalScheduledConsent1())
+                .permission(OBExternalPermissions2Code.CREATE)
+                .initiation(aValidOBInternationalScheduled1())
+                .authorisation(aValidOBAuthorisation1());
+    }
+
+    public static OBWriteDataInternationalScheduledConsent2 aValidOBWriteDataInternationalScheduledConsent2() {
+        return (new OBWriteDataInternationalScheduledConsent2())
+                .permission(OBExternalPermissions2Code.CREATE)
+                .initiation(aValidOBInternationalScheduled2())
+                .authorisation(aValidOBAuthorisation1());
+    }
+
+    public static OBWriteInternationalScheduledConsent4Data aValidOBWriteInternationalScheduledConsent4Data() {
+        return (new OBWriteInternationalScheduledConsent4Data())
+                .permission(PermissionEnum.CREATE)
+                .initiation(aValidOBWriteInternationalScheduled3DataInitiation())
+                .authorisation(aValidOBWriteDomesticConsent3DataAuthorisation())
+                .scASupportData(new OBWriteDomesticConsent3DataSCASupportData());
+    }
+
+    public static OBWriteInternationalScheduled3DataInitiation aValidOBWriteInternationalScheduled3DataInitiation() {
+        return (new OBWriteInternationalScheduled3DataInitiation())
+                .instructionIdentification("ANSM020")
+                .endToEndIdentification("FRESCO.21302.GFX.01")
+                .localInstrument("UK.OBIE.BACS")
+                .instructionPriority(OBWriteInternationalScheduled3DataInitiation.InstructionPriorityEnum.URGENT)
+                .purpose("CDCD")
+                .extendedPurpose("Extended purpose")
+                .chargeBearer(OBChargeBearerType1Code.SHARED)
+                .currencyOfTransfer("USD")
+                .destinationCountryCode("GB")
+                .instructedAmount(aValidOBWriteDomestic2DataInitiationInstructedAmount())
+                .exchangeRateInformation(aValidOBWriteInternational3DataInitiationExchangeRateInformation())
+                .debtorAccount(aValidOBWriteDomestic2DataInitiationDebtorAccount())
+                .creditor(aValidOBWriteInternational3DataInitiationCreditor())
+                .creditorAgent(aValidOBWriteInternational3DataInitiationCreditorAgent())
+                .creditorAccount(aValidOBWriteDomestic2DataInitiationCreditorAccount())
+                .remittanceInformation(aValidOBWriteDomestic2DataInitiationRemittanceInformation())
+                .supplementaryData(new OBSupplementaryData1());
+    }
+
+    public static OBInternationalScheduled1 aValidOBInternationalScheduled1() {
+        return (new OBInternationalScheduled1())
+                .instructionIdentification("ANSM020")
+                .endToEndIdentification("FRESCO.21302.GFX.01")
+                .localInstrument("UK.OBIE.BACS")
+                .instructionPriority(OBPriority2Code.URGENT)
+                .purpose("CDCD")
+                .chargeBearer(OBChargeBearerType1Code.SHARED)
+                .currencyOfTransfer("USD")
+                .instructedAmount(aValidOBActiveOrHistoricCurrencyAndAmount())
+                .exchangeRateInformation(aValidOBExchangeRate1())
+                .debtorAccount(aValidOBCashAccount3())
+                .creditor(aValidOBPartyIdentification43())
+                .creditorAgent(aValidOBBranchAndFinancialInstitutionIdentification3())
+                .creditorAccount(aValidOBCashAccount3())
+                .remittanceInformation(aValidOBRemittanceInformation1());
+    }
+
+    public static OBInternationalScheduled2 aValidOBInternationalScheduled2() {
+        return (new OBInternationalScheduled2())
+                .instructionIdentification("ANSM020")
+                .endToEndIdentification("FRESCO.21302.GFX.01")
+                .localInstrument("UK.OBIE.BACS")
+                .instructionPriority(OBPriority2Code.URGENT)
+                .purpose("CDCD")
+                .chargeBearer(OBChargeBearerType1Code.SHARED)
+                .requestedExecutionDateTime(DateTime.now())
+                .currencyOfTransfer("USD")
+                .instructedAmount(aValidOBActiveOrHistoricCurrencyAndAmount())
+                .exchangeRateInformation(aValidOBExchangeRate1())
+                .debtorAccount(aValidOBCashAccount3())
+                .creditor(aValidOBPartyIdentification43())
+                .creditorAgent(aValidOBBranchAndFinancialInstitutionIdentification3())
+                .creditorAccount(aValidOBCashAccount3())
+                .remittanceInformation(aValidOBRemittanceInformation1())
+                .supplementaryData(new OBSupplementaryData1());
+    }
+}

--- a/src/test/java/uk/org/openbanking/testsupport/payment/OBWriteInternationalStandingOrderConsentTestDataFactory.java
+++ b/src/test/java/uk/org/openbanking/testsupport/payment/OBWriteInternationalStandingOrderConsentTestDataFactory.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.testsupport.payment;
+
+import org.joda.time.DateTime;
+import uk.org.openbanking.datamodel.payment.*;
+
+import static uk.org.openbanking.testsupport.payment.OBAccountTestDataFactory.aValidOBCashAccount3;
+import static uk.org.openbanking.testsupport.payment.OBAccountTestDataFactory.aValidOBCashAccountCreditor3;
+import static uk.org.openbanking.testsupport.payment.OBAccountTestDataFactory.aValidOBCashAccountDebtor4;
+import static uk.org.openbanking.testsupport.payment.OBAmountTestDataFactory.aValidOBActiveOrHistoricCurrencyAndAmount;
+import static uk.org.openbanking.testsupport.payment.OBAmountTestDataFactory.aValidOBDomestic2InstructedAmount;
+import static uk.org.openbanking.testsupport.payment.OBConsentAuthorisationTestDataFactory.aValidOBAuthorisation1;
+import static uk.org.openbanking.testsupport.payment.OBInternationalIdentifierTestDataFactory.aValidOBBranchAndFinancialInstitutionIdentification3;
+import static uk.org.openbanking.testsupport.payment.OBInternationalIdentifierTestDataFactory.aValidOBBranchAndFinancialInstitutionIdentification6;
+import static uk.org.openbanking.testsupport.payment.OBInternationalIdentifierTestDataFactory.aValidOBPartyIdentification43;
+
+/**
+ * Test data factory for the various "OBWriteInternationalStandingOrderConsent" classes.
+ */
+public class OBWriteInternationalStandingOrderConsentTestDataFactory {
+
+    public static OBWriteInternationalStandingOrderConsent2 aValidOBWriteInternationalStandingOrderConsent2() {
+        return (new OBWriteInternationalStandingOrderConsent2())
+                .data(aValidOBWriteDataInternationalStandingOrderConsent2())
+                .risk(new OBRisk1());
+    }
+
+    public static OBWriteInternationalStandingOrderConsent3 aValidOBWriteInternationalStandingOrderConsent3() {
+        return (new OBWriteInternationalStandingOrderConsent3())
+                .data(aValidOBWriteDataInternationalStandingOrderConsent3())
+                .risk(new OBRisk1());
+    }
+
+    public static OBWriteDataInternationalStandingOrderConsent2 aValidOBWriteDataInternationalStandingOrderConsent2() {
+        return (new OBWriteDataInternationalStandingOrderConsent2())
+                .permission(OBExternalPermissions2Code.CREATE)
+                .initiation(aValidOBInternationalStandingOrder2())
+                .authorisation(aValidOBAuthorisation1());
+    }
+
+    public static OBWriteDataInternationalStandingOrderConsent3 aValidOBWriteDataInternationalStandingOrderConsent3() {
+        return (new OBWriteDataInternationalStandingOrderConsent3())
+                .permission(OBExternalPermissions2Code.CREATE)
+                .initiation(aValidOBInternationalStandingOrder3())
+                .authorisation(aValidOBAuthorisation1());
+    }
+
+    public static OBInternationalStandingOrder2 aValidOBInternationalStandingOrder2() {
+        DateTime now = DateTime.now();
+        return (new OBInternationalStandingOrder2())
+                .frequency("EvryWorkgDay")
+                .reference("Ipsum Non Arcu Inc.")
+                .numberOfPayments("1")
+                .firstPaymentDateTime(now)
+                .finalPaymentDateTime(now)
+                .purpose("CDCD")
+                .chargeBearer(OBChargeBearerType1Code.SHARED)
+                .currencyOfTransfer("USD")
+                .instructedAmount(aValidOBActiveOrHistoricCurrencyAndAmount())
+                .debtorAccount(aValidOBCashAccount3())
+                .creditor(aValidOBPartyIdentification43())
+                .creditorAgent(aValidOBBranchAndFinancialInstitutionIdentification3())
+                .creditorAccount(aValidOBCashAccount3())
+                .supplementaryData(new OBSupplementaryData1());
+    }
+
+    private static OBInternationalStandingOrder3 aValidOBInternationalStandingOrder3() {
+        DateTime now = DateTime.now();
+        return (new OBInternationalStandingOrder3())
+                .frequency("EvryWorkgDay")
+                .reference("Ipsum Non Arcu Inc.")
+                .numberOfPayments("1")
+                .firstPaymentDateTime(now)
+                .finalPaymentDateTime(now)
+                .purpose("CDCD")
+                .chargeBearer(OBChargeBearerType1Code.SHARED)
+                .currencyOfTransfer("USD")
+                .instructedAmount(aValidOBDomestic2InstructedAmount())
+                .debtorAccount(aValidOBCashAccountDebtor4())
+                .creditor(aValidOBPartyIdentification43())
+                .creditorAgent(aValidOBBranchAndFinancialInstitutionIdentification6())
+                .creditorAccount(aValidOBCashAccountCreditor3())
+                .supplementaryData(new OBSupplementaryData1());
+    }
+}


### PR DESCRIPTION
This PR introduces the following:

- Converters for v3.x payment related OB objects.
- Test data factories to construct instances of the payment OB objects.

Note that the test data factories are particularly useful in other repos (for example within `openbanking-aspsp` or `ob-functional-tests`). For example, instead of constructing a `OBDomesticConsent3` object in various places (which is repetitive and vulnerable to change), you can now simply have:

`OBWriteDomesticConsent3 obWriteDomesticConsent3 = aValidOBWriteDomesticConsent3();`

Of course it is possible to add other methods within the test data factories - such as `anInvalidOBWriteDomesticConsent3()` (e.g. that's missing a mandatory field) to facilitate testing.