### PR TITLE
Release/3.1.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <groupId>com.forgerock.openbanking.uk</groupId>
     <artifactId>openbanking-uk-datamodel</artifactId>
     <packaging>jar</packaging>
-    <version>3.1.6.0</version>
+    <version>3.1.6.1-SNAPSHOT</version>
     <name>openbanking-uk-datamodel</name>
     <description>
         A Java UK Data Model, generated from the swagger, to help implementing the Open Banking standard :
@@ -187,7 +187,7 @@
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-uk-datamodel.git
         </developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-uk-datamodel.git</url>
-        <tag>3.1.6.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
         <javax.annotations.version>1.3.2</javax.annotations.version>
         <jodatime.version>2.9.9</jodatime.version>
         <javax.validation>2.0.1.Final</javax.validation>
-        <jackson-databind.version>2.9.10.1</jackson-databind.version>
+        <jackson-databind.version>2.9.10.7</jackson-databind.version>
         <assertj.core.version>3.17.2</assertj.core.version>
         <hibernate.validator.version>5.2.4.Final</hibernate.validator.version>
         <javax.el.version>3.0.1-b11</javax.el.version>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <groupId>com.forgerock.openbanking.uk</groupId>
     <artifactId>openbanking-uk-datamodel</artifactId>
     <packaging>jar</packaging>
-    <version>3.1.6.0-SNAPSHOT</version>
+    <version>3.1.6.0</version>
     <name>openbanking-uk-datamodel</name>
     <description>
         A Java UK Data Model, generated from the swagger, to help implementing the Open Banking standard :
@@ -187,7 +187,7 @@
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-uk-datamodel.git
         </developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-uk-datamodel.git</url>
-        <tag>HEAD</tag>
+        <tag>3.1.6.0</tag>
     </scm>
 
     <distributionManagement>


### PR DESCRIPTION
- Release [v3.1.6.0](https://github.com/OpenBankingToolkit/openbanking-uk-datamodel/releases/tag/3.1.6.0) published
- Prepare for the next development iteration `3.1.6.1-SNAPSHOT`