### PR TITLE
27: fix datatype of 'risk.deliveryAddress.countrySubDivison`

### DIFF
--- a/src/main/java/uk/org/openbanking/datamodel/payment/OBRisk1DeliveryAddress.java
+++ b/src/main/java/uk/org/openbanking/datamodel/payment/OBRisk1DeliveryAddress.java
@@ -58,8 +58,7 @@ public class OBRisk1DeliveryAddress   {
   private String townName = null;
 
   @JsonProperty("CountrySubDivision")
-  @Valid
-  private List<String> countrySubDivision = null;
+  private String countrySubDivision = null;
 
   @JsonProperty("Country")
   private String country = null;
@@ -173,16 +172,8 @@ public class OBRisk1DeliveryAddress   {
     this.townName = townName;
   }
 
-  public OBRisk1DeliveryAddress countrySubDivision(List<String> countrySubDivision) {
+  public OBRisk1DeliveryAddress countrySubDivision(String countrySubDivision) {
     this.countrySubDivision = countrySubDivision;
-    return this;
-  }
-
-  public OBRisk1DeliveryAddress addCountrySubDivisionItem(String countrySubDivisionItem) {
-    if (this.countrySubDivision == null) {
-      this.countrySubDivision = new ArrayList<String>();
-    }
-    this.countrySubDivision.add(countrySubDivisionItem);
     return this;
   }
 
@@ -192,12 +183,12 @@ public class OBRisk1DeliveryAddress   {
   **/
   @ApiModelProperty(value = "Identifies a subdivision of a country, for instance state, region, county.")
 
-@Size(min=0,max=2) 
-  public List<String> getCountrySubDivision() {
+@Size(min=1,max=35)
+  public String getCountrySubDivision() {
     return countrySubDivision;
   }
 
-  public void setCountrySubDivision(List<String> countrySubDivision) {
+  public void setCountrySubDivision(String countrySubDivision) {
     this.countrySubDivision = countrySubDivision;
   }
 

--- a/src/test/java/uk/org/openbanking/jackson/payment/OBRiskTest.java
+++ b/src/test/java/uk/org/openbanking/jackson/payment/OBRiskTest.java
@@ -67,9 +67,7 @@ public class OBRiskTest {
                 "\"BuildingNumber\":\"27\"," +
                 "\"PostCode\":\"GU31 2ZZ\"," +
                 "\"TownName\":\"Sparsholt\"," +
-                "\"CountrySubDivision\":[" +
-                "\"Wessex\"" +
-                "]," +
+                "\"CountrySubDivision\":\"Wessex\"," +
                 "\"Country\":\"UK\"" +
                 "}" +
                 "}";
@@ -100,9 +98,7 @@ public class OBRiskTest {
                 "\"BuildingNumber\":\"27\"," +
                 "\"PostCode\":\"GU31 2ZZ\"," +
                 "\"TownName\":\"Sparsholt\"," +
-                "\"CountrySubDivision\":[" +
-                "\"Wessex\"" +
-                "]," +
+                "\"CountrySubDivision\":\"Wessex\"," +
                 "\"Country\":\"UK\"" +
                 "}" +
                 "}";
@@ -134,9 +130,7 @@ public class OBRiskTest {
                 "\"BuildingNumber\":\"27\"," +
                 "\"PostCode\":\"GU31 2ZZ\"," +
                 "\"TownName\":\"Sparsholt\"," +
-                "\"CountrySubDivision\":[" +
-                "\"Wessex\"" +
-                "]," +
+                "\"CountrySubDivision\":\"Wessex\"," +
                 "\"Country\":\"UK\"" +
                 "}" +
                 "}";

--- a/src/test/java/uk/org/openbanking/testsupport/payment/OBRisk1TestDataFactory.java
+++ b/src/test/java/uk/org/openbanking/testsupport/payment/OBRisk1TestDataFactory.java
@@ -46,7 +46,7 @@ public class OBRisk1TestDataFactory {
                 .streetName("Queen Square")
                 .townName("Bristol")
                 .country("GB")
-                .countrySubDivision(Collections.singletonList("en"))
+                .countrySubDivision("en")
                 .postCode("BS1 1AA");
     }
 }


### PR DESCRIPTION
- Updated `OBRisk1DeliveryAddress` `countrySubDivision` from List to String
- Updated Tests
- Updated Test Data Factory

Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/27