### PR TITLE
16: Add GenericOBDiscoveryAPILinks as subtype of OBDiscoveryAPILinks

### DIFF
--- a/src/main/java/uk/org/openbanking/datamodel/discovery/GenericOBDiscoveryAPILinks.java
+++ b/src/main/java/uk/org/openbanking/datamodel/discovery/GenericOBDiscoveryAPILinks.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.datamodel.discovery;
+
+import java.util.*;
+
+public class GenericOBDiscoveryAPILinks implements OBDiscoveryAPILinks {
+    private Map<String, String> links = new HashMap<>();
+
+    public GenericOBDiscoveryAPILinks() {
+    }
+
+    public GenericOBDiscoveryAPILinks(Map<String, String> links) {
+        this.links = links;
+    }
+
+    public GenericOBDiscoveryAPILinks addLink(String reference, String endpoint) {
+        links.put(reference, endpoint);
+        return this;
+    }
+
+    public Collection<String> getLinkValues() {
+        return new ArrayList(links.values());
+    }
+
+    public Map<String, String> getLinks() {
+        return links;
+    }
+
+    public void setLinks(Map<String, String> links) {
+        this.links = links;
+    }
+
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof GenericOBDiscoveryAPILinks)) return false;
+        GenericOBDiscoveryAPILinks that = (GenericOBDiscoveryAPILinks) o;
+        return Objects.equals(links, that.links);
+    }
+
+    public int hashCode() {
+        return Objects.hash(links);
+    }
+
+    public String toString() {
+        return "GenericOBDiscoveryAPILinks{" +
+                "links='" + links + '\'' +
+                '}';
+    }
+
+    public static GenericOBDiscoveryAPILinks.GenericOBDiscoveryAPILinksBuilder builder() {
+        return new GenericOBDiscoveryAPILinks.GenericOBDiscoveryAPILinksBuilder();
+    }
+
+    public static class GenericOBDiscoveryAPILinksBuilder {
+        private Map<String, String> links;
+
+        public GenericOBDiscoveryAPILinks.GenericOBDiscoveryAPILinksBuilder links(Map<String, String> links) {
+            this.links = links;
+            return this;
+        }
+
+        public GenericOBDiscoveryAPILinks build() {
+            return new GenericOBDiscoveryAPILinks(this.links);
+        }
+    }
+}

--- a/src/main/java/uk/org/openbanking/datamodel/discovery/OBDiscoveryAPILinks.java
+++ b/src/main/java/uk/org/openbanking/datamodel/discovery/OBDiscoveryAPILinks.java
@@ -28,6 +28,7 @@ import io.swagger.annotations.ApiModel;
         use = JsonTypeInfo.Id.NAME
 )
 @JsonSubTypes({
+        @JsonSubTypes.Type(value = GenericOBDiscoveryAPILinks.class, name = "GenericOBDiscoveryAPILinks"),
         @JsonSubTypes.Type(value = OBDiscoveryAPILinksAccount1.class, name = "OBDiscoveryAPILinksAccount1"),
         @JsonSubTypes.Type(value = OBDiscoveryAPILinksAccount2.class, name = "OBDiscoveryAPILinksAccount2"),
         @JsonSubTypes.Type(value = OBDiscoveryAPILinksAccount3.class, name = "OBDiscoveryAPILinksAccount3"),


### PR DESCRIPTION
### Add GenericOBDiscoveryAPILinks as subtype of OBDiscoveryAPILinks

This enables clients of the Discovery API to serialise the Links in the response to `GenericOBDiscoveryAPILinks`:

![image](https://user-images.githubusercontent.com/63234126/112343703-45a2c400-8cbb-11eb-9b9a-24a6a6d35d48.png)

**Issue**: https://github.com/OpenBankingToolkit/openbanking-uk-datamodel/issues/16