### PR TITLE
Fixed potential NullPointerExceptions within enum conversions (#272)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <parent>
         <groupId>com.forgerock.openbanking</groupId>
         <artifactId>forgerock-openbanking-starter-parent</artifactId>
-        <version>1.0.75</version>
+        <version>1.0.76</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
     

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBExchangeRateConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBExchangeRateConverter.java
@@ -50,7 +50,7 @@ public class OBExchangeRateConverter {
         return calculatedExchangeRate == null ? null : (new OBExchangeRate2())
                 .unitCurrency(calculatedExchangeRate.getUnitCurrency())
                 .exchangeRate(calculatedExchangeRate.getExchangeRate())
-                .rateType(OBExchangeRateType2Code.valueOf(calculatedExchangeRate.getRateType().name()))
+                .rateType(toOBExchangeRateType2Code(calculatedExchangeRate.getRateType()))
                 .contractIdentification(calculatedExchangeRate.getContractIdentification())
                 .expirationDateTime(calculatedExchangeRate.getExpirationDateTime());
     }
@@ -62,12 +62,11 @@ public class OBExchangeRateConverter {
                 .rateType(toRateTypeEnum(exchangeRateInformation.getRateType()))
                 .contractIdentification(exchangeRateInformation.getContractIdentification());
     }
-
     public static OBWriteInternationalConsentResponse4DataExchangeRateInformation toOBWriteInternationalConsentResponse4DataExchangeRateInformation(OBWriteInternationalConsentResponse6DataExchangeRateInformation calculatedExchangeRate) {
         return calculatedExchangeRate == null ? null : (new OBWriteInternationalConsentResponse4DataExchangeRateInformation())
                 .unitCurrency(calculatedExchangeRate.getUnitCurrency())
                 .exchangeRate(calculatedExchangeRate.getExchangeRate())
-                .rateType(OBWriteInternationalConsentResponse4DataExchangeRateInformation.RateTypeEnum.valueOf(calculatedExchangeRate.getRateType().name()))
+                .rateType(toRateTypeEnum(calculatedExchangeRate.getRateType()))
                 .contractIdentification(calculatedExchangeRate.getContractIdentification())
                 .expirationDateTime(calculatedExchangeRate.getExpirationDateTime());
     }
@@ -76,11 +75,19 @@ public class OBExchangeRateConverter {
         return rateType == null ? null : OBWriteInternational3DataInitiationExchangeRateInformation.RateTypeEnum.valueOf(rateType.name());
     }
 
+    public static OBWriteInternationalConsentResponse4DataExchangeRateInformation.RateTypeEnum toRateTypeEnum(OBWriteInternationalConsentResponse6DataExchangeRateInformation.RateTypeEnum rateType) {
+        return rateType == null ? null : OBWriteInternationalConsentResponse4DataExchangeRateInformation.RateTypeEnum.valueOf(rateType.name());
+    }
+
     public static OBExchangeRateType2Code toOBExchangeRateType2Code(OBWriteInternational3DataInitiationExchangeRateInformation.RateTypeEnum rateType) {
         return rateType == null ? null : OBExchangeRateType2Code.valueOf(rateType.name());
     }
 
     public static OBExchangeRateType2Code toOBExchangeRateType2Code(OBWriteInternationalConsentResponse4DataExchangeRateInformation.RateTypeEnum rateType) {
+        return rateType == null ? null : OBExchangeRateType2Code.valueOf(rateType.name());
+    }
+
+    public static OBExchangeRateType2Code toOBExchangeRateType2Code(OBWriteInternationalConsentResponse6DataExchangeRateInformation.RateTypeEnum rateType) {
         return rateType == null ? null : OBExchangeRateType2Code.valueOf(rateType.name());
     }
 }

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBInternationalConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBInternationalConverter.java
@@ -123,7 +123,7 @@ public class OBInternationalConverter {
                 .instructionIdentification(initiation.getInstructionIdentification())
                 .endToEndIdentification(initiation.getEndToEndIdentification())
                 .localInstrument(initiation.getLocalInstrument())
-                .instructionPriority(OBWriteInternational3DataInitiation.InstructionPriorityEnum.valueOf(initiation.getInstructionPriority().name()))
+                .instructionPriority(toOBWriteInternational3DataInitiationInstructionPriorityEnum(initiation.getInstructionPriority()))
                 .purpose(initiation.getPurpose())
                 .extendedPurpose(null)
                 .chargeBearer(initiation.getChargeBearer())

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteDomesticConsentConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteDomesticConsentConverter.java
@@ -131,17 +131,33 @@ public class OBWriteDomesticConsentConverter {
                 .initiation(toOBDomestic2(data.getInitiation()));
     }
 
-    public static OBWriteDomesticConsent4DataSCASupportData toOBWriteDomesticConsent4DataSCASupportData(OBWriteDomesticConsent3DataSCASupportData scASupportData) {
-        return scASupportData == null ? null : (new OBWriteDomesticConsent4DataSCASupportData())
-                .requestedSCAExemptionType(OBWriteDomesticConsent4DataSCASupportData.RequestedSCAExemptionTypeEnum.valueOf(scASupportData.getRequestedSCAExemptionType().name()))
-                .appliedAuthenticationApproach(OBWriteDomesticConsent4DataSCASupportData.AppliedAuthenticationApproachEnum.valueOf(scASupportData.getAppliedAuthenticationApproach().name()))
+    public static OBWriteDomesticConsent3DataSCASupportData toOBWriteDomesticConsent3DataSCASupportData(OBWriteDomesticConsent4DataSCASupportData scASupportData) {
+        return scASupportData == null ? null : (new OBWriteDomesticConsent3DataSCASupportData())
+                .requestedSCAExemptionType(toRequestedSCAExemptionType(scASupportData.getRequestedSCAExemptionType()))
+                .appliedAuthenticationApproach(toAppliedAuthenticationApproach(scASupportData.getAppliedAuthenticationApproach()))
                 .referencePaymentOrderId(scASupportData.getReferencePaymentOrderId());
     }
 
-    public static OBWriteDomesticConsent3DataSCASupportData toOBWriteDomesticConsent3DataSCASupportData(OBWriteDomesticConsent4DataSCASupportData scASupportData) {
-        return scASupportData == null ? null : (new OBWriteDomesticConsent3DataSCASupportData())
-                .requestedSCAExemptionType(OBWriteDomesticConsent3DataSCASupportData.RequestedSCAExemptionTypeEnum.valueOf(scASupportData.getRequestedSCAExemptionType().name()))
-                .appliedAuthenticationApproach(OBWriteDomesticConsent3DataSCASupportData.AppliedAuthenticationApproachEnum.valueOf(scASupportData.getAppliedAuthenticationApproach().name()))
+    public static OBWriteDomesticConsent4DataSCASupportData toOBWriteDomesticConsent4DataSCASupportData(OBWriteDomesticConsent3DataSCASupportData scASupportData) {
+        return scASupportData == null ? null : (new OBWriteDomesticConsent4DataSCASupportData())
+                .requestedSCAExemptionType(toRequestedSCAExemptionType(scASupportData.getRequestedSCAExemptionType()))
+                .appliedAuthenticationApproach(toAppliedAuthenticationApproach(scASupportData.getAppliedAuthenticationApproach()))
                 .referencePaymentOrderId(scASupportData.getReferencePaymentOrderId());
+    }
+
+    public static OBWriteDomesticConsent3DataSCASupportData.RequestedSCAExemptionTypeEnum toRequestedSCAExemptionType(OBWriteDomesticConsent4DataSCASupportData.RequestedSCAExemptionTypeEnum requestedSCAExemptionType) {
+        return requestedSCAExemptionType == null ? null : OBWriteDomesticConsent3DataSCASupportData.RequestedSCAExemptionTypeEnum.valueOf(requestedSCAExemptionType.name());
+    }
+
+    public static OBWriteDomesticConsent4DataSCASupportData.RequestedSCAExemptionTypeEnum toRequestedSCAExemptionType(OBWriteDomesticConsent3DataSCASupportData.RequestedSCAExemptionTypeEnum requestedSCAExemptionType) {
+        return requestedSCAExemptionType == null ? null : OBWriteDomesticConsent4DataSCASupportData.RequestedSCAExemptionTypeEnum.valueOf(requestedSCAExemptionType.name());
+    }
+
+    public static OBWriteDomesticConsent3DataSCASupportData.AppliedAuthenticationApproachEnum toAppliedAuthenticationApproach(OBWriteDomesticConsent4DataSCASupportData.AppliedAuthenticationApproachEnum appliedAuthenticationApproach) {
+        return appliedAuthenticationApproach == null ? null : OBWriteDomesticConsent3DataSCASupportData.AppliedAuthenticationApproachEnum.valueOf(appliedAuthenticationApproach.name());
+    }
+
+    public static OBWriteDomesticConsent4DataSCASupportData.AppliedAuthenticationApproachEnum toAppliedAuthenticationApproach(OBWriteDomesticConsent3DataSCASupportData.AppliedAuthenticationApproachEnum appliedAuthenticationApproach) {
+        return appliedAuthenticationApproach == null ? null : OBWriteDomesticConsent4DataSCASupportData.AppliedAuthenticationApproachEnum.valueOf(appliedAuthenticationApproach.name());
     }
 }

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteDomesticScheduledConsentConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteDomesticScheduledConsentConverter.java
@@ -21,7 +21,6 @@
 package uk.org.openbanking.datamodel.service.converter.payment;
 
 import uk.org.openbanking.datamodel.payment.*;
-import uk.org.openbanking.datamodel.payment.OBWriteDomesticScheduledConsent3Data.PermissionEnum;
 
 import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBAuthorisation1;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBConsentAuthorisationConverter.toOBWriteDomesticConsent3DataAuthorisation;
@@ -88,35 +87,35 @@ public class OBWriteDomesticScheduledConsentConverter {
 
     public static OBWriteDataDomesticScheduledConsent1 toOBWriteDataDomesticScheduledConsent1(OBWriteDataDomesticScheduledConsent2 data) {
         return data == null ? null : (new OBWriteDataDomesticScheduledConsent1())
-                .permission(OBExternalPermissions2Code.valueOf(data.getPermission().name()))
+                .permission(data.getPermission())
                 .initiation(toOBDomesticScheduled1(data.getInitiation()))
                 .authorisation(data.getAuthorisation());
     }
 
     public static OBWriteDataDomesticScheduledConsent1 toOBWriteDataDomesticScheduledConsent1(OBWriteDomesticScheduledConsent3Data data) {
         return data == null ? null : (new OBWriteDataDomesticScheduledConsent1())
-                .permission(OBExternalPermissions2Code.valueOf(data.getPermission().name()))
+                .permission(toOBExternalPermissions2Code(data.getPermission()))
                 .initiation(toOBDomesticScheduled1(data.getInitiation()))
                 .authorisation(toOBAuthorisation1(data.getAuthorisation()));
     }
 
     public static OBWriteDataDomesticScheduledConsent1 toOBWriteDataDomesticScheduledConsent1(OBWriteDomesticScheduledConsent4Data data) {
         return data == null ? null : (new OBWriteDataDomesticScheduledConsent1())
-                .permission(OBExternalPermissions2Code.valueOf(data.getPermission().name()))
+                .permission(toOBExternalPermissions2Code(data.getPermission()))
                 .initiation(toOBDomesticScheduled1(data.getInitiation()))
                 .authorisation(toOBAuthorisation1(data.getAuthorisation()));
     }
 
     public static OBWriteDataDomesticScheduledConsent2 toOBWriteDataDomesticScheduledConsent2(OBWriteDataDomesticScheduledConsent1 data) {
         return data == null ? null : (new OBWriteDataDomesticScheduledConsent2())
-                .permission(OBExternalPermissions2Code.valueOf(data.getPermission().name()))
+                .permission(data.getPermission())
                 .initiation(toOBDomesticScheduled2(data.getInitiation()))
                 .authorisation(data.getAuthorisation());
     }
 
     public static OBWriteDomesticScheduledConsent3Data toOBWriteDomesticScheduledConsent3Data(OBWriteDataDomesticScheduledConsent1 data) {
         return data == null ? null : (new OBWriteDomesticScheduledConsent3Data())
-                .permission(OBWriteDomesticScheduledConsent3Data.PermissionEnum.valueOf(data.getPermission().name()))
+                .permission(toOBWriteDomesticScheduledConsent3DataPermission(data.getPermission()))
                 .initiation(toOBWriteDomesticScheduled2DataInitiation(data.getInitiation()))
                 .authorisation(toOBWriteDomesticConsent3DataAuthorisation(data.getAuthorisation()))
                 .scASupportData(null);
@@ -124,7 +123,7 @@ public class OBWriteDomesticScheduledConsentConverter {
 
     public static OBWriteDomesticScheduledConsent4Data toOBWriteDomesticScheduledConsent4Data(OBWriteDataDomesticScheduledConsent1 data) {
         return data == null ? null : (new OBWriteDomesticScheduledConsent4Data())
-                .permission(OBWriteDomesticScheduledConsent4Data.PermissionEnum.valueOf(data.getPermission().name()))
+                .permission(toOBWriteDomesticScheduledConsent4DataPermission(data.getPermission()))
                 .readRefundAccount(null)
                 .initiation(toOBWriteDomesticScheduled2DataInitiation(data.getInitiation()))
                 .authorisation(toOBWriteDomesticConsent4DataAuthorisation(data.getAuthorisation()))
@@ -133,7 +132,7 @@ public class OBWriteDomesticScheduledConsentConverter {
 
     public static OBWriteDomesticScheduledConsent4Data toOBWriteDomesticScheduledConsent4Data(OBWriteDataDomesticScheduledConsent2 data) {
         return data == null ? null : (new OBWriteDomesticScheduledConsent4Data())
-                .permission(OBWriteDomesticScheduledConsent4Data.PermissionEnum.valueOf(data.getPermission().name()))
+                .permission(toOBWriteDomesticScheduledConsent4DataPermission(data.getPermission()))
                 .readRefundAccount(null)
                 .initiation(toOBWriteDomesticScheduled2DataInitiation(data.getInitiation()))
                 .authorisation(toOBWriteDomesticConsent4DataAuthorisation(data.getAuthorisation()))
@@ -142,7 +141,7 @@ public class OBWriteDomesticScheduledConsentConverter {
 
     public static OBWriteDomesticScheduledConsent3Data toOBWriteDomesticScheduledConsent3Data(OBWriteDataDomesticScheduledConsent2 data) {
         return data == null ? null : (new OBWriteDomesticScheduledConsent3Data())
-                .permission(toPermissionEnum(data))
+                .permission(toOBWriteDomesticScheduledConsent3DataPermission(data.getPermission()))
                 .initiation(toOBWriteDomesticScheduled2DataInitiation(data.getInitiation()))
                 .authorisation(toOBWriteDomesticConsent3DataAuthorisation(data.getAuthorisation()));
     }
@@ -153,8 +152,20 @@ public class OBWriteDomesticScheduledConsentConverter {
                 .initiation(toOBDomesticScheduled2(data.getInitiation()));
     }
 
-    public static PermissionEnum toPermissionEnum(OBWriteDataDomesticScheduledConsent2 data) {
-        return data.getPermission() == null ? null : PermissionEnum.valueOf(data.getPermission().name());
+    public static OBExternalPermissions2Code toOBExternalPermissions2Code(OBWriteDomesticScheduledConsent3Data.PermissionEnum permission) {
+        return permission == null ? null : OBExternalPermissions2Code.valueOf(permission.name());
+    }
+
+    private static OBExternalPermissions2Code toOBExternalPermissions2Code(OBWriteDomesticScheduledConsent4Data.PermissionEnum permission) {
+        return permission == null ? null : OBExternalPermissions2Code.valueOf(permission.name());
+    }
+
+    public static OBWriteDomesticScheduledConsent3Data.PermissionEnum toOBWriteDomesticScheduledConsent3DataPermission(OBExternalPermissions2Code permission) {
+        return permission == null ? null : OBWriteDomesticScheduledConsent3Data.PermissionEnum.valueOf(permission.name());
+    }
+
+    public static OBWriteDomesticScheduledConsent4Data.PermissionEnum toOBWriteDomesticScheduledConsent4DataPermission(OBExternalPermissions2Code permission) {
+        return permission == null ? null : OBWriteDomesticScheduledConsent4Data.PermissionEnum.valueOf(permission.name());
     }
 
 }

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteDomesticStandingOrderConsentConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteDomesticStandingOrderConsentConverter.java
@@ -181,14 +181,14 @@ public class OBWriteDomesticStandingOrderConsentConverter {
 
     public static OBWriteDataDomesticStandingOrderConsent1 toOBWriteDataDomesticStandingOrderConsent1(OBWriteDomesticStandingOrderConsent5Data data) {
         return data == null ? null : (new OBWriteDataDomesticStandingOrderConsent1())
-                .permission(OBExternalPermissions2Code.valueOf(data.getPermission().name()))
+                .permission(toOBExternalPermissions2Code(data.getPermission()))
                 .initiation(toOBDomesticStandingOrder1(data.getInitiation()))
                 .authorisation(toOBAuthorisation1(data.getAuthorisation()));
     }
 
     public static OBWriteDataDomesticStandingOrderConsent2 toOBWriteDataDomesticStandingOrderConsent2(OBWriteDomesticStandingOrderConsent5Data data) {
         return data == null ? null : (new OBWriteDataDomesticStandingOrderConsent2())
-                .permission(OBExternalPermissions2Code.valueOf(data.getPermission().name()))
+                .permission(toOBExternalPermissions2Code(data.getPermission()))
                 .initiation(toOBDomesticStandingOrder2(data.getInitiation()))
                 .authorisation(toOBAuthorisation1(data.getAuthorisation()));
     }
@@ -223,14 +223,14 @@ public class OBWriteDomesticStandingOrderConsentConverter {
 
     public static OBWriteDataDomesticStandingOrderConsent3 toOBWriteDataDomesticStandingOrderConsent3(OBWriteDomesticStandingOrderConsent4Data data) {
         return data == null ? null : (new OBWriteDataDomesticStandingOrderConsent3())
-                .permission(toOBExternalPermissions2Code(data))
+                .permission(toOBExternalPermissions2Code(data.getPermission()))
                 .initiation(toOBDomesticStandingOrder3(data.getInitiation()))
                 .authorisation(toOBAuthorisation1(data.getAuthorisation()));
     }
 
     public static OBWriteDomesticScheduledConsent4Data toOBWriteDomesticScheduledConsent4Data(OBWriteDomesticScheduledConsent3Data data) {
         return data == null ? null : (new OBWriteDomesticScheduledConsent4Data())
-                .permission(OBWriteDomesticScheduledConsent4Data.PermissionEnum.valueOf(data.getPermission().name()))
+                .permission(toOBWriteDomesticScheduledConsent4DataPermission(data.getPermission()))
                 .readRefundAccount(null)
                 .initiation(data.getInitiation())
                 .authorisation(toOBWriteDomesticConsent4DataAuthorisation(data.getAuthorisation()))
@@ -239,7 +239,7 @@ public class OBWriteDomesticStandingOrderConsentConverter {
 
     public static OBWriteDomesticStandingOrderConsent5Data toOBWriteDomesticStandingOrderConsent5Data(OBWriteDataDomesticStandingOrderConsent1 data) {
         return data == null ? null : (new OBWriteDomesticStandingOrderConsent5Data())
-                .permission(OBWriteDomesticStandingOrderConsent5Data.PermissionEnum.valueOf(data.getPermission().name()))
+                .permission(toOBWriteDomesticScheduledConsent5DataPermission(data.getPermission()))
                 .readRefundAccount(null)
                 .initiation(toOBWriteDomesticStandingOrder3DataInitiation(data.getInitiation()))
                 .authorisation(toOBWriteDomesticConsent4DataAuthorisation(data.getAuthorisation()))
@@ -248,7 +248,7 @@ public class OBWriteDomesticStandingOrderConsentConverter {
 
     public static OBWriteDomesticStandingOrderConsent5Data toOBWriteDomesticStandingOrderConsent5Data(OBWriteDataDomesticStandingOrderConsent2 data) {
         return data == null ? null : (new OBWriteDomesticStandingOrderConsent5Data())
-                .permission(OBWriteDomesticStandingOrderConsent5Data.PermissionEnum.valueOf(data.getPermission().name()))
+                .permission(toOBWriteDomesticScheduledConsent5DataPermission(data.getPermission()))
                 .readRefundAccount(null)
                 .initiation(toOBWriteDomesticStandingOrder3DataInitiation(data.getInitiation()))
                 .authorisation(toOBWriteDomesticConsent4DataAuthorisation(data.getAuthorisation()))
@@ -257,7 +257,7 @@ public class OBWriteDomesticStandingOrderConsentConverter {
 
     public static OBWriteDomesticStandingOrderConsent5Data toOBWriteDomesticStandingOrderConsent5Data(OBWriteDataDomesticStandingOrderConsent3 data) {
         return data == null ? null : (new OBWriteDomesticStandingOrderConsent5Data())
-                .permission(OBWriteDomesticStandingOrderConsent5Data.PermissionEnum.valueOf(data.getPermission().name()))
+                .permission(toOBWriteDomesticScheduledConsent5DataPermission(data.getPermission()))
                 .readRefundAccount(null)
                 .initiation(toOBWriteDomesticStandingOrder3DataInitiation(data.getInitiation()))
                 .authorisation(toOBWriteDomesticConsent4DataAuthorisation(data.getAuthorisation()))
@@ -266,14 +266,30 @@ public class OBWriteDomesticStandingOrderConsentConverter {
 
     public static OBWriteDomesticStandingOrderConsent5Data toOBWriteDomesticStandingOrderConsent5Data(OBWriteDomesticStandingOrderConsent4Data data) {
         return data == null ? null : (new OBWriteDomesticStandingOrderConsent5Data())
-                .permission(OBWriteDomesticStandingOrderConsent5Data.PermissionEnum.valueOf(data.getPermission().name()))
+                .permission(toOBWriteDomesticScheduledConsent5DataPermission(data.getPermission()))
                 .readRefundAccount(null)
                 .initiation(data.getInitiation())
                 .authorisation(toOBWriteDomesticConsent4DataAuthorisation(data.getAuthorisation()))
                 .scASupportData(toOBWriteDomesticConsent4DataSCASupportData(data.getScASupportData()));
     }
 
-    public static OBExternalPermissions2Code toOBExternalPermissions2Code(OBWriteDomesticStandingOrderConsent4Data data) {
-        return data.getPermission() == null ? null : OBExternalPermissions2Code.valueOf(data.getPermission().name());
+    public static OBExternalPermissions2Code toOBExternalPermissions2Code(OBWriteDomesticStandingOrderConsent4Data.PermissionEnum permission) {
+        return permission == null ? null : OBExternalPermissions2Code.valueOf(permission.name());
+    }
+
+    public static OBExternalPermissions2Code toOBExternalPermissions2Code(OBWriteDomesticStandingOrderConsent5Data.PermissionEnum permission) {
+        return permission == null ? null : OBExternalPermissions2Code.valueOf(permission.name());
+    }
+
+    public static OBWriteDomesticScheduledConsent4Data.PermissionEnum toOBWriteDomesticScheduledConsent4DataPermission(OBWriteDomesticScheduledConsent3Data.PermissionEnum permission) {
+        return permission == null ? null : OBWriteDomesticScheduledConsent4Data.PermissionEnum.valueOf(permission.name());
+    }
+
+    public static OBWriteDomesticStandingOrderConsent5Data.PermissionEnum toOBWriteDomesticScheduledConsent5DataPermission(OBExternalPermissions2Code permission) {
+        return permission == null ? null : OBWriteDomesticStandingOrderConsent5Data.PermissionEnum.valueOf(permission.name());
+    }
+
+    public static OBWriteDomesticStandingOrderConsent5Data.PermissionEnum toOBWriteDomesticScheduledConsent5DataPermission(OBWriteDomesticStandingOrderConsent4Data.PermissionEnum permission) {
+        return permission == null ? null : OBWriteDomesticStandingOrderConsent5Data.PermissionEnum.valueOf(permission.name());
     }
 }

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteInternationalScheduledConsentConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteInternationalScheduledConsentConverter.java
@@ -126,7 +126,7 @@ public class OBWriteInternationalScheduledConsentConverter {
 
     public static OBWriteDataInternationalScheduledConsent1 toOBWriteDataInternationalScheduledConsent1(OBWriteInternationalScheduledConsent5Data data) {
         return data == null ? null : (new OBWriteDataInternationalScheduledConsent1())
-                .permission(OBExternalPermissions2Code.valueOf(data.getPermission().name()))
+                .permission(toOBExternalPermissions2Code(data.getPermission()))
                 .initiation(toOBInternationalScheduled1(data.getInitiation()))
                 .authorisation(toOBAuthorisation1(data.getAuthorisation()));
     }
@@ -140,7 +140,7 @@ public class OBWriteInternationalScheduledConsentConverter {
 
     public static OBWriteInternationalScheduledConsent4Data toOBWriteInternationalScheduledConsent4Data(OBWriteDataInternationalScheduledConsent1 data) {
         return data == null ? null : (new OBWriteInternationalScheduledConsent4Data())
-                .permission(toPermissionEnum(data.getPermission()))
+                .permission(toOBWriteInternationalScheduledConsent4DataPermission(data.getPermission()))
                 .initiation(toOBWriteInternationalScheduled3DataInitiation(data.getInitiation()))
                 .authorisation(toOBWriteDomesticConsent3DataAuthorisation(data.getAuthorisation()))
                 .scASupportData(null);
@@ -148,7 +148,7 @@ public class OBWriteInternationalScheduledConsentConverter {
 
     public static OBWriteInternationalScheduledConsent4Data toOBWriteInternationalScheduledConsent4Data(OBWriteDataInternationalScheduledConsent2 data) {
         return data == null ? null : (new OBWriteInternationalScheduledConsent4Data())
-                .permission(toPermissionEnum(data.getPermission()))
+                .permission(toOBWriteInternationalScheduledConsent4DataPermission(data.getPermission()))
                 .initiation(toOBWriteInternationalScheduled3DataInitiation(data.getInitiation()))
                 .authorisation(toOBWriteDomesticConsent3DataAuthorisation(data.getAuthorisation()))
                 .scASupportData(null);
@@ -156,7 +156,7 @@ public class OBWriteInternationalScheduledConsentConverter {
 
     public static OBWriteInternationalScheduledConsent5Data toOBWriteInternationalScheduledConsent5Data(OBWriteDataInternationalScheduledConsent1 data) {
         return data == null ? null : (new OBWriteInternationalScheduledConsent5Data())
-                .permission(OBWriteInternationalScheduledConsent5Data.PermissionEnum.valueOf(data.getPermission().name()))
+                .permission(toOBWriteInternationalScheduledConsent5DataPermission(data.getPermission()))
                 .readRefundAccount(null)
                 .initiation(toOBWriteInternationalScheduled3DataInitiation(data.getInitiation()))
                 .authorisation(toOBWriteDomesticConsent4DataAuthorisation(data.getAuthorisation()))
@@ -165,7 +165,7 @@ public class OBWriteInternationalScheduledConsentConverter {
 
     public static OBWriteInternationalScheduledConsent5Data toOBWriteInternationalScheduledConsent5Data(OBWriteDataInternationalScheduledConsent2 data) {
         return data == null ? null : (new OBWriteInternationalScheduledConsent5Data())
-                .permission(OBWriteInternationalScheduledConsent5Data.PermissionEnum.valueOf(data.getPermission().name()))
+                .permission(toOBWriteInternationalScheduledConsent5DataPermission(data.getPermission()))
                 .readRefundAccount(null)
                 .initiation(toOBWriteInternationalScheduled3DataInitiation(data.getInitiation()))
                 .authorisation(toOBWriteDomesticConsent4DataAuthorisation(data.getAuthorisation()))
@@ -174,15 +174,11 @@ public class OBWriteInternationalScheduledConsentConverter {
 
     public static OBWriteInternationalScheduledConsent5Data toOBWriteInternationalScheduledConsent5Data(OBWriteInternationalScheduledConsent4Data data) {
         return data == null ? null : (new OBWriteInternationalScheduledConsent5Data())
-                .permission(OBWriteInternationalScheduledConsent5Data.PermissionEnum.valueOf(data.getPermission().name()))
+                .permission(toOBWriteInternationalScheduledConsent5DataPermission(data.getPermission()))
                 .readRefundAccount(null)
                 .initiation(data.getInitiation())
                 .authorisation(toOBWriteDomesticConsent4DataAuthorisation(data.getAuthorisation()))
                 .scASupportData(toOBWriteDomesticConsent4DataSCASupportData(data.getScASupportData()));
-    }
-
-    public static OBWriteInternationalScheduledConsent4Data.PermissionEnum toPermissionEnum(OBExternalPermissions2Code permission) {
-        return permission == null ? null : OBWriteInternationalScheduledConsent4Data.PermissionEnum.valueOf(permission.name());
     }
 
     public static OBExternalPermissions2Code toOBExternalPermissions2Code(OBWriteInternationalScheduledConsent4Data.PermissionEnum permission) {
@@ -191,5 +187,17 @@ public class OBWriteInternationalScheduledConsentConverter {
 
     public static OBExternalPermissions2Code toOBExternalPermissions2Code(OBWriteInternationalScheduledConsent5Data.PermissionEnum permission) {
         return permission == null ? null : OBExternalPermissions2Code.valueOf(permission.name());
+    }
+
+    public static OBWriteInternationalScheduledConsent4Data.PermissionEnum toOBWriteInternationalScheduledConsent4DataPermission(OBExternalPermissions2Code permission) {
+        return permission == null ? null : OBWriteInternationalScheduledConsent4Data.PermissionEnum.valueOf(permission.name());
+    }
+
+    public static OBWriteInternationalScheduledConsent5Data.PermissionEnum toOBWriteInternationalScheduledConsent5DataPermission(OBExternalPermissions2Code permission) {
+        return permission == null ? null : OBWriteInternationalScheduledConsent5Data.PermissionEnum.valueOf(permission.name());
+    }
+
+    public static OBWriteInternationalScheduledConsent5Data.PermissionEnum toOBWriteInternationalScheduledConsent5DataPermission(OBWriteInternationalScheduledConsent4Data.PermissionEnum permission) {
+        return permission == null ? null : OBWriteInternationalScheduledConsent5Data.PermissionEnum.valueOf(permission.name());
     }
 }

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteInternationalStandingOrderConsentConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteInternationalStandingOrderConsentConverter.java
@@ -177,7 +177,7 @@ public class OBWriteInternationalStandingOrderConsentConverter {
 
     public static OBWriteInternationalStandingOrderConsent5Data toOBWriteInternationalStandingOrderConsent5Data(OBWriteDataInternationalStandingOrderConsent1 data) {
         return data == null ? null : (new OBWriteInternationalStandingOrderConsent5Data())
-                .permission(OBWriteInternationalStandingOrderConsent5Data.PermissionEnum.valueOf(data.getPermission().name()))
+                .permission(toOBWriteInternationalStandingOrderConsent5DataPermission(data.getPermission()))
                 .initiation(toOBWriteInternationalStandingOrder4DataInitiation(data.getInitiation()))
                 .authorisation(toOBWriteDomesticConsent3DataAuthorisation(data.getAuthorisation()))
                 .scASupportData(null);
@@ -185,21 +185,21 @@ public class OBWriteInternationalStandingOrderConsentConverter {
 
     public static OBWriteInternationalStandingOrderConsent5Data toOBWriteInternationalStandingOrderConsent5Data(OBWriteDataInternationalStandingOrderConsent2 data) {
         return data == null ? null : (new OBWriteInternationalStandingOrderConsent5Data())
-                .permission(toPermissionEnum(data.getPermission()))
+                .permission(toOBWriteInternationalStandingOrderConsent5DataPermission(data.getPermission()))
                 .initiation(toOBWriteInternationalStandingOrder4DataInitiation(data.getInitiation()))
                 .authorisation(toOBWriteDomesticConsent3DataAuthorisation(data.getAuthorisation()));
     }
 
     public static OBWriteInternationalStandingOrderConsent5Data toOBWriteInternationalStandingOrderConsent5Data(OBWriteDataInternationalStandingOrderConsent3 data) {
         return data == null ? null : (new OBWriteInternationalStandingOrderConsent5Data())
-                .permission(toPermissionEnum(data.getPermission()))
+                .permission(toOBWriteInternationalStandingOrderConsent5DataPermission(data.getPermission()))
                 .initiation(toOBWriteInternationalStandingOrder4DataInitiation(data.getInitiation()))
                 .authorisation(toOBWriteDomesticConsent3DataAuthorisation(data.getAuthorisation()));
     }
 
     public static OBWriteInternationalStandingOrderConsent6Data toOBWriteInternationalStandingOrderConsent6Data(OBWriteDataInternationalStandingOrderConsent1 data) {
         return data == null ? null : (new OBWriteInternationalStandingOrderConsent6Data())
-                .permission(OBWriteInternationalStandingOrderConsent6Data.PermissionEnum.valueOf(data.getPermission().name()))
+                .permission(toOBWriteInternationalStandingOrderConsent6DataPermission(data.getPermission()))
                 .readRefundAccount(null)
                 .initiation(toOBWriteInternationalStandingOrder4DataInitiation(data.getInitiation()))
                 .authorisation(toOBWriteDomesticConsent4DataAuthorisation(data.getAuthorisation()))
@@ -208,7 +208,7 @@ public class OBWriteInternationalStandingOrderConsentConverter {
 
     public static OBWriteInternationalStandingOrderConsent6Data toOBWriteInternationalStandingOrderConsent6Data(OBWriteDataInternationalStandingOrderConsent2 data) {
         return data == null ? null : (new OBWriteInternationalStandingOrderConsent6Data())
-                .permission(OBWriteInternationalStandingOrderConsent6Data.PermissionEnum.valueOf(data.getPermission().name()))
+                .permission(toOBWriteInternationalStandingOrderConsent6DataPermission(data.getPermission()))
                 .readRefundAccount(null)
                 .initiation(toOBWriteInternationalStandingOrder4DataInitiation(data.getInitiation()))
                 .authorisation(toOBWriteDomesticConsent4DataAuthorisation(data.getAuthorisation()))
@@ -217,7 +217,7 @@ public class OBWriteInternationalStandingOrderConsentConverter {
 
     public static OBWriteInternationalStandingOrderConsent6Data toOBWriteInternationalStandingOrderConsent6Data(OBWriteDataInternationalStandingOrderConsent3 data) {
         return data == null ? null : (new OBWriteInternationalStandingOrderConsent6Data())
-                .permission(OBWriteInternationalStandingOrderConsent6Data.PermissionEnum.valueOf(data.getPermission().name()))
+                .permission(toOBWriteInternationalStandingOrderConsent6DataPermission(data.getPermission()))
                 .readRefundAccount(null)
                 .initiation(toOBWriteInternationalStandingOrder4DataInitiation(data.getInitiation()))
                 .authorisation(toOBWriteDomesticConsent4DataAuthorisation(data.getAuthorisation()))
@@ -226,15 +226,11 @@ public class OBWriteInternationalStandingOrderConsentConverter {
 
     public static OBWriteInternationalStandingOrderConsent6Data toOBWriteInternationalStandingOrderConsent6Data(OBWriteInternationalStandingOrderConsent5Data data) {
         return data == null ? null : (new OBWriteInternationalStandingOrderConsent6Data())
-                .permission(OBWriteInternationalStandingOrderConsent6Data.PermissionEnum.valueOf(data.getPermission().name()))
+                .permission(toOBWriteInternationalStandingOrderConsent6DataPermission(data.getPermission()))
                 .readRefundAccount(null)
                 .initiation(data.getInitiation())
                 .authorisation(toOBWriteDomesticConsent4DataAuthorisation(data.getAuthorisation()))
                 .scASupportData(toOBWriteDomesticConsent4DataSCASupportData(data.getScASupportData()));
-    }
-
-    public static PermissionEnum toPermissionEnum(OBExternalPermissions2Code permission) {
-        return permission == null ? null : PermissionEnum.valueOf(permission.name());
     }
 
     public static OBExternalPermissions2Code toOBExternalPermissions2Code(PermissionEnum permission) {
@@ -243,5 +239,17 @@ public class OBWriteInternationalStandingOrderConsentConverter {
 
     public static OBExternalPermissions2Code toOBExternalPermissions2Code(OBWriteInternationalStandingOrderConsent6Data.PermissionEnum permission) {
         return permission == null ? null : OBExternalPermissions2Code.valueOf(permission.name());
+    }
+
+    public static OBWriteInternationalStandingOrderConsent5Data.PermissionEnum toOBWriteInternationalStandingOrderConsent5DataPermission(OBExternalPermissions2Code permission) {
+        return permission == null ? null : OBWriteInternationalStandingOrderConsent5Data.PermissionEnum.valueOf(permission.name());
+    }
+
+    public static OBWriteInternationalStandingOrderConsent6Data.PermissionEnum toOBWriteInternationalStandingOrderConsent6DataPermission(OBExternalPermissions2Code permission) {
+        return permission == null ? null : OBWriteInternationalStandingOrderConsent6Data.PermissionEnum.valueOf(permission.name());
+    }
+
+    public static OBWriteInternationalStandingOrderConsent6Data.PermissionEnum toOBWriteInternationalStandingOrderConsent6DataPermission(OBWriteInternationalStandingOrderConsent5Data.PermissionEnum permission) {
+        return permission == null ? null : OBWriteInternationalStandingOrderConsent6Data.PermissionEnum.valueOf(permission.name());
     }
 }


### PR DESCRIPTION
Now ensuring the original (source) enums are not null before conversion.