### PR TITLE
Release/3.1.2.25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <groupId>com.forgerock.openbanking.uk</groupId>
     <artifactId>openbanking-uk-datamodel</artifactId>
     <packaging>jar</packaging>
-    <version>3.1.2.25-SNAPSHOT</version>
+    <version>3.1.2.25</version>
     <name>openbanking-uk-datamodel</name>
     <description>
         A Java UK Data Model, generated from the swagger, to help implementing the Open Banking standard : https://www.openbanking.org.uk/read-write-apis/
@@ -215,7 +215,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-uk-datamodel.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-uk-datamodel.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-uk-datamodel.git</url>
-        <tag>HEAD</tag>
+        <tag>3.1.2.25</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <groupId>com.forgerock.openbanking.uk</groupId>
     <artifactId>openbanking-uk-datamodel</artifactId>
     <packaging>jar</packaging>
-    <version>3.1.2.24-SNAPSHOT</version>
+    <version>3.1.2.25-SNAPSHOT</version>
     <name>openbanking-uk-datamodel</name>
     <description>
         A Java UK Data Model, generated from the swagger, to help implementing the Open Banking standard : https://www.openbanking.org.uk/read-write-apis/

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <groupId>com.forgerock.openbanking.uk</groupId>
     <artifactId>openbanking-uk-datamodel</artifactId>
     <packaging>jar</packaging>
-    <version>3.1.2.25</version>
+    <version>3.1.2.26-SNAPSHOT</version>
     <name>openbanking-uk-datamodel</name>
     <description>
         A Java UK Data Model, generated from the swagger, to help implementing the Open Banking standard : https://www.openbanking.org.uk/read-write-apis/
@@ -215,7 +215,7 @@
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-uk-datamodel.git</connection>
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-uk-datamodel.git</developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-uk-datamodel.git</url>
-        <tag>3.1.2.25</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>


### PR DESCRIPTION
**Release 3.1.2.25**
- Merge [3.1.2.25 release](https://github.com/OpenBankingToolkit/openbanking-uk-datamodel/releases/tag/3.1.2.25)
- Fix [Issue 16](https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/16)
- Prepare for the next development iteration.