### PR TITLE
Added a basic attempt to determine country code

### DIFF
--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/CountryCodeHelper.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/CountryCodeHelper.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.datamodel.service.converter.payment;
+
+import static uk.org.openbanking.datamodel.account.OBExternalAccountIdentification4Code.IBAN;
+
+/**
+ * This class makes a crude attempt to determine the destination country code. If an IBAN is used as the creditor's account identifier, then the country code prefix is used.
+ * Otherwise "GB" is used as a default value.
+ *
+ * <p>
+ * This is to populate the corresponding value in the various OB international "data initiation" objects, which became mandatory in v3.1.3 of the API (i.e. this is to avoid a
+ * validation error). The actual value is not so important, as it won't be returned from earlier values of the API and will be correctly populated when a customer starts using
+ * v3.1.3 onwards.
+ * </p>
+ */
+public class CountryCodeHelper {
+
+    private static final String DEFAULT_COUNTRY_CODE = "GB";
+
+    public static String determineCountryCode(String schemeName, String identification) {
+        String countryCode = DEFAULT_COUNTRY_CODE;
+        if (isIbanScheme(schemeName) && hasCountryCodePrefix(identification)) {
+            countryCode = identification.substring(0, 2);
+        }
+        return countryCode;
+    }
+
+    private static boolean isIbanScheme(String schemeName) {
+        return IBAN.toString().equals(schemeName);
+    }
+
+    private static boolean hasCountryCodePrefix(String identification) {
+        return identification.length() > 2 && isAlpha(identification.substring(0, 2)); // a very crude test! It doesn't actually matter if it's not a valid country code
+    }
+
+    private static boolean isAlpha(String value) {
+        return value.matches("[a-zA-Z]+");
+    }
+}

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBInternationalConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBInternationalConverter.java
@@ -20,10 +20,12 @@
  */
 package uk.org.openbanking.datamodel.service.converter.payment;
 
+import uk.org.openbanking.datamodel.account.OBCashAccount3;
 import uk.org.openbanking.datamodel.payment.OBInternational1;
 import uk.org.openbanking.datamodel.payment.OBInternational2;
 import uk.org.openbanking.datamodel.payment.OBWriteInternational3DataInitiation;
 
+import static uk.org.openbanking.datamodel.service.converter.payment.CountryCodeHelper.determineCountryCode;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBCashAccount3;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBWriteDomestic2DataInitiationCreditorAccount;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBWriteDomestic2DataInitiationDebtorAccount;
@@ -41,8 +43,6 @@ import static uk.org.openbanking.datamodel.service.converter.payment.OBRemittanc
 import static uk.org.openbanking.datamodel.service.converter.payment.OBRemittanceInformationConverter.toOBWriteDomestic2DataInitiationRemittanceInformation;
 
 public class OBInternationalConverter {
-
-    private static String DEFAULT_COUNTRY_CODE = "GB";
 
     public static OBInternational1 toOBInternational1(OBInternational2 obInternational2) {
         return obInternational2 == null ? null : (new OBInternational1())
@@ -119,6 +119,7 @@ public class OBInternationalConverter {
     }
 
     public static OBWriteInternational3DataInitiation toOBWriteInternational3DataInitiation(OBInternational1 initiation) {
+        OBCashAccount3 creditorAccount = initiation.getCreditorAccount();
         return initiation == null ? null : (new OBWriteInternational3DataInitiation())
                 .instructionIdentification(initiation.getInstructionIdentification())
                 .endToEndIdentification(initiation.getEndToEndIdentification())
@@ -128,7 +129,28 @@ public class OBInternationalConverter {
                 .extendedPurpose(null)
                 .chargeBearer(initiation.getChargeBearer())
                 .currencyOfTransfer(initiation.getCurrencyOfTransfer())
-                .destinationCountryCode(DEFAULT_COUNTRY_CODE) // to prevent validation error
+                .destinationCountryCode(determineCountryCode(creditorAccount.getSchemeName(), creditorAccount.getIdentification())) // to prevent validation error
+                .instructedAmount(toOBWriteDomestic2DataInitiationInstructedAmount(initiation.getInstructedAmount()))
+                .exchangeRateInformation(toOBWriteInternational3DataInitiationExchangeRateInformation(initiation.getExchangeRateInformation()))
+                .debtorAccount(toOBWriteDomestic2DataInitiationDebtorAccount(initiation.getDebtorAccount()))
+                .creditor(toOBWriteInternational3DataInitiationCreditor(initiation.getCreditor()))
+                .creditorAgent(toOBWriteInternational3DataInitiationCreditorAgent(initiation.getCreditorAgent()))
+                .creditorAccount(toOBWriteDomestic2DataInitiationCreditorAccount(creditorAccount))
+                .remittanceInformation(toOBWriteDomestic2DataInitiationRemittanceInformation(initiation.getRemittanceInformation()))
+                .supplementaryData(null);
+    }
+
+    public static OBWriteInternational3DataInitiation toOBWriteInternational3DataInitiation(OBInternational2 initiation) {
+        OBCashAccount3 creditorAccount = initiation.getCreditorAccount();
+        return initiation == null ? null : (new OBWriteInternational3DataInitiation())
+                .instructionIdentification(initiation.getInstructionIdentification())
+                .endToEndIdentification(initiation.getEndToEndIdentification())
+                .localInstrument(initiation.getLocalInstrument())
+                .instructionPriority(toOBWriteInternational3DataInitiationInstructionPriorityEnum(initiation.getInstructionPriority()))
+                .purpose(initiation.getPurpose())
+                .chargeBearer(initiation.getChargeBearer())
+                .currencyOfTransfer(initiation.getCurrencyOfTransfer())
+                .destinationCountryCode(determineCountryCode(creditorAccount.getSchemeName(), creditorAccount.getIdentification())) // to prevent validation error
                 .instructedAmount(toOBWriteDomestic2DataInitiationInstructedAmount(initiation.getInstructedAmount()))
                 .exchangeRateInformation(toOBWriteInternational3DataInitiationExchangeRateInformation(initiation.getExchangeRateInformation()))
                 .debtorAccount(toOBWriteDomestic2DataInitiationDebtorAccount(initiation.getDebtorAccount()))
@@ -136,26 +158,6 @@ public class OBInternationalConverter {
                 .creditorAgent(toOBWriteInternational3DataInitiationCreditorAgent(initiation.getCreditorAgent()))
                 .creditorAccount(toOBWriteDomestic2DataInitiationCreditorAccount(initiation.getCreditorAccount()))
                 .remittanceInformation(toOBWriteDomestic2DataInitiationRemittanceInformation(initiation.getRemittanceInformation()))
-                .supplementaryData(null);
-    }
-
-    public static OBWriteInternational3DataInitiation toOBWriteInternational3DataInitiation(OBInternational2 obInternational2) {
-        return obInternational2 == null ? null : (new OBWriteInternational3DataInitiation())
-                .instructionIdentification(obInternational2.getInstructionIdentification())
-                .endToEndIdentification(obInternational2.getEndToEndIdentification())
-                .localInstrument(obInternational2.getLocalInstrument())
-                .instructionPriority(toOBWriteInternational3DataInitiationInstructionPriorityEnum(obInternational2.getInstructionPriority()))
-                .purpose(obInternational2.getPurpose())
-                .chargeBearer(obInternational2.getChargeBearer())
-                .currencyOfTransfer(obInternational2.getCurrencyOfTransfer())
-                .destinationCountryCode(DEFAULT_COUNTRY_CODE) // to prevent validation error
-                .instructedAmount(toOBWriteDomestic2DataInitiationInstructedAmount(obInternational2.getInstructedAmount()))
-                .exchangeRateInformation(toOBWriteInternational3DataInitiationExchangeRateInformation(obInternational2.getExchangeRateInformation()))
-                .debtorAccount(toOBWriteDomestic2DataInitiationDebtorAccount(obInternational2.getDebtorAccount()))
-                .creditor(toOBWriteInternational3DataInitiationCreditor(obInternational2.getCreditor()))
-                .creditorAgent(toOBWriteInternational3DataInitiationCreditorAgent(obInternational2.getCreditorAgent()))
-                .creditorAccount(toOBWriteDomestic2DataInitiationCreditorAccount(obInternational2.getCreditorAccount()))
-                .remittanceInformation(toOBWriteDomestic2DataInitiationRemittanceInformation(obInternational2.getRemittanceInformation()))
-                .supplementaryData(obInternational2.getSupplementaryData());
+                .supplementaryData(initiation.getSupplementaryData());
     }
 }

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBInternationalScheduledConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBInternationalScheduledConverter.java
@@ -20,10 +20,12 @@
  */
 package uk.org.openbanking.datamodel.service.converter.payment;
 
+import uk.org.openbanking.datamodel.account.OBCashAccount3;
 import uk.org.openbanking.datamodel.payment.OBInternationalScheduled1;
 import uk.org.openbanking.datamodel.payment.OBInternationalScheduled2;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalScheduled3DataInitiation;
 
+import static uk.org.openbanking.datamodel.service.converter.payment.CountryCodeHelper.determineCountryCode;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBCashAccount3;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBWriteDomestic2DataInitiationCreditorAccount;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBWriteDomestic2DataInitiationDebtorAccount;
@@ -41,8 +43,6 @@ import static uk.org.openbanking.datamodel.service.converter.payment.OBRemittanc
 import static uk.org.openbanking.datamodel.service.converter.payment.OBRemittanceInformationConverter.toOBWriteDomestic2DataInitiationRemittanceInformation;
 
 public class OBInternationalScheduledConverter {
-
-    private static String DEFAULT_COUNTRY_CODE = "GB";
 
     public static OBInternationalScheduled1 toOBInternationalScheduled1(OBInternationalScheduled2 obInternationalScheduled2) {
         return obInternationalScheduled2 == null ? null : (new OBInternationalScheduled1())
@@ -123,6 +123,7 @@ public class OBInternationalScheduledConverter {
     }
 
     public static OBWriteInternationalScheduled3DataInitiation toOBWriteInternationalScheduled3DataInitiation(OBInternationalScheduled1 obInternationalScheduled1) {
+        OBCashAccount3 creditorAccount = obInternationalScheduled1.getCreditorAccount();
         return obInternationalScheduled1 == null ? null : (new OBWriteInternationalScheduled3DataInitiation())
                 .instructionIdentification(obInternationalScheduled1.getInstructionIdentification())
                 .endToEndIdentification(obInternationalScheduled1.getEndToEndIdentification())
@@ -132,18 +133,19 @@ public class OBInternationalScheduledConverter {
                 .chargeBearer(obInternationalScheduled1.getChargeBearer())
                 .requestedExecutionDateTime(obInternationalScheduled1.getRequestedExecutionDateTime())
                 .currencyOfTransfer(obInternationalScheduled1.getCurrencyOfTransfer())
-                .destinationCountryCode(DEFAULT_COUNTRY_CODE) // to prevent validation error
+                .destinationCountryCode(determineCountryCode(creditorAccount.getSchemeName(), creditorAccount.getIdentification())) // to prevent validation error
                 .instructedAmount(toOBWriteDomestic2DataInitiationInstructedAmount(obInternationalScheduled1.getInstructedAmount()))
                 .exchangeRateInformation(toOBWriteInternational3DataInitiationExchangeRateInformation(obInternationalScheduled1.getExchangeRateInformation()))
                 .debtorAccount(toOBWriteDomestic2DataInitiationDebtorAccount(obInternationalScheduled1.getDebtorAccount()))
                 .creditor(toOBWriteInternational3DataInitiationCreditor(obInternationalScheduled1.getCreditor()))
                 .creditorAgent(toOBWriteInternational3DataInitiationCreditorAgent(obInternationalScheduled1.getCreditorAgent()))
-                .creditorAccount(toOBWriteDomestic2DataInitiationCreditorAccount(obInternationalScheduled1.getCreditorAccount()))
+                .creditorAccount(toOBWriteDomestic2DataInitiationCreditorAccount(creditorAccount))
                 .remittanceInformation(toOBWriteDomestic2DataInitiationRemittanceInformation(obInternationalScheduled1.getRemittanceInformation()))
                 .supplementaryData(null);
     }
 
     public static OBWriteInternationalScheduled3DataInitiation toOBWriteInternationalScheduled3DataInitiation(OBInternationalScheduled2 obInternationalScheduled2) {
+        OBCashAccount3 creditorAccount = obInternationalScheduled2.getCreditorAccount();
         return obInternationalScheduled2 == null ? null : (new OBWriteInternationalScheduled3DataInitiation())
                 .instructionIdentification(obInternationalScheduled2.getInstructionIdentification())
                 .endToEndIdentification(obInternationalScheduled2.getEndToEndIdentification())
@@ -153,13 +155,13 @@ public class OBInternationalScheduledConverter {
                 .chargeBearer(obInternationalScheduled2.getChargeBearer())
                 .requestedExecutionDateTime(obInternationalScheduled2.getRequestedExecutionDateTime())
                 .currencyOfTransfer(obInternationalScheduled2.getCurrencyOfTransfer())
-                .destinationCountryCode(DEFAULT_COUNTRY_CODE) // to prevent validation error
+                .destinationCountryCode(determineCountryCode(creditorAccount.getSchemeName(), creditorAccount.getIdentification())) // to prevent validation error
                 .instructedAmount(toOBWriteDomestic2DataInitiationInstructedAmount(obInternationalScheduled2.getInstructedAmount()))
                 .exchangeRateInformation(toOBWriteInternational3DataInitiationExchangeRateInformation(obInternationalScheduled2.getExchangeRateInformation()))
                 .debtorAccount(toOBWriteDomestic2DataInitiationDebtorAccount(obInternationalScheduled2.getDebtorAccount()))
                 .creditor(toOBWriteInternational3DataInitiationCreditor(obInternationalScheduled2.getCreditor()))
                 .creditorAgent(toOBWriteInternational3DataInitiationCreditorAgent(obInternationalScheduled2.getCreditorAgent()))
-                .creditorAccount(toOBWriteDomestic2DataInitiationCreditorAccount(obInternationalScheduled2.getCreditorAccount()))
+                .creditorAccount(toOBWriteDomestic2DataInitiationCreditorAccount(creditorAccount))
                 .remittanceInformation(toOBWriteDomestic2DataInitiationRemittanceInformation(obInternationalScheduled2.getRemittanceInformation()))
                 .supplementaryData(obInternationalScheduled2.getSupplementaryData());
     }

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBInternationalStandingOrderConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBInternationalStandingOrderConverter.java
@@ -20,11 +20,14 @@
  */
 package uk.org.openbanking.datamodel.service.converter.payment;
 
+import uk.org.openbanking.datamodel.account.OBCashAccount3;
+import uk.org.openbanking.datamodel.payment.OBCashAccountCreditor3;
 import uk.org.openbanking.datamodel.payment.OBInternationalStandingOrder1;
 import uk.org.openbanking.datamodel.payment.OBInternationalStandingOrder2;
 import uk.org.openbanking.datamodel.payment.OBInternationalStandingOrder3;
 import uk.org.openbanking.datamodel.payment.OBWriteInternationalStandingOrder4DataInitiation;
 
+import static uk.org.openbanking.datamodel.service.converter.payment.CountryCodeHelper.determineCountryCode;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBCashAccount3;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBCashAccountCreditor3;
 import static uk.org.openbanking.datamodel.service.converter.payment.OBAccountConverter.toOBCashAccountDebtor4;
@@ -40,8 +43,6 @@ import static uk.org.openbanking.datamodel.service.converter.payment.OBInternati
 import static uk.org.openbanking.datamodel.service.converter.payment.OBInternationalIdentifierConverter.toOBWriteInternationalStandingOrder4DataInitiationCreditorAgent;
 
 public class OBInternationalStandingOrderConverter {
-
-    private static String DEFAULT_COUNTRY_CODE = "GB";
 
     public static OBInternationalStandingOrder1 toOBInternationalStandingOrder1(OBInternationalStandingOrder2 obInternationalStandingOrder2) {
         return (new OBInternationalStandingOrder1())
@@ -203,6 +204,7 @@ public class OBInternationalStandingOrderConverter {
     }
 
     public static OBWriteInternationalStandingOrder4DataInitiation toOBWriteInternationalStandingOrder4DataInitiation(OBInternationalStandingOrder1 obInternationalStandingOrder1) {
+        OBCashAccount3 creditorAccount = obInternationalStandingOrder1.getCreditorAccount();
         return obInternationalStandingOrder1 == null ? null : (new OBWriteInternationalStandingOrder4DataInitiation())
                 .frequency(obInternationalStandingOrder1.getFrequency())
                 .reference(obInternationalStandingOrder1.getReference())
@@ -213,16 +215,17 @@ public class OBInternationalStandingOrderConverter {
                 .extendedPurpose(null)
                 .chargeBearer(obInternationalStandingOrder1.getChargeBearer())
                 .currencyOfTransfer(obInternationalStandingOrder1.getCurrencyOfTransfer())
-                .destinationCountryCode(DEFAULT_COUNTRY_CODE) // to prevent validation error
+                .destinationCountryCode(determineCountryCode(creditorAccount.getSchemeName(), creditorAccount.getIdentification())) // to prevent validation error
                 .instructedAmount(toOBWriteDomestic2DataInitiationInstructedAmount(obInternationalStandingOrder1.getInstructedAmount()))
                 .debtorAccount(toOBWriteDomesticStandingOrder3DataInitiationDebtorAccount(obInternationalStandingOrder1.getDebtorAccount()))
                 .creditor(toOBWriteInternational3DataInitiationCreditor(obInternationalStandingOrder1.getCreditor()))
                 .creditorAgent(toOBWriteInternationalStandingOrder4DataInitiationCreditorAgent(obInternationalStandingOrder1.getCreditorAgent()))
-                .creditorAccount(toOBWriteInternationalStandingOrder4DataInitiationCreditorAccount(obInternationalStandingOrder1.getCreditorAccount()))
+                .creditorAccount(toOBWriteInternationalStandingOrder4DataInitiationCreditorAccount(creditorAccount))
                 .supplementaryData(null);
     }
 
     public static OBWriteInternationalStandingOrder4DataInitiation toOBWriteInternationalStandingOrder4DataInitiation(OBInternationalStandingOrder2 obInternationalStandingOrder2) {
+        OBCashAccount3 creditorAccount = obInternationalStandingOrder2.getCreditorAccount();
         return obInternationalStandingOrder2 == null ? null : (new OBWriteInternationalStandingOrder4DataInitiation())
                 .frequency(obInternationalStandingOrder2.getFrequency())
                 .reference(obInternationalStandingOrder2.getReference())
@@ -232,17 +235,18 @@ public class OBInternationalStandingOrderConverter {
                 .purpose(obInternationalStandingOrder2.getPurpose())
                 .chargeBearer(obInternationalStandingOrder2.getChargeBearer())
                 .currencyOfTransfer(obInternationalStandingOrder2.getCurrencyOfTransfer())
-                .destinationCountryCode(DEFAULT_COUNTRY_CODE) // to prevent validation error
+                .destinationCountryCode(determineCountryCode(creditorAccount.getSchemeName(), creditorAccount.getIdentification())) // to prevent validation error
                 .instructedAmount(toOBWriteDomestic2DataInitiationInstructedAmount(obInternationalStandingOrder2.getInstructedAmount()))
                 .debtorAccount(toOBWriteDomesticStandingOrder3DataInitiationDebtorAccount(obInternationalStandingOrder2.getDebtorAccount()))
                 .creditor(toOBWriteInternational3DataInitiationCreditor(obInternationalStandingOrder2.getCreditor()))
                 .creditorAgent(OBInternationalIdentifierConverter.toOBWriteInternationalStandingOrder4DataInitiationCreditorAgent(obInternationalStandingOrder2.getCreditorAgent()))
-                .creditorAccount(toOBWriteInternationalStandingOrder4DataInitiationCreditorAccount(obInternationalStandingOrder2.getCreditorAccount()))
+                .creditorAccount(toOBWriteInternationalStandingOrder4DataInitiationCreditorAccount(creditorAccount))
                 .supplementaryData(obInternationalStandingOrder2.getSupplementaryData());
     }
 
 
     public static OBWriteInternationalStandingOrder4DataInitiation toOBWriteInternationalStandingOrder4DataInitiation(OBInternationalStandingOrder3 obInternationalStandingOrder3) {
+        OBCashAccountCreditor3 creditorAccount = obInternationalStandingOrder3.getCreditorAccount();
         return obInternationalStandingOrder3 == null ? null : (new OBWriteInternationalStandingOrder4DataInitiation())
                 .frequency(obInternationalStandingOrder3.getFrequency())
                 .reference(obInternationalStandingOrder3.getReference())
@@ -252,12 +256,13 @@ public class OBInternationalStandingOrderConverter {
                 .purpose(obInternationalStandingOrder3.getPurpose())
                 .chargeBearer(obInternationalStandingOrder3.getChargeBearer())
                 .currencyOfTransfer(obInternationalStandingOrder3.getCurrencyOfTransfer())
-                .destinationCountryCode(DEFAULT_COUNTRY_CODE) // to prevent validation error
+                .destinationCountryCode(determineCountryCode(creditorAccount.getSchemeName(), creditorAccount.getIdentification())) // to prevent validation error
                 .instructedAmount(toOBWriteDomestic2DataInitiationInstructedAmount(obInternationalStandingOrder3.getInstructedAmount()))
                 .debtorAccount(toOBWriteDomesticStandingOrder3DataInitiationDebtorAccount(obInternationalStandingOrder3.getDebtorAccount()))
                 .creditor(toOBWriteInternational3DataInitiationCreditor(obInternationalStandingOrder3.getCreditor()))
                 .creditorAgent(OBInternationalIdentifierConverter.toOBWriteInternationalStandingOrder4DataInitiationCreditorAgent(obInternationalStandingOrder3.getCreditorAgent()))
-                .creditorAccount(toOBWriteInternationalStandingOrder4DataInitiationCreditorAccount(obInternationalStandingOrder3.getCreditorAccount()))
+                .creditorAccount(toOBWriteInternationalStandingOrder4DataInitiationCreditorAccount(creditorAccount))
                 .supplementaryData(obInternationalStandingOrder3.getSupplementaryData());
     }
+
 }

--- a/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteDomesticConsentConverter.java
+++ b/src/main/java/uk/org/openbanking/datamodel/service/converter/payment/OBWriteDomesticConsentConverter.java
@@ -54,6 +54,12 @@ public class OBWriteDomesticConsentConverter {
                 .risk(obWriteDomesticConsent3.getRisk());
     }
 
+    public static OBWriteDomesticConsent2 toOBWriteDomesticConsent2(OBWriteDomesticConsent4 obWriteDomesticConsent4) {
+        return (new OBWriteDomesticConsent2())
+                .data(toOBWriteDataDomesticConsent2(obWriteDomesticConsent4.getData()))
+                .risk(obWriteDomesticConsent4.getRisk());
+    }
+
     public static OBWriteDomesticConsent4 toOBWriteDomesticConsent4(OBWriteDomesticConsent1 obWriteDomesticConsent1) {
         return (new OBWriteDomesticConsent4())
                 .data(toOBWriteDomesticConsent4Data(obWriteDomesticConsent1.getData()))
@@ -94,6 +100,12 @@ public class OBWriteDomesticConsentConverter {
         return data == null ? null : (new OBWriteDataDomesticConsent2())
                 .initiation(toOBDomestic2(data.getInitiation()))
                 .authorisation(data.getAuthorisation());
+    }
+
+    public static OBWriteDataDomesticConsent2 toOBWriteDataDomesticConsent2(OBWriteDomesticConsent4Data data) {
+        return data == null ? null : (new OBWriteDataDomesticConsent2())
+                .initiation(toOBDomestic2(data.getInitiation()))
+                .authorisation(toOBAuthorisation1(data.getAuthorisation()));
     }
 
     public static OBWriteDomesticConsent4Data toOBWriteDomesticConsent4Data(OBWriteDataDomesticConsent2 data) {

--- a/src/test/java/uk/org/openbanking/datamodel/service/converter/payment/CountryCodeHelperTest.java
+++ b/src/test/java/uk/org/openbanking/datamodel/service/converter/payment/CountryCodeHelperTest.java
@@ -1,0 +1,97 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.datamodel.service.converter.payment;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static uk.org.openbanking.datamodel.account.OBExternalAccountIdentification4Code.IBAN;
+import static uk.org.openbanking.datamodel.account.OBExternalAccountIdentification4Code.SORTCODEACCOUNTNUMBER;
+
+public class CountryCodeHelperTest {
+
+    private static final String DEFAULT_COUNTRY_CODE = "GB";
+
+    @Test
+    public void shouldUseDefaultCountryCodeGivenSortCodeAndAccountNumber() {
+        // Given
+        String schemeName = SORTCODEACCOUNTNUMBER.toString();
+        String identification = "40400412345678";
+
+        // When
+        String countryCode = CountryCodeHelper.determineCountryCode(schemeName, identification);
+
+        // Then
+        assertThat(countryCode).isEqualTo(DEFAULT_COUNTRY_CODE);
+    }
+
+    @Test
+    public void shouldUseIbanCountryCodeGivenValidIban() {
+        // Given
+        String schemeName = IBAN.toString();
+        String identification = "DE89 3704 0044 0532 0130 00";
+
+        // When
+        String countryCode = CountryCodeHelper.determineCountryCode(schemeName, identification);
+
+        // Then
+        assertThat(countryCode).isEqualTo("DE");
+    }
+
+    @Test
+    public void shouldUseDefaultCountryCodeGivenInvalidIban() {
+        // Given
+        String schemeName = IBAN.toString();
+        String identification = "40400412345678";
+
+        // When
+        String countryCode = CountryCodeHelper.determineCountryCode(schemeName, identification);
+
+        // Then
+        assertThat(countryCode).isEqualTo(DEFAULT_COUNTRY_CODE);
+    }
+
+    @Test
+    public void shouldUseDefaultCountryCodeGivenMissingIban() {
+        // Given
+        String schemeName = IBAN.toString();
+        String identification = "";
+
+        // When
+        String countryCode = CountryCodeHelper.determineCountryCode(schemeName, identification);
+
+        // Then
+        assertThat(countryCode).isEqualTo(DEFAULT_COUNTRY_CODE);
+    }
+
+    @Test
+    public void shouldUseDefaultCountryCodeGivenIbanWithOtherScheme() {
+        // Given
+        String schemeName = SORTCODEACCOUNTNUMBER.toString();
+        String identification = "DE89 3704 0044 0532 0130 00";
+
+        // When
+        String countryCode = CountryCodeHelper.determineCountryCode(schemeName, identification);
+
+        // Then
+        assertThat(countryCode).isEqualTo(DEFAULT_COUNTRY_CODE);
+    }
+}


### PR DESCRIPTION
Added CountryCodeHelper to attempt to resolve the country code when an IBAN is provided (#296)

The destination country code is mandatory in v3.1.3 of the payments API onwards. This means that if a request to save an international payment is made via v3.1.2 or earlier, the country code value must be populated within the corresponding Mongo document. Otherwise, if the payment is retrieved at a later point using v3.1.3 or later of the API, then an error would occur.