### PR TITLE
33: Add openapi-generator-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <!-- plugins -->
         <license-maven-plugin.version>3.0</license-maven-plugin.version>
         <maven-release-plugin.version>3.0.0-M1</maven-release-plugin.version>
+        <openapi-generator.version>4.3.1</openapi-generator.version>
     </properties>
 
     <dependencies>
@@ -179,8 +180,55 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.openapitools</groupId>
+                <artifactId>openapi-generator-maven-plugin</artifactId>
+                <version>${openapi-generator.version}</version>
+            </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <!-- Swagger code generation. Note that instructions for this profile are in the README.md and must be kept in sync. -->
+            <id>code-gen</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.openapitools</groupId>
+                        <artifactId>openapi-generator-maven-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>generate</goal>
+                                </goals>
+                                <configuration>
+                                    <!-- Only one input file is supported. Uncomment the relevant spec as required -->
+                                    <inputSpec>${project.basedir}/src/main/resources/specification/account-info-openapi.yaml</inputSpec>
+                                    <!--<inputSpec>${project.basedir}/src/main/resources/specification/confirmation-funds-openapi.yaml</inputSpec>-->
+                                    <!--<inputSpec>${project.basedir}/src/main/resources/specification/event-notifications-openapi.yaml</inputSpec>-->
+                                    <!--<inputSpec>${project.basedir}/src/main/resources/specification/events-openapi.yaml</inputSpec>-->
+                                    <!--<inputSpec>${project.basedir}/src/main/resources/specification/payment-initiation-openapi.yaml</inputSpec>-->
+                                    <!--<inputSpec>${project.basedir}/src/main/resources/specification/vrp-openapi.yaml</inputSpec>-->
+                                    <output>${project.build.directory}/generated-sources/swagger</output>
+                                    <generatorName>spring</generatorName>
+                                    <!-- Change the package here as per the chosen spec above -->
+                                    <modelPackage>
+                                        uk.org.openbanking.datamodel.account
+                                    </modelPackage>
+                                    <generateApis>false</generateApis>
+                                    <configOptions>
+                                        <dateLibrary>joda</dateLibrary>
+                                    </configOptions>
+                                    <addCompileSourceRoot>false</addCompileSourceRoot>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <scm>
         <connection>scm:git:git@github.com:OpenBankingToolkit/openbanking-uk-datamodel.git</connection>

--- a/src/main/resources/specification/account-info-openapi.yaml
+++ b/src/main/resources/specification/account-info-openapi.yaml
@@ -1,0 +1,10014 @@
+openapi: "3.0.0"
+info:
+  title: "Account and Transaction API Specification"
+  description: "Swagger for Account and Transaction API Specification"
+  termsOfService: "https://www.openbanking.org.uk/terms"
+  contact:
+    name: "Service Desk"
+    email: "ServiceDesk@openbanking.org.uk"
+  license:
+    name: "open-licence"
+    url: "https://www.openbanking.org.uk/open-licence"
+  version: "3.1.8"
+paths:
+  /account-access-consents:
+    post:
+      tags:
+        - "Account Access"
+      summary: "Create Account Access Consents"
+      operationId: "CreateAccountAccessConsents"
+      parameters:
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      requestBody:
+        content:
+          application/json; charset=utf-8:
+            schema:
+              $ref: "#/components/schemas/OBReadConsent1"
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OBReadConsent1"
+          application/jose+jwe:
+            schema:
+              $ref: "#/components/schemas/OBReadConsent1"
+        description: "Default"
+        required: true
+      responses:
+        201:
+          $ref: "#/components/responses/201AccountAccessConsentsCreated"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        415:
+          $ref: "#/components/responses/415Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - TPPOAuth2Security:
+            - "accounts"
+  /account-access-consents/{ConsentId}:
+    get:
+      tags:
+        - "Account Access"
+      summary: "Get Account Access Consents"
+      operationId: "GetAccountAccessConsentsConsentId"
+      parameters:
+        - $ref: "#/components/parameters/ConsentId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200AccountAccessConsentsConsentIdRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - TPPOAuth2Security:
+            - "accounts"
+    delete:
+      tags:
+        - "Account Access"
+      summary: "Delete Account Access Consents"
+      operationId: "DeleteAccountAccessConsentsConsentId"
+      parameters:
+        - $ref: "#/components/parameters/ConsentId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        204:
+          $ref: "#/components/responses/204AccountAccessConsentsConsentIdDeleted"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - TPPOAuth2Security:
+            - "accounts"
+  /accounts:
+    get:
+      tags:
+        - "Accounts"
+      summary: "Get Accounts"
+      operationId: "GetAccounts"
+      parameters:
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200AccountsRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - PSUOAuth2Security:
+            - "accounts"
+  /accounts/{AccountId}:
+    get:
+      tags:
+        - "Accounts"
+      summary: "Get Accounts"
+      operationId: "GetAccountsAccountId"
+      parameters:
+        - $ref: "#/components/parameters/AccountId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200AccountsAccountIdRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - PSUOAuth2Security:
+            - "accounts"
+  /accounts/{AccountId}/balances:
+    get:
+      tags:
+        - "Balances"
+      summary: "Get Balances"
+      operationId: "GetAccountsAccountIdBalances"
+      parameters:
+        - $ref: "#/components/parameters/AccountId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200AccountsAccountIdBalancesRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - PSUOAuth2Security:
+            - "accounts"
+  /accounts/{AccountId}/beneficiaries:
+    get:
+      tags:
+        - "Beneficiaries"
+      summary: "Get Beneficiaries"
+      operationId: "GetAccountsAccountIdBeneficiaries"
+      parameters:
+        - $ref: "#/components/parameters/AccountId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200AccountsAccountIdBeneficiariesRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - PSUOAuth2Security:
+            - "accounts"
+  /accounts/{AccountId}/direct-debits:
+    get:
+      tags:
+        - "Direct Debits"
+      summary: "Get Direct Debits"
+      operationId: "GetAccountsAccountIdDirectDebits"
+      parameters:
+        - $ref: "#/components/parameters/AccountId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200AccountsAccountIdDirectDebitsRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - PSUOAuth2Security:
+            - "accounts"
+  /accounts/{AccountId}/offers:
+    get:
+      tags:
+        - "Offers"
+      summary: "Get Offers"
+      operationId: "GetAccountsAccountIdOffers"
+      parameters:
+        - $ref: "#/components/parameters/AccountId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200AccountsAccountIdOffersRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - PSUOAuth2Security:
+            - "accounts"
+  /accounts/{AccountId}/parties:
+    get:
+      tags:
+        - "Parties"
+      summary: "Get Parties"
+      operationId: "GetAccountsAccountIdParties"
+      parameters:
+        - $ref: "#/components/parameters/AccountId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200AccountsAccountIdPartiesRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - PSUOAuth2Security:
+            - "accounts"
+  /accounts/{AccountId}/party:
+    get:
+      tags:
+        - "Parties"
+      summary: "Get Parties"
+      operationId: "GetAccountsAccountIdParty"
+      parameters:
+        - $ref: "#/components/parameters/AccountId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200AccountsAccountIdPartyRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - PSUOAuth2Security:
+            - "accounts"
+  /accounts/{AccountId}/product:
+    get:
+      tags:
+        - "Products"
+      summary: "Get Products"
+      operationId: "GetAccountsAccountIdProduct"
+      parameters:
+        - $ref: "#/components/parameters/AccountId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200AccountsAccountIdProductRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - PSUOAuth2Security:
+            - "accounts"
+  /accounts/{AccountId}/scheduled-payments:
+    get:
+      tags:
+        - "Scheduled Payments"
+      summary: "Get Scheduled Payments"
+      operationId: "GetAccountsAccountIdScheduledPayments"
+      parameters:
+        - $ref: "#/components/parameters/AccountId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200AccountsAccountIdScheduledPaymentsRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - PSUOAuth2Security:
+            - "accounts"
+  /accounts/{AccountId}/standing-orders:
+    get:
+      tags:
+        - "Standing Orders"
+      summary: "Get Standing Orders"
+      operationId: "GetAccountsAccountIdStandingOrders"
+      parameters:
+        - $ref: "#/components/parameters/AccountId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200AccountsAccountIdStandingOrdersRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - PSUOAuth2Security:
+            - "accounts"
+  /accounts/{AccountId}/statements:
+    get:
+      tags:
+        - "Statements"
+      summary: "Get Statements"
+      operationId: "GetAccountsAccountIdStatements"
+      parameters:
+        - $ref: "#/components/parameters/AccountId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+        - $ref: "#/components/parameters/FromStatementDateTimeParam"
+        - $ref: "#/components/parameters/ToStatementDateTimeParam"
+      responses:
+        200:
+          $ref: "#/components/responses/200AccountsAccountIdStatementsRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - PSUOAuth2Security:
+            - "accounts"
+  /accounts/{AccountId}/statements/{StatementId}:
+    get:
+      tags:
+        - "Statements"
+      summary: "Get Statements"
+      operationId: "GetAccountsAccountIdStatementsStatementId"
+      parameters:
+        - $ref: "#/components/parameters/StatementId"
+        - $ref: "#/components/parameters/AccountId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200AccountsAccountIdStatementsStatementIdRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - PSUOAuth2Security:
+            - "accounts"
+  /accounts/{AccountId}/statements/{StatementId}/file:
+    get:
+      tags:
+        - "Statements"
+      summary: "Get Statements"
+      operationId: "GetAccountsAccountIdStatementsStatementIdFile"
+      parameters:
+        - $ref: "#/components/parameters/StatementId"
+        - $ref: "#/components/parameters/AccountId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200AccountsAccountIdStatementsStatementIdFileRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - PSUOAuth2Security:
+            - "accounts"
+  /accounts/{AccountId}/statements/{StatementId}/transactions:
+    get:
+      tags:
+        - "Transactions"
+      summary: "Get Transactions"
+      operationId: "GetAccountsAccountIdStatementsStatementIdTransactions"
+      parameters:
+        - $ref: "#/components/parameters/StatementId"
+        - $ref: "#/components/parameters/AccountId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200AccountsAccountIdStatementsStatementIdTransactionsRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - PSUOAuth2Security:
+            - "accounts"
+  /accounts/{AccountId}/transactions:
+    get:
+      tags:
+        - "Transactions"
+      summary: "Get Transactions"
+      operationId: "GetAccountsAccountIdTransactions"
+      parameters:
+        - $ref: "#/components/parameters/AccountId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+        - $ref: "#/components/parameters/FromBookingDateTimeParam"
+        - $ref: "#/components/parameters/ToBookingDateTimeParam"
+      responses:
+        200:
+          $ref: "#/components/responses/200AccountsAccountIdTransactionsRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - PSUOAuth2Security:
+            - "accounts"
+  /balances:
+    get:
+      tags:
+        - "Balances"
+      summary: "Get Balances"
+      operationId: "GetBalances"
+      parameters:
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200BalancesRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - PSUOAuth2Security:
+            - "accounts"
+  /beneficiaries:
+    get:
+      tags:
+        - "Beneficiaries"
+      summary: "Get Beneficiaries"
+      operationId: "GetBeneficiaries"
+      parameters:
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200BeneficiariesRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - PSUOAuth2Security:
+            - "accounts"
+  /direct-debits:
+    get:
+      tags:
+        - "Direct Debits"
+      summary: "Get Direct Debits"
+      operationId: "GetDirectDebits"
+      parameters:
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200DirectDebitsRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - PSUOAuth2Security:
+            - "accounts"
+  /offers:
+    get:
+      tags:
+        - "Offers"
+      summary: "Get Offers"
+      operationId: "GetOffers"
+      parameters:
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200OffersRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - PSUOAuth2Security:
+            - "accounts"
+  /party:
+    get:
+      tags:
+        - "Parties"
+      summary: "Get Parties"
+      operationId: "GetParty"
+      parameters:
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200PartyRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - PSUOAuth2Security:
+            - "accounts"
+  /products:
+    get:
+      tags:
+        - "Products"
+      summary: "Get Products"
+      operationId: "GetProducts"
+      parameters:
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200ProductsRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - PSUOAuth2Security:
+            - "accounts"
+  /scheduled-payments:
+    get:
+      tags:
+        - "Scheduled Payments"
+      summary: "Get Scheduled Payments"
+      operationId: "GetScheduledPayments"
+      parameters:
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200ScheduledPaymentsRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - PSUOAuth2Security:
+            - "accounts"
+  /standing-orders:
+    get:
+      tags:
+        - "Standing Orders"
+      summary: "Get Standing Orders"
+      operationId: "GetStandingOrders"
+      parameters:
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200StandingOrdersRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - PSUOAuth2Security:
+            - "accounts"
+  /statements:
+    get:
+      tags:
+        - "Statements"
+      summary: "Get Statements"
+      operationId: "GetStatements"
+      parameters:
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/FromStatementDateTimeParam"
+        - $ref: "#/components/parameters/ToStatementDateTimeParam"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200StatementsRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - PSUOAuth2Security:
+            - "accounts"
+  /transactions:
+    get:
+      tags:
+        - "Transactions"
+      summary: "Get Transactions"
+      operationId: "GetTransactions"
+      parameters:
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+        - $ref: "#/components/parameters/FromBookingDateTimeParam"
+        - $ref: "#/components/parameters/ToBookingDateTimeParam"
+      responses:
+        200:
+          $ref: "#/components/responses/200TransactionsRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - PSUOAuth2Security:
+            - "accounts"
+servers:
+  - url: "/open-banking/v3.1/aisp"
+components:
+  parameters:
+    FromBookingDateTimeParam:
+      in: "query"
+      name: "fromBookingDateTime"
+      description: "The UTC ISO 8601 Date Time to filter transactions FROM\nNB Time component is optional - set to 00:00:00 for just Date.\nIf the Date Time contains a timezone, the ASPSP must ignore the timezone component."
+      schema:
+        type: "string"
+        format: "date-time"
+    ToBookingDateTimeParam:
+      in: "query"
+      name: "toBookingDateTime"
+      description: "The UTC ISO 8601 Date Time to filter transactions TO\nNB Time component is optional - set to 00:00:00 for just Date.\nIf the Date Time contains a timezone, the ASPSP must ignore the timezone component."
+      schema:
+        type: "string"
+        format: "date-time"
+    FromStatementDateTimeParam:
+      in: "query"
+      name: "fromStatementDateTime"
+      description: "The UTC ISO 8601 Date Time to filter statements FROM\nNB Time component is optional - set to 00:00:00 for just Date.\nIf the Date Time contains a timezone, the ASPSP must ignore the timezone component."
+      schema:
+        type: "string"
+        format: "date-time"
+    ToStatementDateTimeParam:
+      in: "query"
+      name: "toStatementDateTime"
+      description: "The UTC ISO 8601 Date Time to filter statements TO\nNB Time component is optional - set to 00:00:00 for just Date.\nIf the Date Time contains a timezone, the ASPSP must ignore the timezone component."
+      schema:
+        type: "string"
+        format: "date-time"
+    ConsentId:
+      name: "ConsentId"
+      in: "path"
+      description: "ConsentId"
+      required: true
+      schema:
+        type: "string"
+    AccountId:
+      name: "AccountId"
+      in: "path"
+      description: "AccountId"
+      required: true
+      schema:
+        type: "string"
+    StatementId:
+      name: "StatementId"
+      in: "path"
+      description: "StatementId"
+      required: true
+      schema:
+        type: "string"
+    Authorization:
+      in: "header"
+      name: "Authorization"
+      required: true
+      description: "An Authorisation Token as per https://tools.ietf.org/html/rfc6750"
+      schema:
+        type: "string"
+    x-customer-user-agent:
+      in: "header"
+      name: "x-customer-user-agent"
+      description: "Indicates the user-agent that the PSU is using."
+      required: false
+      schema:
+        type: "string"
+    x-fapi-customer-ip-address:
+      in: "header"
+      name: "x-fapi-customer-ip-address"
+      required: false
+      description: "The PSU's IP address if the PSU is currently logged in with the TPP."
+      schema:
+        type: "string"
+    x-fapi-auth-date:
+      in: "header"
+      name: "x-fapi-auth-date"
+      required: false
+      description: "The time when the PSU last logged in with the TPP. \nAll dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below: \nSun, 10 Sep 2017 19:43:31 UTC"
+      schema:
+        type: "string"
+        pattern: "^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), \\d{2} (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \\d{4} \\d{2}:\\d{2}:\\d{2} (GMT|UTC)$"
+    x-fapi-interaction-id:
+      in: "header"
+      name: "x-fapi-interaction-id"
+      required: false
+      description: "An RFC4122 UID used as a correlation id."
+      schema:
+        type: "string"
+    x-idempotency-key:
+      name: "x-idempotency-key"
+      in: "header"
+      description: "Every request will be processed only once per x-idempotency-key.  The\nIdempotency Key will be valid for 24 hours.\n"
+      required: true
+      schema:
+        type: "string"
+        maxLength: 40
+        pattern: "^(?!\\s)(.*)(\\S)$"
+    x-jws-signature:
+      in: "header"
+      name: "x-jws-signature"
+      required: true
+      description: "A detached JWS signature of the body of the payload."
+      schema:
+        type: "string"
+  responses:
+    201AccountAccessConsentsCreated:
+      description: "Account Access Consents Created"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBReadConsentResponse1"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBReadConsentResponse1"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBReadConsentResponse1"
+    200AccountAccessConsentsConsentIdRead:
+      description: "Account Access Consents Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBReadConsentResponse1"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBReadConsentResponse1"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBReadConsentResponse1"
+    204AccountAccessConsentsConsentIdDeleted:
+      description: "Account Access Consents Deleted"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+    200AccountsRead:
+      description: "Accounts Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBReadAccount6"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBReadAccount6"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBReadAccount6"
+    200AccountsAccountIdRead:
+      description: "Accounts Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBReadAccount6"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBReadAccount6"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBReadAccount6"
+    200AccountsAccountIdBalancesRead:
+      description: "Balances Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBReadBalance1"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBReadBalance1"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBReadBalance1"
+    200BalancesRead:
+      description: "Balances Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBReadBalance1"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBReadBalance1"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBReadBalance1"
+    200AccountsAccountIdBeneficiariesRead:
+      description: "Beneficiaries Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBReadBeneficiary5"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBReadBeneficiary5"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBReadBeneficiary5"
+    200BeneficiariesRead:
+      description: "Beneficiaries Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBReadBeneficiary5"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBReadBeneficiary5"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBReadBeneficiary5"
+    200AccountsAccountIdDirectDebitsRead:
+      description: "Direct Debits Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBReadDirectDebit2"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBReadDirectDebit2"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBReadDirectDebit2"
+    200DirectDebitsRead:
+      description: "Direct Debits Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBReadDirectDebit2"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBReadDirectDebit2"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBReadDirectDebit2"
+    200AccountsAccountIdOffersRead:
+      description: "Offers Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBReadOffer1"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBReadOffer1"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBReadOffer1"
+    200OffersRead:
+      description: "Offers Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBReadOffer1"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBReadOffer1"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBReadOffer1"
+    200AccountsAccountIdPartiesRead:
+      description: "Parties Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBReadParty3"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBReadParty3"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBReadParty3"
+    200AccountsAccountIdPartyRead:
+      description: "Parties Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBReadParty2"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBReadParty2"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBReadParty2"
+    200PartyRead:
+      description: "Parties Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBReadParty2"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBReadParty2"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBReadParty2"
+    200AccountsAccountIdProductRead:
+      description: "Products Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBReadProduct2"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBReadProduct2"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBReadProduct2"
+    200ProductsRead:
+      description: "Products Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBReadProduct2"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBReadProduct2"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBReadProduct2"
+    200AccountsAccountIdScheduledPaymentsRead:
+      description: "Scheduled Payments Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBReadScheduledPayment3"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBReadScheduledPayment3"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBReadScheduledPayment3"
+    200ScheduledPaymentsRead:
+      description: "Scheduled Payments Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBReadScheduledPayment3"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBReadScheduledPayment3"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBReadScheduledPayment3"
+    200AccountsAccountIdStandingOrdersRead:
+      description: "Standing Orders Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBReadStandingOrder6"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBReadStandingOrder6"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBReadStandingOrder6"
+    200StandingOrdersRead:
+      description: "Standing Orders Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBReadStandingOrder6"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBReadStandingOrder6"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBReadStandingOrder6"
+    200AccountsAccountIdStatementsRead:
+      description: "Statements Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBReadStatement2"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBReadStatement2"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBReadStatement2"
+    200AccountsAccountIdStatementsStatementIdRead:
+      description: "Statements Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBReadStatement2"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBReadStatement2"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBReadStatement2"
+    200AccountsAccountIdStatementsStatementIdFileRead:
+      description: "Statements Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/File"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/File"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/File"
+    200AccountsAccountIdStatementsStatementIdTransactionsRead:
+      description: "Transactions Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBReadTransaction6"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBReadTransaction6"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBReadTransaction6"
+    200StatementsRead:
+      description: "Statements Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBReadStatement2"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBReadStatement2"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBReadStatement2"
+    200AccountsAccountIdTransactionsRead:
+      description: "Transactions Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBReadTransaction6"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBReadTransaction6"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBReadTransaction6"
+    200TransactionsRead:
+      description: "Transactions Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBReadTransaction6"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBReadTransaction6"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBReadTransaction6"
+    400Error:
+      description: "Bad request"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBErrorResponse1"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBErrorResponse1"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBErrorResponse1"
+    401Error:
+      description: "Unauthorized"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+    403Error:
+      description: "Forbidden"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBErrorResponse1"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBErrorResponse1"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBErrorResponse1"
+    404Error:
+      description: "Not found"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+    405Error:
+      description: "Method Not Allowed"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+    406Error:
+      description: "Not Acceptable"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+    415Error:
+      description: "Unsupported Media Type"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+    429Error:
+      description: "Too Many Requests"
+      headers:
+        Retry-After:
+          description: "Number in seconds to wait"
+          schema:
+            type: "integer"
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          schema:
+            type: "string"
+    500Error:
+      description: "Internal Server Error"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBErrorResponse1"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBErrorResponse1"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBErrorResponse1"
+  securitySchemes:
+    TPPOAuth2Security:
+      type: "oauth2"
+      description: "TPP client credential authorisation flow with the ASPSP"
+      flows:
+        clientCredentials:
+          tokenUrl: "https://authserver.example/token"
+          scopes:
+            accounts: "Ability to read Accounts information"
+    PSUOAuth2Security:
+      type: "oauth2"
+      description: "OAuth flow, it is required when the PSU needs to perform SCA with the ASPSP when a TPP wants to access an ASPSP resource owned by the PSU"
+      flows:
+        authorizationCode:
+          authorizationUrl: "https://authserver.example/authorization"
+          tokenUrl: "https://authserver.example/token"
+          scopes:
+            accounts: "Ability to read Accounts information"
+  schemas:
+    AccountId:
+      description: "A unique and immutable identifier used to identify the account resource. This identifier has no meaning to the account owner."
+      type: "string"
+      minLength: 1
+      maxLength: 40
+    ActiveOrHistoricCurrencyCode_0:
+      description: "Identification of the currency in which the account is held. \nUsage: Currency should only be used in case one and the same account number covers several currencies\nand the initiating party needs to identify which currency needs to be used for settlement on the account."
+      type: "string"
+      pattern: "^[A-Z]{3,3}$"
+    ActiveOrHistoricCurrencyCode_1:
+      description: "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\"."
+      type: "string"
+      pattern: "^[A-Z]{3,3}$"
+    AddressLine:
+      description: "Information that locates and identifies a specific address for a transaction entry, that is presented in free format text."
+      type: "string"
+      minLength: 1
+      maxLength: 70
+    BeneficiaryId:
+      description: "A unique and immutable identifier used to identify the beneficiary resource. This identifier has no meaning to the account owner."
+      type: "string"
+      minLength: 1
+      maxLength: 40
+    BookingDateTime:
+      description: "Date and time when a transaction entry is posted to an account on the account servicer's books.\nUsage: Booking date is the expected booking date, unless the status is booked, in which case it is the actual booking date.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+      type: "string"
+      format: "date-time"
+    BuildingNumber:
+      description: "Number that identifies the position of a building on a street."
+      type: "string"
+      minLength: 1
+      maxLength: 16
+    CountryCode:
+      description: "Nation with its own government, occupying a particular territory."
+      type: "string"
+      pattern: "^[A-Z]{2,2}$"
+    CountrySubDivision:
+      description: "Identifies a subdivision of a country eg, state, region, county."
+      type: "string"
+      minLength: 1
+      maxLength: 35
+    CreationDateTime:
+      description: "Date and time at which the resource was created.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+      type: "string"
+      format: "date-time"
+    DateTime:
+      description: "Date and time associated with the date time type.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+      type: "string"
+      format: "date-time"
+    DebtorReference:
+      description: "A reference value provided by the PSU to the PISP while setting up the scheduled payment."
+      type: "string"
+      minLength: 1
+      maxLength: 35
+    Description_0:
+      description: "Specifies the description of the account type."
+      type: "string"
+      minLength: 1
+      maxLength: 35
+    Description_1:
+      description: "Description that may be available for the statement fee."
+      type: "string"
+      minLength: 1
+      maxLength: 128
+    Description_2:
+      description: "Description that may be available for the statement interest."
+      type: "string"
+      minLength: 1
+      maxLength: 128
+    Description_3:
+      description: "Description to describe the purpose of the code"
+      type: "string"
+      minLength: 1
+      maxLength: 350
+    DirectDebitId:
+      description: "A unique and immutable identifier used to identify the direct debit resource. This identifier has no meaning to the account owner."
+      type: "string"
+      minLength: 1
+      maxLength: 40
+    EmailAddress:
+      description: "Address for electronic mail (e-mail)."
+      type: "string"
+      minLength: 1
+      maxLength: 256
+    EndDateTime:
+      description: "Date and time at which the statement period ends.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+      type: "string"
+      format: "date-time"
+    File:
+      type: "object"
+      properties: { }
+    FinalPaymentDateTime:
+      description: "The date on which the final payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+      type: "string"
+      format: "date-time"
+    FirstPaymentDateTime:
+      description: "The date on which the first payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+      type: "string"
+      format: "date-time"
+    Frequency_1:
+      description: "Individual Definitions:\nNotKnown - Not Known\nEvryDay - Every day\nEvryWorkgDay - Every working day\nIntrvlDay - An interval specified in number of calendar days (02 to 31)\nIntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07)\nWkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07)\nIntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-05 to -01, 01 to 31)\nQtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED)\nENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December.\nSCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November.\nRECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December.\nIndividual Patterns:\nNotKnown (ScheduleCode)\nEvryDay (ScheduleCode)\nEvryWorkgDay (ScheduleCode)\nIntrvlDay:NoOfDay (ScheduleCode + NoOfDay)\nIntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek)\nWkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek)\nIntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth)\nQtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay\nThe regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here:\nNotKnown\nEvryDay\nEvryWorkgDay\nIntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1])\nIntrvlWkDay:0[1-9]:0[1-7]\nWkInMnthDay:0[1-5]:0[1-7]\nIntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01])\nQtrDay:(ENGLISH|SCOTTISH|RECEIVED)\nFull Regular Expression:\n^(NotKnown)$|^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]))$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+      type: "string"
+      pattern: "^(NotKnown)$|^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]))$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+    FullLegalName:
+      description: "Specifies a character string with a maximum length of 350 characters."
+      type: "string"
+      minLength: 1
+      maxLength: 350
+    ISODateTime:
+      description: "All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+      type: "string"
+      format: "date-time"
+    Identification_0:
+      description: "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+      type: "string"
+      minLength: 1
+      maxLength: 256
+    Identification_1:
+      description: "Unique and unambiguous identification of the servicing institution."
+      type: "string"
+      minLength: 1
+      maxLength: 35
+    Identification_2:
+      description: "Unique and unambiguous identification of a financial institution or a branch of a financial institution."
+      type: "string"
+      minLength: 1
+      maxLength: 35
+    LastPaymentDateTime:
+      description: "The date on which the last (most recent) payment for a Standing Order schedule was made.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+      type: "string"
+      format: "date-time"
+    Links:
+      type: "object"
+      description: "Links relevant to the payload"
+      properties:
+        Self:
+          type: "string"
+          format: "uri"
+        First:
+          type: "string"
+          format: "uri"
+        Prev:
+          type: "string"
+          format: "uri"
+        Next:
+          type: "string"
+          format: "uri"
+        Last:
+          type: "string"
+          format: "uri"
+      additionalProperties: false
+      required:
+        - "Self"
+    MandateIdentification:
+      description: "Direct Debit reference. For AUDDIS service users provide Core Reference. For non AUDDIS service users provide Core reference if possible or last used reference."
+      type: "string"
+      minLength: 1
+      maxLength: 35
+    MaturityDate:
+      description: "Maturity date of the account.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+      type: "string"
+      format: "date-time"
+    Meta:
+      title: "MetaData"
+      type: "object"
+      description: "Meta Data relevant to the payload"
+      properties:
+        TotalPages:
+          type: "integer"
+          format: "int32"
+        FirstAvailableDateTime:
+          $ref: "#/components/schemas/ISODateTime"
+        LastAvailableDateTime:
+          $ref: "#/components/schemas/ISODateTime"
+      additionalProperties: false
+    Name_0:
+      description: "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels.\nNote, the account name is not the product name or the nickname of the account."
+      type: "string"
+      minLength: 1
+      maxLength: 350
+    Name_1:
+      description: "Name by which an agent is known and which is usually used to identify that agent."
+      type: "string"
+      minLength: 1
+      maxLength: 140
+    Name_2:
+      description: "Name of Service User."
+      type: "string"
+      minLength: 1
+      maxLength: 70
+    Name_3:
+      description: "Name by which a party is known and which is usually used to identify that party."
+      type: "string"
+      minLength: 1
+      maxLength: 350
+    Name_4:
+      description: "Long name associated with the code"
+      type: "string"
+      minLength: 1
+      maxLength: 70
+    NextPaymentDateTime:
+      description: "The date on which the next payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+      type: "string"
+      format: "date-time"
+    Nickname:
+      description: "The nickname of the account, assigned by the account owner in order to provide an additional means of identification of the account."
+      type: "string"
+      minLength: 1
+      maxLength: 70
+    NumberOfPayments:
+      description: "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date."
+      type: "string"
+      minLength: 1
+      maxLength: 35
+    Number_0:
+      description: "Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it�s part of a government scheme, or whether the rate may vary dependent on the applicant�s circumstances."
+      type: "integer"
+    Number_1:
+      description: "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount"
+      type: "integer"
+    OBAccount6:
+      type: "object"
+      description: "Unambiguous identification of the account to which credit and debit entries are made. The following fields are optional only for accounts that are switched:\n\n  * Data.Currency  \n  * Data.AccountType  \n  * Data.AccountSubType\n\nFor all other accounts, the fields must be populated by the ASPSP."
+      required:
+        - "AccountId"
+      properties:
+        AccountId:
+          $ref: "#/components/schemas/AccountId"
+        Status:
+          $ref: "#/components/schemas/OBAccountStatus1Code"
+        StatusUpdateDateTime:
+          $ref: "#/components/schemas/StatusUpdateDateTime"
+        Currency:
+          $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode_0"
+        AccountType:
+          $ref: "#/components/schemas/OBExternalAccountType1Code"
+        AccountSubType:
+          $ref: "#/components/schemas/OBExternalAccountSubType1Code"
+        Description:
+          $ref: "#/components/schemas/Description_0"
+        Nickname:
+          $ref: "#/components/schemas/Nickname"
+        OpeningDate:
+          $ref: "#/components/schemas/OpeningDate"
+        MaturityDate:
+          $ref: "#/components/schemas/MaturityDate"
+        SwitchStatus:
+          $ref: "#/components/schemas/OBExternalSwitchStatusCode"
+        Account:
+          type: "array"
+          items:
+            type: "object"
+            description: "Provides the details to identify an account."
+            required:
+              - "SchemeName"
+              - "Identification"
+            properties:
+              SchemeName:
+                $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+              Identification:
+                $ref: "#/components/schemas/Identification_0"
+              Name:
+                $ref: "#/components/schemas/Name_0"
+              SecondaryIdentification:
+                $ref: "#/components/schemas/SecondaryIdentification"
+        Servicer:
+          $ref: "#/components/schemas/OBBranchAndFinancialInstitutionIdentification5_0"
+      additionalProperties: false
+    OBAccount6Basic:
+      type: "object"
+      description: "Unambiguous identification of the account to which credit and debit entries are made."
+      required:
+        - "AccountId"
+        - "Currency"
+        - "AccountType"
+        - "AccountSubType"
+      properties:
+        AccountId:
+          $ref: "#/components/schemas/AccountId"
+        Status:
+          $ref: "#/components/schemas/OBAccountStatus1Code"
+        StatusUpdateDateTime:
+          $ref: "#/components/schemas/StatusUpdateDateTime"
+        Currency:
+          $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode_0"
+        AccountType:
+          $ref: "#/components/schemas/OBExternalAccountType1Code"
+        AccountSubType:
+          $ref: "#/components/schemas/OBExternalAccountSubType1Code"
+        Description:
+          $ref: "#/components/schemas/Description_0"
+        Nickname:
+          $ref: "#/components/schemas/Nickname"
+        OpeningDate:
+          $ref: "#/components/schemas/OpeningDate"
+        MaturityDate:
+          $ref: "#/components/schemas/MaturityDate"
+        SwitchStatus:
+          $ref: "#/components/schemas/OBExternalSwitchStatusCode"
+      additionalProperties: false
+    OBAccount6Detail:
+      type: "object"
+      description: "Unambiguous identification of the account to which credit and debit entries are made."
+      required:
+        - "AccountId"
+        - "Currency"
+        - "AccountType"
+        - "AccountSubType"
+        - "Account"
+      properties:
+        AccountId:
+          $ref: "#/components/schemas/AccountId"
+        Status:
+          $ref: "#/components/schemas/OBAccountStatus1Code"
+        StatusUpdateDateTime:
+          $ref: "#/components/schemas/StatusUpdateDateTime"
+        Currency:
+          $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode_0"
+        AccountType:
+          $ref: "#/components/schemas/OBExternalAccountType1Code"
+        AccountSubType:
+          $ref: "#/components/schemas/OBExternalAccountSubType1Code"
+        Description:
+          $ref: "#/components/schemas/Description_0"
+        Nickname:
+          $ref: "#/components/schemas/Nickname"
+        OpeningDate:
+          $ref: "#/components/schemas/OpeningDate"
+        MaturityDate:
+          $ref: "#/components/schemas/MaturityDate"
+        SwitchStatus:
+          $ref: "#/components/schemas/OBExternalSwitchStatusCode"
+        Account:
+          type: "array"
+          items:
+            type: "object"
+            description: "Provides the details to identify an account."
+            required:
+              - "SchemeName"
+              - "Identification"
+            properties:
+              SchemeName:
+                $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+              Identification:
+                $ref: "#/components/schemas/Identification_0"
+              Name:
+                $ref: "#/components/schemas/Name_0"
+              SecondaryIdentification:
+                $ref: "#/components/schemas/SecondaryIdentification"
+        Servicer:
+          $ref: "#/components/schemas/OBBranchAndFinancialInstitutionIdentification5_0"
+      additionalProperties: false
+    OBAccountStatus1Code:
+      description: "Specifies the status of account resource in code form."
+      type: "string"
+      enum:
+        - "Deleted"
+        - "Disabled"
+        - "Enabled"
+        - "Pending"
+        - "ProForma"
+    OBActiveCurrencyAndAmount_SimpleType:
+      description: "A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217."
+      type: "string"
+      pattern: "^\\d{1,13}$|^\\d{1,13}\\.\\d{1,5}$"
+    OBActiveOrHistoricCurrencyAndAmount_0:
+      type: "object"
+      required:
+        - "Amount"
+        - "Currency"
+      description: "The amount of the most recent direct debit collection."
+      properties:
+        Amount:
+          $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+        Currency:
+          $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode_1"
+    OBActiveOrHistoricCurrencyAndAmount_1:
+      type: "object"
+      required:
+        - "Amount"
+        - "Currency"
+      description: "Amount of money to be moved between the debtor and creditor, before deduction of charges, expressed in the currency as ordered by the initiating party.\nUsage: This amount has to be transported unchanged through the transaction chain."
+      properties:
+        Amount:
+          $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+        Currency:
+          $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode_1"
+    OBActiveOrHistoricCurrencyAndAmount_10:
+      type: "object"
+      required:
+        - "Amount"
+        - "Currency"
+      description: "Transaction charges to be paid by the charge bearer."
+      properties:
+        Amount:
+          $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+        Currency:
+          $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode_1"
+    OBActiveOrHistoricCurrencyAndAmount_11:
+      type: "object"
+      required:
+        - "Amount"
+        - "Currency"
+      description: "The amount of the last (most recent) Standing Order instruction."
+      properties:
+        Amount:
+          $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+        Currency:
+          $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode_1"
+    OBActiveOrHistoricCurrencyAndAmount_2:
+      type: "object"
+      required:
+        - "Amount"
+        - "Currency"
+      description: "The amount of the first Standing Order"
+      properties:
+        Amount:
+          $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+        Currency:
+          $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode_1"
+    OBActiveOrHistoricCurrencyAndAmount_3:
+      type: "object"
+      required:
+        - "Amount"
+        - "Currency"
+      description: "The amount of the next Standing Order."
+      properties:
+        Amount:
+          $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+        Currency:
+          $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode_1"
+    OBActiveOrHistoricCurrencyAndAmount_4:
+      type: "object"
+      required:
+        - "Amount"
+        - "Currency"
+      description: "The amount of the final Standing Order"
+      properties:
+        Amount:
+          $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+        Currency:
+          $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode_1"
+    OBActiveOrHistoricCurrencyAndAmount_5:
+      type: "object"
+      required:
+        - "Amount"
+        - "Currency"
+      description: "Amount of money associated with the statement benefit type."
+      properties:
+        Amount:
+          $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+        Currency:
+          $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode_1"
+    OBActiveOrHistoricCurrencyAndAmount_6:
+      type: "object"
+      required:
+        - "Amount"
+        - "Currency"
+      description: "Amount of money associated with the statement fee type."
+      properties:
+        Amount:
+          $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+        Currency:
+          $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode_1"
+    OBActiveOrHistoricCurrencyAndAmount_7:
+      type: "object"
+      required:
+        - "Amount"
+        - "Currency"
+      description: "Amount of money associated with the statement interest amount type."
+      properties:
+        Amount:
+          $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+        Currency:
+          $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode_1"
+    OBActiveOrHistoricCurrencyAndAmount_8:
+      type: "object"
+      required:
+        - "Amount"
+        - "Currency"
+      description: "Amount of money associated with the amount type."
+      properties:
+        Amount:
+          $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+        Currency:
+          $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode_1"
+    OBActiveOrHistoricCurrencyAndAmount_9:
+      type: "object"
+      required:
+        - "Amount"
+        - "Currency"
+      description: "Amount of money in the cash transaction entry."
+      properties:
+        Amount:
+          $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+        Currency:
+          $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode_1"
+    OBAddressTypeCode:
+      description: "Identifies the nature of the postal address."
+      type: "string"
+      enum:
+        - "Business"
+        - "Correspondence"
+        - "DeliveryTo"
+        - "MailTo"
+        - "POBox"
+        - "Postal"
+        - "Residential"
+        - "Statement"
+    OBBCAData1:
+      type: "object"
+      title: "BCA"
+      properties:
+        ProductDetails:
+          type: "object"
+          title: "ProductDetails"
+          properties:
+            Segment:
+              description: "Market segmentation is a marketing term referring to the aggregating of prospective buyers into groups, or segments, that have common needs and respond similarly to a marketing action. Market segmentation enables companies to target different categories of consumers who perceive the full value of certain products and services differently from one another.\n\nRead more: Market Segmentation http://www.investopedia.com/terms/m/marketsegmentation.asp#ixzz4gfEEalTd \nWith respect to BCA products, they are segmented in relation to different markets that they wish to focus on. "
+              title: "Segment"
+              type: "array"
+              items:
+                description: "Market segmentation is a marketing term referring to the aggregating of prospective buyers into groups, or segments, that have common needs and respond similarly to a marketing action. Market segmentation enables companies to target different categories of consumers who perceive the full value of certain products and services differently from one another.\n\nRead more: Market Segmentation http://www.investopedia.com/terms/m/marketsegmentation.asp#ixzz4gfEEalTd \nWith respect to BCA products, they are segmented in relation to different markets that they wish to focus on. "
+                type: "string"
+                enum:
+                  - "ClientAccount"
+                  - "Standard"
+                  - "NonCommercialChaitiesClbSoc"
+                  - "NonCommercialPublicAuthGovt"
+                  - "Religious"
+                  - "SectorSpecific"
+                  - "Startup"
+                  - "Switcher"
+            FeeFreeLength:
+              description: "The length/duration of the fee free period"
+              title: "FeeFreeLength"
+              type: "number"
+              format: "float"
+            FeeFreeLengthPeriod:
+              description: "The unit of period (days, weeks, months etc.) of the promotional length"
+              title: "FeeFreeLengthPeriod"
+              type: "string"
+              enum:
+                - "Day"
+                - "Half Year"
+                - "Month"
+                - "Quarter"
+                - "Week"
+                - "Year"
+            Notes:
+              description: "Optional additional notes to supplement the Core product details"
+              title: "Notes"
+              type: "array"
+              items:
+                description: "maxLength 2000 text"
+                type: "string"
+                minLength: 1
+                maxLength: 2000
+          additionalProperties: false
+        CreditInterest:
+          description: "Details about the interest that may be payable to the BCA account holders"
+          type: "object"
+          title: "CreditInterest"
+          properties:
+            TierBandSet:
+              description: "The group of tiers or bands for which credit interest can be applied."
+              type: "array"
+              title: "TierBandSet"
+              items:
+                description: "The group of tiers or bands for which credit interest can be applied."
+                type: "object"
+                properties:
+                  TierBandMethod:
+                    description: "The methodology of how credit interest is paid/applied. It can be:-\n\n1. Banded\nInterest rates are banded. i.e. Increasing rate on whole balance as balance increases.\n\n2. Tiered\nInterest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance.\n\n3. Whole\nThe same interest rate is applied irrespective of the BCA balance"
+                    title: "TierBandMethod"
+                    type: "string"
+                    enum:
+                      - "Banded"
+                      - "Tiered"
+                      - "Whole"
+                  CalculationMethod:
+                    description: "Methods of calculating interest"
+                    title: "CalculationMethod"
+                    type: "string"
+                    enum:
+                      - "Compound"
+                      - "SimpleInterest"
+                  Destination:
+                    description: "Describes whether accrued interest is payable only to the BCA or to another bank account"
+                    title: "Destination"
+                    type: "string"
+                    enum:
+                      - "PayAway"
+                      - "SelfCredit"
+                  Notes:
+                    description: "Optional additional notes to supplement the Tier Band Set details"
+                    title: "Notes"
+                    type: "array"
+                    items:
+                      description: "maxLength 2000 text"
+                      type: "string"
+                      minLength: 1
+                      maxLength: 2000
+                  TierBand:
+                    description: "Tier Band Details"
+                    type: "array"
+                    title: "TierBand"
+                    items:
+                      description: "Tier Band Details"
+                      type: "object"
+                      properties:
+                        Identification:
+                          description: "Unique and unambiguous identification of a  Tier Band for a BCA."
+                          title: "Identification"
+                          type: "string"
+                          minLength: 1
+                          maxLength: 35
+                        TierValueMinimum:
+                          description: "Minimum deposit value for which the credit interest tier applies."
+                          title: "TierValueMinimum"
+                          type: "string"
+                          pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                        TierValueMaximum:
+                          description: "Maximum deposit value for which the credit interest tier applies."
+                          title: "TierValueMaximum"
+                          type: "string"
+                          pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                        CalculationFrequency:
+                          description: "How often is credit interest calculated for the account."
+                          title: "CalculationFrequency"
+                          type: "string"
+                          enum:
+                            - "Daily"
+                            - "HalfYearly"
+                            - "Monthly"
+                            - "Other"
+                            - "Quarterly"
+                            - "PerStatementDate"
+                            - "Weekly"
+                            - "Yearly"
+                        ApplicationFrequency:
+                          description: "How often is interest applied to the BCA for this tier/band i.e. how often the financial institution pays accumulated interest to the customer's BCA."
+                          title: "ApplicationFrequency"
+                          type: "string"
+                          enum:
+                            - "Daily"
+                            - "HalfYearly"
+                            - "Monthly"
+                            - "Other"
+                            - "Quarterly"
+                            - "PerStatementDate"
+                            - "Weekly"
+                            - "Yearly"
+                        DepositInterestAppliedCoverage:
+                          description: "Amount on which Interest applied."
+                          title: "DepositInterestAppliedCoverage"
+                          type: "string"
+                          enum:
+                            - "Banded"
+                            - "Tiered"
+                            - "Whole"
+                        FixedVariableInterestRateType:
+                          description: "Type of interest rate, Fixed or Variable"
+                          title: "FixedVariableInterestRateType"
+                          type: "string"
+                          enum:
+                            - "Fixed"
+                            - "Variable"
+                        AER:
+                          description: "The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made. \n\nRead more: Annual Equivalent Rate (AER) http://www.investopedia.com/terms/a/aer.asp#ixzz4gfR7IO1A"
+                          title: "AER"
+                          type: "string"
+                          pattern: "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$"
+                        BankInterestRateType:
+                          description: "Interest rate types, other than AER, which financial institutions may use to describe the annual interest rate payable to the BCA."
+                          title: "BankInterestRateType"
+                          type: "string"
+                          enum:
+                            - "Gross"
+                            - "Other"
+                        BankInterestRate:
+                          description: "Bank Interest for the BCA product"
+                          title: "BankInterestRate"
+                          type: "string"
+                          pattern: "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$"
+                        Notes:
+                          description: "Optional additional notes to supplement the Tier Band details"
+                          title: "Notes"
+                          type: "array"
+                          items:
+                            description: "maxLength 2000 text"
+                            type: "string"
+                            minLength: 1
+                            maxLength: 2000
+                        OtherBankInterestType:
+                          description: "Other interest rate types which are not available in the standard code list"
+                          type: "object"
+                          title: "OtherBankInterestType"
+                          properties:
+                            Code:
+                              description: "The four letter Mnemonic used within an XML file to identify a code"
+                              title: "Code"
+                              type: "string"
+                              pattern: "^\\w{0,4}$"
+                              minLength: 0
+                              maxLength: 4
+                            Name:
+                              description: "Long name associated with the code"
+                              title: "Name"
+                              type: "string"
+                              minLength: 1
+                              maxLength: 70
+                            Description:
+                              description: "Description to describe the purpose of the code"
+                              title: "Description"
+                              type: "string"
+                              minLength: 1
+                              maxLength: 350
+                          additionalProperties: false
+                          required:
+                            - "Name"
+                            - "Description"
+                        OtherApplicationFrequency:
+                          description: "Other application frequencies that are not available in the standard code list"
+                          type: "object"
+                          title: "OtherApplicationFrequency"
+                          properties:
+                            Code:
+                              description: "The four letter Mnemonic used within an XML file to identify a code"
+                              title: "Code"
+                              type: "string"
+                              pattern: "^\\w{0,4}$"
+                              minLength: 0
+                              maxLength: 4
+                            Name:
+                              description: "Long name associated with the code"
+                              title: "Name"
+                              type: "string"
+                              minLength: 1
+                              maxLength: 70
+                            Description:
+                              description: "Description to describe the purpose of the code"
+                              title: "Description"
+                              type: "string"
+                              minLength: 1
+                              maxLength: 350
+                          additionalProperties: false
+                          required:
+                            - "Name"
+                            - "Description"
+                        OtherCalculationFrequency:
+                          description: "Other calculation frequency which is not available in the standard code set."
+                          type: "object"
+                          title: "OtherCalculationFrequency"
+                          properties:
+                            Code:
+                              description: "The four letter Mnemonic used within an XML file to identify a code"
+                              title: "Code"
+                              type: "string"
+                              pattern: "^\\w{0,4}$"
+                              minLength: 0
+                              maxLength: 4
+                            Name:
+                              description: "Long name associated with the code"
+                              title: "Name"
+                              type: "string"
+                              minLength: 1
+                              maxLength: 70
+                            Description:
+                              description: "Description to describe the purpose of the code"
+                              title: "Description"
+                              type: "string"
+                              minLength: 1
+                              maxLength: 350
+                          additionalProperties: false
+                          required:
+                            - "Name"
+                            - "Description"
+                      required:
+                        - "TierValueMinimum"
+                        - "ApplicationFrequency"
+                        - "FixedVariableInterestRateType"
+                        - "AER"
+                    minItems: 1
+                required:
+                  - "TierBandMethod"
+                  - "Destination"
+                  - "TierBand"
+              minItems: 1
+          additionalProperties: false
+          required:
+            - "TierBandSet"
+        Overdraft:
+          description: "Borrowing details"
+          type: "object"
+          title: "Overdraft"
+          properties:
+            Notes:
+              description: "Associated Notes about the overdraft rates"
+              title: "Notes"
+              type: "array"
+              items:
+                description: "maxLength 2000 text"
+                type: "string"
+                minLength: 1
+                maxLength: 2000
+            OverdraftTierBandSet:
+              description: "Tier band set details"
+              type: "array"
+              title: "OverdraftTierBandSet"
+              items:
+                description: "Tier band set details"
+                type: "object"
+                properties:
+                  TierBandMethod:
+                    description: "The methodology of how overdraft is charged. It can be:\n'Whole'  Where the same charge/rate is applied to the entirety of the overdraft balance (where charges are applicable). \n'Tiered' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount tiers defined by the lending financial organisation\n'Banded' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount bands defined by a government organisation."
+                    title: "TierBandMethod"
+                    type: "string"
+                    enum:
+                      - "Banded"
+                      - "Tiered"
+                      - "Whole"
+                  OverdraftType:
+                    description: "An overdraft can either be 'committed' which means that the facility cannot be withdrawn without reasonable notification before it's agreed end date, or 'on demand' which means that the financial institution can demand repayment at any point in time."
+                    title: "OverdraftType"
+                    type: "string"
+                    enum:
+                      - "Committed"
+                      - "OnDemand"
+                  Identification:
+                    description: "Unique and unambiguous identification of a  Tier Band for a overdraft product."
+                    title: "Identification"
+                    type: "string"
+                    minLength: 1
+                    maxLength: 35
+                  AuthorisedIndicator:
+                    description: "Indicates if the Overdraft is authorised (Y) or unauthorised (N)"
+                    title: "AuthorisedIndicator"
+                    type: "boolean"
+                  BufferAmount:
+                    description: "When a customer exceeds their credit limit, a financial institution will not charge the customer unauthorised overdraft charges if they do not exceed by more than the buffer amount. Note: Authorised overdraft charges may still apply."
+                    title: "BufferAmount"
+                    type: "string"
+                    pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                  Notes:
+                    description: "Optional additional notes to supplement the overdraft Tier Band Set details"
+                    title: "Notes"
+                    type: "array"
+                    items:
+                      description: "maxLength 2000 text"
+                      type: "string"
+                      minLength: 1
+                      maxLength: 2000
+                  OverdraftTierBand:
+                    description: "Provides overdraft details for a specific tier or band"
+                    type: "array"
+                    title: "OverdraftTierBand"
+                    items:
+                      description: "Provides overdraft details for a specific tier or band"
+                      type: "object"
+                      properties:
+                        Identification:
+                          description: "Unique and unambiguous identification of a  Tier Band for a overdraft."
+                          title: "Identification"
+                          type: "string"
+                          minLength: 1
+                          maxLength: 35
+                        TierValueMin:
+                          description: "Minimum value of Overdraft Tier/Band"
+                          title: "TierValueMin"
+                          type: "string"
+                          pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                        TierValueMax:
+                          description: "Maximum value of Overdraft Tier/Band"
+                          title: "TierValueMax"
+                          type: "string"
+                          pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                        EAR:
+                          description: "EAR means Effective Annual Rate and/or Equivalent Annual Rate (frequently\nused interchangeably), being the actual annual interest rate of an Overdraft."
+                          title: "EAR"
+                          type: "string"
+                          pattern: "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$"
+                        RepresentativeAPR:
+                          description: "An annual percentage rate (APR) is the annual rate charged for borrowing or earned through an investment. APR is expressed as a percentage that represents the actual yearly cost of funds over the term of a loan. This includes any fees or additional costs associated with the transaction but does not take compounding into account."
+                          title: "RepresentativeAPR"
+                          type: "string"
+                          pattern: "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$"
+                        AgreementLengthMin:
+                          description: "Specifies the minimum length of a band for a fixed overdraft agreement"
+                          title: "AgreementLengthMin"
+                          type: "number"
+                          format: "float"
+                        AgreementLengthMax:
+                          description: "Specifies the maximum length of a band for a fixed overdraft agreement"
+                          title: "AgreementLengthMax"
+                          type: "number"
+                          format: "float"
+                        AgreementPeriod:
+                          description: "Specifies the period of a fixed length overdraft agreement"
+                          title: "AgreementPeriod"
+                          type: "string"
+                          enum:
+                            - "Day"
+                            - "Half Year"
+                            - "Month"
+                            - "Quarter"
+                            - "Week"
+                            - "Year"
+                        OverdraftInterestChargingCoverage:
+                          description: "Refers to which interest rate is applied when interests are tiered. For example, if an overdraft balance is £2k and the interest tiers are:- 0-£500 0.1%, 500-1000 0.2%, 1000-10000 0.5%, then the applicable interest rate could either be 0.5% of the entire balance (since the account balance sits in the top interest tier) or (0.1%*500)+(0.2%*500)+(0.5%*1000). In the 1st situation, we say the interest is applied to the ‘Whole’ of the account balance,  and in the 2nd that it is ‘Tiered’."
+                          title: "OverdraftInterestChargingCoverage"
+                          type: "string"
+                          enum:
+                            - "Banded"
+                            - "Tiered"
+                            - "Whole"
+                        BankGuaranteedIndicator:
+                          description: "Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it’s part of a government scheme, or whether the rate may vary dependent on the applicant’s circumstances."
+                          title: "BankGuaranteedIndicator"
+                          type: "boolean"
+                        Notes:
+                          description: "Optional additional notes to supplement the Tier/band details"
+                          title: "Notes"
+                          type: "array"
+                          items:
+                            description: "maxLength 2000 text"
+                            type: "string"
+                            minLength: 1
+                            maxLength: 2000
+                        OverdraftFeesCharges:
+                          description: "Overdraft fees and charges"
+                          type: "array"
+                          title: "OverdraftFeesCharges"
+                          items:
+                            description: "Overdraft fees and charges"
+                            type: "object"
+                            properties:
+                              OverdraftFeeChargeCap:
+                                description: "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate."
+                                type: "array"
+                                title: "OverdraftFeeChargeCap"
+                                items:
+                                  description: "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate."
+                                  type: "object"
+                                  properties:
+                                    FeeType:
+                                      description: "Fee/charge type which is being capped"
+                                      title: "FeeType"
+                                      type: "array"
+                                      items:
+                                        description: "Overdraft fee type"
+                                        type: "string"
+                                        enum:
+                                          - "ArrangedOverdraft"
+                                          - "AnnualReview"
+                                          - "EmergencyBorrowing"
+                                          - "BorrowingItem"
+                                          - "OverdraftRenewal"
+                                          - "OverdraftSetup"
+                                          - "Surcharge"
+                                          - "TempOverdraft"
+                                          - "UnauthorisedBorrowing"
+                                          - "UnauthorisedPaidTrans"
+                                          - "Other"
+                                          - "UnauthorisedUnpaidTrans"
+                                      minItems: 1
+                                    MinMaxType:
+                                      description: "Min Max type"
+                                      title: "MinMaxType"
+                                      type: "string"
+                                      enum:
+                                        - "Minimum"
+                                        - "Maximum"
+                                    FeeCapOccurrence:
+                                      description: "Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it’s part of a government scheme, or whether the rate may vary dependent on the applicant’s circumstances."
+                                      title: "FeeCapOccurrence"
+                                      type: "number"
+                                      format: "float"
+                                    FeeCapAmount:
+                                      description: "Cap amount charged for a fee/charge"
+                                      title: "FeeCapAmount"
+                                      type: "string"
+                                      pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                                    CappingPeriod:
+                                      description: "Period e.g. day, week, month etc. for which the fee/charge is capped"
+                                      title: "CappingPeriod"
+                                      type: "string"
+                                      enum:
+                                        - "Day"
+                                        - "Half Year"
+                                        - "Month"
+                                        - "Quarter"
+                                        - "Week"
+                                        - "Year"
+                                    Notes:
+                                      description: "Notes related to Overdraft fee charge cap"
+                                      title: "Notes"
+                                      type: "array"
+                                      items:
+                                        description: "maxLength 2000 text"
+                                        type: "string"
+                                        minLength: 1
+                                        maxLength: 2000
+                                    OtherFeeType:
+                                      description: "Other fee type code which is not available in the standard code set"
+                                      type: "array"
+                                      title: "OtherFeeType"
+                                      items:
+                                        description: "Other fee type code which is not available in the standard code set"
+                                        type: "object"
+                                        properties:
+                                          Code:
+                                            description: "The four letter Mnemonic used within an XML file to identify a code"
+                                            title: "Code"
+                                            type: "string"
+                                            pattern: "^\\w{0,4}$"
+                                            minLength: 0
+                                            maxLength: 4
+                                          Name:
+                                            description: "Long name associated with the code"
+                                            title: "Name"
+                                            type: "string"
+                                            minLength: 1
+                                            maxLength: 70
+                                          Description:
+                                            description: "Description to describe the purpose of the code"
+                                            title: "Description"
+                                            type: "string"
+                                            minLength: 1
+                                            maxLength: 350
+                                        required:
+                                          - "Name"
+                                          - "Description"
+                                  required:
+                                    - "FeeType"
+                                    - "MinMaxType"
+                              OverdraftFeeChargeDetail:
+                                description: "Details about the fees/charges"
+                                type: "array"
+                                title: "OverdraftFeeChargeDetail"
+                                items:
+                                  description: "Details about the fees/charges"
+                                  type: "object"
+                                  properties:
+                                    FeeType:
+                                      description: "Overdraft fee type"
+                                      title: "FeeType"
+                                      type: "string"
+                                      enum:
+                                        - "ArrangedOverdraft"
+                                        - "AnnualReview"
+                                        - "EmergencyBorrowing"
+                                        - "BorrowingItem"
+                                        - "OverdraftRenewal"
+                                        - "OverdraftSetup"
+                                        - "Surcharge"
+                                        - "TempOverdraft"
+                                        - "UnauthorisedBorrowing"
+                                        - "UnauthorisedPaidTrans"
+                                        - "Other"
+                                        - "UnauthorisedUnpaidTrans"
+                                    NegotiableIndicator:
+                                      description: "Indicates whether fee and charges are negotiable"
+                                      title: "NegotiableIndicator"
+                                      type: "boolean"
+                                    OverdraftControlIndicator:
+                                      description: "Indicates if the fee/charge is already covered by an 'Overdraft Control' fee or not."
+                                      title: "OverdraftControlIndicator"
+                                      type: "boolean"
+                                    IncrementalBorrowingAmount:
+                                      description: "Every additional tranche of an overdraft balance to which an overdraft fee is applied"
+                                      title: "IncrementalBorrowingAmount"
+                                      type: "string"
+                                      pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                                    FeeAmount:
+                                      description: "Amount charged for an overdraft fee/charge (where it is charged in terms of an amount rather than a rate)"
+                                      title: "FeeAmount"
+                                      type: "string"
+                                      pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                                    FeeRate:
+                                      description: "Rate charged for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)"
+                                      title: "FeeRate"
+                                      type: "string"
+                                      pattern: "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$"
+                                    FeeRateType:
+                                      description: "Rate type for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)"
+                                      title: "FeeRateType"
+                                      type: "string"
+                                      enum:
+                                        - "Gross"
+                                        - "Other"
+                                    ApplicationFrequency:
+                                      description: "Frequency at which the overdraft charge is applied to the account"
+                                      title: "ApplicationFrequency"
+                                      type: "string"
+                                      enum:
+                                        - "OnClosing"
+                                        - "OnOpening"
+                                        - "ChargingPeriod"
+                                        - "Daily"
+                                        - "PerItem"
+                                        - "Monthly"
+                                        - "OnAnniversary"
+                                        - "Other"
+                                        - "PerHundredPounds"
+                                        - "PerHour"
+                                        - "PerOccurrence"
+                                        - "PerSheet"
+                                        - "PerTransaction"
+                                        - "PerTransactionAmount"
+                                        - "PerTransactionPercentage"
+                                        - "Quarterly"
+                                        - "SixMonthly"
+                                        - "StatementMonthly"
+                                        - "Weekly"
+                                        - "Yearly"
+                                    CalculationFrequency:
+                                      description: "How often is the overdraft fee/charge calculated for the account."
+                                      title: "CalculationFrequency"
+                                      type: "string"
+                                      enum:
+                                        - "OnClosing"
+                                        - "OnOpening"
+                                        - "ChargingPeriod"
+                                        - "Daily"
+                                        - "PerItem"
+                                        - "Monthly"
+                                        - "OnAnniversary"
+                                        - "Other"
+                                        - "PerHundredPounds"
+                                        - "PerHour"
+                                        - "PerOccurrence"
+                                        - "PerSheet"
+                                        - "PerTransaction"
+                                        - "PerTransactionAmount"
+                                        - "PerTransactionPercentage"
+                                        - "Quarterly"
+                                        - "SixMonthly"
+                                        - "StatementMonthly"
+                                        - "Weekly"
+                                        - "Yearly"
+                                    Notes:
+                                      description: "Free text for capturing any other info related to Overdraft Fees Charge Details"
+                                      title: "Notes"
+                                      type: "array"
+                                      items:
+                                        description: "maxLength 2000 text"
+                                        type: "string"
+                                        minLength: 1
+                                        maxLength: 2000
+                                    OverdraftFeeChargeCap:
+                                      description: "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate."
+                                      type: "array"
+                                      title: "OverdraftFeeChargeCap"
+                                      items:
+                                        description: "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate."
+                                        type: "object"
+                                        properties:
+                                          FeeType:
+                                            description: "Fee/charge type which is being capped"
+                                            title: "FeeType"
+                                            type: "array"
+                                            items:
+                                              description: "Overdraft fee type"
+                                              type: "string"
+                                              enum:
+                                                - "ArrangedOverdraft"
+                                                - "AnnualReview"
+                                                - "EmergencyBorrowing"
+                                                - "BorrowingItem"
+                                                - "OverdraftRenewal"
+                                                - "OverdraftSetup"
+                                                - "Surcharge"
+                                                - "TempOverdraft"
+                                                - "UnauthorisedBorrowing"
+                                                - "UnauthorisedPaidTrans"
+                                                - "Other"
+                                                - "UnauthorisedUnpaidTrans"
+                                            minItems: 1
+                                          MinMaxType:
+                                            description: "Min Max type"
+                                            title: "MinMaxType"
+                                            type: "string"
+                                            enum:
+                                              - "Minimum"
+                                              - "Maximum"
+                                          FeeCapOccurrence:
+                                            description: "Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it’s part of a government scheme, or whether the rate may vary dependent on the applicant’s circumstances."
+                                            title: "FeeCapOccurrence"
+                                            type: "number"
+                                            format: "float"
+                                          FeeCapAmount:
+                                            description: "Cap amount charged for a fee/charge"
+                                            title: "FeeCapAmount"
+                                            type: "string"
+                                            pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                                          CappingPeriod:
+                                            description: "Period e.g. day, week, month etc. for which the fee/charge is capped"
+                                            title: "CappingPeriod"
+                                            type: "string"
+                                            enum:
+                                              - "Day"
+                                              - "Half Year"
+                                              - "Month"
+                                              - "Quarter"
+                                              - "Week"
+                                              - "Year"
+                                          Notes:
+                                            description: "Notes related to Overdraft fee charge cap"
+                                            title: "Notes"
+                                            type: "array"
+                                            items:
+                                              description: "maxLength 2000 text"
+                                              type: "string"
+                                              minLength: 1
+                                              maxLength: 2000
+                                          OtherFeeType:
+                                            description: "Other fee type code which is not available in the standard code set"
+                                            type: "array"
+                                            title: "OtherFeeType"
+                                            items:
+                                              description: "Other fee type code which is not available in the standard code set"
+                                              type: "object"
+                                              properties:
+                                                Code:
+                                                  description: "The four letter Mnemonic used within an XML file to identify a code"
+                                                  title: "Code"
+                                                  type: "string"
+                                                  pattern: "^\\w{0,4}$"
+                                                  minLength: 0
+                                                  maxLength: 4
+                                                Name:
+                                                  description: "Long name associated with the code"
+                                                  title: "Name"
+                                                  type: "string"
+                                                  minLength: 1
+                                                  maxLength: 70
+                                                Description:
+                                                  description: "Description to describe the purpose of the code"
+                                                  title: "Description"
+                                                  type: "string"
+                                                  minLength: 1
+                                                  maxLength: 350
+                                              required:
+                                                - "Name"
+                                                - "Description"
+                                        required:
+                                          - "FeeType"
+                                          - "MinMaxType"
+                                    OtherFeeType:
+                                      description: "Other Fee type which is not available in the standard code set"
+                                      type: "object"
+                                      title: "OtherFeeType"
+                                      properties:
+                                        Code:
+                                          description: "The four letter Mnemonic used within an XML file to identify a code"
+                                          title: "Code"
+                                          type: "string"
+                                          pattern: "^\\w{0,4}$"
+                                          minLength: 0
+                                          maxLength: 4
+                                        Name:
+                                          description: "Long name associated with the code"
+                                          title: "Name"
+                                          type: "string"
+                                          minLength: 1
+                                          maxLength: 70
+                                        Description:
+                                          description: "Description to describe the purpose of the code"
+                                          title: "Description"
+                                          type: "string"
+                                          minLength: 1
+                                          maxLength: 350
+                                      additionalProperties: false
+                                      required:
+                                        - "Name"
+                                        - "Description"
+                                    OtherFeeRateType:
+                                      description: "Other fee rate type code which is not available in the standard code set"
+                                      type: "object"
+                                      title: "OtherFeeRateType"
+                                      properties:
+                                        Code:
+                                          description: "The four letter Mnemonic used within an XML file to identify a code"
+                                          title: "Code"
+                                          type: "string"
+                                          pattern: "^\\w{0,4}$"
+                                          minLength: 0
+                                          maxLength: 4
+                                        Name:
+                                          description: "Long name associated with the code"
+                                          title: "Name"
+                                          type: "string"
+                                          minLength: 1
+                                          maxLength: 70
+                                        Description:
+                                          description: "Description to describe the purpose of the code"
+                                          title: "Description"
+                                          type: "string"
+                                          minLength: 1
+                                          maxLength: 350
+                                      additionalProperties: false
+                                      required:
+                                        - "Name"
+                                        - "Description"
+                                    OtherApplicationFrequency:
+                                      description: "Other application frequencies that are not available in the standard code list"
+                                      type: "object"
+                                      title: "OtherApplicationFrequency"
+                                      properties:
+                                        Code:
+                                          description: "The four letter Mnemonic used within an XML file to identify a code"
+                                          title: "Code"
+                                          type: "string"
+                                          pattern: "^\\w{0,4}$"
+                                          minLength: 0
+                                          maxLength: 4
+                                        Name:
+                                          description: "Long name associated with the code"
+                                          title: "Name"
+                                          type: "string"
+                                          minLength: 1
+                                          maxLength: 70
+                                        Description:
+                                          description: "Description to describe the purpose of the code"
+                                          title: "Description"
+                                          type: "string"
+                                          minLength: 1
+                                          maxLength: 350
+                                      additionalProperties: false
+                                      required:
+                                        - "Name"
+                                        - "Description"
+                                    OtherCalculationFrequency:
+                                      description: "Other calculation frequency which is not available in the standard code set."
+                                      type: "object"
+                                      title: "OtherCalculationFrequency"
+                                      properties:
+                                        Code:
+                                          description: "The four letter Mnemonic used within an XML file to identify a code"
+                                          title: "Code"
+                                          type: "string"
+                                          pattern: "^\\w{0,4}$"
+                                          minLength: 0
+                                          maxLength: 4
+                                        Name:
+                                          description: "Long name associated with the code"
+                                          title: "Name"
+                                          type: "string"
+                                          minLength: 1
+                                          maxLength: 70
+                                        Description:
+                                          description: "Description to describe the purpose of the code"
+                                          title: "Description"
+                                          type: "string"
+                                          minLength: 1
+                                          maxLength: 350
+                                      additionalProperties: false
+                                      required:
+                                        - "Name"
+                                        - "Description"
+                                  required:
+                                    - "FeeType"
+                                    - "ApplicationFrequency"
+                                minItems: 1
+                            required:
+                              - "OverdraftFeeChargeDetail"
+                      required:
+                        - "TierValueMin"
+                    minItems: 1
+                  OverdraftFeesCharges:
+                    description: "Overdraft fees and charges details"
+                    type: "array"
+                    title: "OverdraftFeesCharges"
+                    items:
+                      description: "Overdraft fees and charges details"
+                      type: "object"
+                      properties:
+                        OverdraftFeeChargeCap:
+                          description: "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate."
+                          type: "array"
+                          title: "OverdraftFeeChargeCap"
+                          items:
+                            description: "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate."
+                            type: "object"
+                            properties:
+                              FeeType:
+                                description: "Fee/charge type which is being capped"
+                                title: "FeeType"
+                                type: "array"
+                                items:
+                                  description: "Overdraft fee type"
+                                  type: "string"
+                                  enum:
+                                    - "ArrangedOverdraft"
+                                    - "AnnualReview"
+                                    - "EmergencyBorrowing"
+                                    - "BorrowingItem"
+                                    - "OverdraftRenewal"
+                                    - "OverdraftSetup"
+                                    - "Surcharge"
+                                    - "TempOverdraft"
+                                    - "UnauthorisedBorrowing"
+                                    - "UnauthorisedPaidTrans"
+                                    - "Other"
+                                    - "UnauthorisedUnpaidTrans"
+                                minItems: 1
+                              MinMaxType:
+                                description: "Min Max type"
+                                title: "MinMaxType"
+                                type: "string"
+                                enum:
+                                  - "Minimum"
+                                  - "Maximum"
+                              FeeCapOccurrence:
+                                description: "Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it’s part of a government scheme, or whether the rate may vary dependent on the applicant’s circumstances."
+                                title: "FeeCapOccurrence"
+                                type: "number"
+                                format: "float"
+                              FeeCapAmount:
+                                description: "Cap amount charged for a fee/charge"
+                                title: "FeeCapAmount"
+                                type: "string"
+                                pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                              CappingPeriod:
+                                description: "Period e.g. day, week, month etc. for which the fee/charge is capped"
+                                title: "CappingPeriod"
+                                type: "string"
+                                enum:
+                                  - "Day"
+                                  - "Half Year"
+                                  - "Month"
+                                  - "Quarter"
+                                  - "Week"
+                                  - "Year"
+                              Notes:
+                                description: "Notes related to Overdraft fee charge cap"
+                                title: "Notes"
+                                type: "array"
+                                items:
+                                  description: "maxLength 2000 text"
+                                  type: "string"
+                                  minLength: 1
+                                  maxLength: 2000
+                              OtherFeeType:
+                                description: "Other fee type code which is not available in the standard code set"
+                                type: "array"
+                                title: "OtherFeeType"
+                                items:
+                                  description: "Other fee type code which is not available in the standard code set"
+                                  type: "object"
+                                  properties:
+                                    Code:
+                                      description: "The four letter Mnemonic used within an XML file to identify a code"
+                                      title: "Code"
+                                      type: "string"
+                                      pattern: "^\\w{0,4}$"
+                                      minLength: 0
+                                      maxLength: 4
+                                    Name:
+                                      description: "Long name associated with the code"
+                                      title: "Name"
+                                      type: "string"
+                                      minLength: 1
+                                      maxLength: 70
+                                    Description:
+                                      description: "Description to describe the purpose of the code"
+                                      title: "Description"
+                                      type: "string"
+                                      minLength: 1
+                                      maxLength: 350
+                                  required:
+                                    - "Name"
+                                    - "Description"
+                            required:
+                              - "FeeType"
+                              - "MinMaxType"
+                        OverdraftFeeChargeDetail:
+                          description: "Details about the fees/charges"
+                          type: "array"
+                          title: "OverdraftFeeChargeDetail"
+                          items:
+                            description: "Details about the fees/charges"
+                            type: "object"
+                            properties:
+                              FeeType:
+                                description: "Overdraft fee type"
+                                title: "FeeType"
+                                type: "string"
+                                enum:
+                                  - "ArrangedOverdraft"
+                                  - "AnnualReview"
+                                  - "EmergencyBorrowing"
+                                  - "BorrowingItem"
+                                  - "OverdraftRenewal"
+                                  - "OverdraftSetup"
+                                  - "Surcharge"
+                                  - "TempOverdraft"
+                                  - "UnauthorisedBorrowing"
+                                  - "UnauthorisedPaidTrans"
+                                  - "Other"
+                                  - "UnauthorisedUnpaidTrans"
+                              NegotiableIndicator:
+                                description: "Indicates whether fee and charges are negotiable"
+                                title: "NegotiableIndicator"
+                                type: "boolean"
+                              OverdraftControlIndicator:
+                                description: "Indicates if the fee/charge is already covered by an 'Overdraft Control' fee or not."
+                                title: "OverdraftControlIndicator"
+                                type: "boolean"
+                              IncrementalBorrowingAmount:
+                                description: "Every additional tranche of an overdraft balance to which an overdraft fee is applied"
+                                title: "IncrementalBorrowingAmount"
+                                type: "string"
+                                pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                              FeeAmount:
+                                description: "Amount charged for an overdraft fee/charge (where it is charged in terms of an amount rather than a rate)"
+                                title: "FeeAmount"
+                                type: "string"
+                                pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                              FeeRate:
+                                description: "Rate charged for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)"
+                                title: "FeeRate"
+                                type: "string"
+                                pattern: "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$"
+                              FeeRateType:
+                                description: "Rate type for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)"
+                                title: "FeeRateType"
+                                type: "string"
+                                enum:
+                                  - "Gross"
+                                  - "Other"
+                              ApplicationFrequency:
+                                description: "Frequency at which the overdraft charge is applied to the account"
+                                title: "ApplicationFrequency"
+                                type: "string"
+                                enum:
+                                  - "OnClosing"
+                                  - "OnOpening"
+                                  - "ChargingPeriod"
+                                  - "Daily"
+                                  - "PerItem"
+                                  - "Monthly"
+                                  - "OnAnniversary"
+                                  - "Other"
+                                  - "PerHundredPounds"
+                                  - "PerHour"
+                                  - "PerOccurrence"
+                                  - "PerSheet"
+                                  - "PerTransaction"
+                                  - "PerTransactionAmount"
+                                  - "PerTransactionPercentage"
+                                  - "Quarterly"
+                                  - "SixMonthly"
+                                  - "StatementMonthly"
+                                  - "Weekly"
+                                  - "Yearly"
+                              CalculationFrequency:
+                                description: "How often is the overdraft fee/charge calculated for the account."
+                                title: "CalculationFrequency"
+                                type: "string"
+                                enum:
+                                  - "OnClosing"
+                                  - "OnOpening"
+                                  - "ChargingPeriod"
+                                  - "Daily"
+                                  - "PerItem"
+                                  - "Monthly"
+                                  - "OnAnniversary"
+                                  - "Other"
+                                  - "PerHundredPounds"
+                                  - "PerHour"
+                                  - "PerOccurrence"
+                                  - "PerSheet"
+                                  - "PerTransaction"
+                                  - "PerTransactionAmount"
+                                  - "PerTransactionPercentage"
+                                  - "Quarterly"
+                                  - "SixMonthly"
+                                  - "StatementMonthly"
+                                  - "Weekly"
+                                  - "Yearly"
+                              Notes:
+                                description: "Free text for capturing any other info related to Overdraft Fees Charge Details"
+                                title: "Notes"
+                                type: "array"
+                                items:
+                                  description: "maxLength 2000 text"
+                                  type: "string"
+                                  minLength: 1
+                                  maxLength: 2000
+                              OverdraftFeeChargeCap:
+                                description: "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate."
+                                type: "array"
+                                title: "OverdraftFeeChargeCap"
+                                items:
+                                  description: "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate."
+                                  type: "object"
+                                  properties:
+                                    FeeType:
+                                      description: "Fee/charge type which is being capped"
+                                      title: "FeeType"
+                                      type: "array"
+                                      items:
+                                        description: "Overdraft fee type"
+                                        type: "string"
+                                        enum:
+                                          - "ArrangedOverdraft"
+                                          - "AnnualReview"
+                                          - "EmergencyBorrowing"
+                                          - "BorrowingItem"
+                                          - "OverdraftRenewal"
+                                          - "OverdraftSetup"
+                                          - "Surcharge"
+                                          - "TempOverdraft"
+                                          - "UnauthorisedBorrowing"
+                                          - "UnauthorisedPaidTrans"
+                                          - "Other"
+                                          - "UnauthorisedUnpaidTrans"
+                                      minItems: 1
+                                    MinMaxType:
+                                      description: "Min Max type"
+                                      title: "MinMaxType"
+                                      type: "string"
+                                      enum:
+                                        - "Minimum"
+                                        - "Maximum"
+                                    FeeCapOccurrence:
+                                      description: "Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it’s part of a government scheme, or whether the rate may vary dependent on the applicant’s circumstances."
+                                      title: "FeeCapOccurrence"
+                                      type: "number"
+                                      format: "float"
+                                    FeeCapAmount:
+                                      description: "Cap amount charged for a fee/charge"
+                                      title: "FeeCapAmount"
+                                      type: "string"
+                                      pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                                    CappingPeriod:
+                                      description: "Period e.g. day, week, month etc. for which the fee/charge is capped"
+                                      title: "CappingPeriod"
+                                      type: "string"
+                                      enum:
+                                        - "Day"
+                                        - "Half Year"
+                                        - "Month"
+                                        - "Quarter"
+                                        - "Week"
+                                        - "Year"
+                                    Notes:
+                                      description: "Notes related to Overdraft fee charge cap"
+                                      title: "Notes"
+                                      type: "array"
+                                      items:
+                                        description: "maxLength 2000 text"
+                                        type: "string"
+                                        minLength: 1
+                                        maxLength: 2000
+                                    OtherFeeType:
+                                      description: "Other fee type code which is not available in the standard code set"
+                                      type: "array"
+                                      title: "OtherFeeType"
+                                      items:
+                                        description: "Other fee type code which is not available in the standard code set"
+                                        type: "object"
+                                        properties:
+                                          Code:
+                                            description: "The four letter Mnemonic used within an XML file to identify a code"
+                                            title: "Code"
+                                            type: "string"
+                                            pattern: "^\\w{0,4}$"
+                                            minLength: 0
+                                            maxLength: 4
+                                          Name:
+                                            description: "Long name associated with the code"
+                                            title: "Name"
+                                            type: "string"
+                                            minLength: 1
+                                            maxLength: 70
+                                          Description:
+                                            description: "Description to describe the purpose of the code"
+                                            title: "Description"
+                                            type: "string"
+                                            minLength: 1
+                                            maxLength: 350
+                                        required:
+                                          - "Name"
+                                          - "Description"
+                                  required:
+                                    - "FeeType"
+                                    - "MinMaxType"
+                              OtherFeeType:
+                                description: "Other Fee type which is not available in the standard code set"
+                                type: "object"
+                                title: "OtherFeeType"
+                                properties:
+                                  Code:
+                                    description: "The four letter Mnemonic used within an XML file to identify a code"
+                                    title: "Code"
+                                    type: "string"
+                                    pattern: "^\\w{0,4}$"
+                                    minLength: 0
+                                    maxLength: 4
+                                  Name:
+                                    description: "Long name associated with the code"
+                                    title: "Name"
+                                    type: "string"
+                                    minLength: 1
+                                    maxLength: 70
+                                  Description:
+                                    description: "Description to describe the purpose of the code"
+                                    title: "Description"
+                                    type: "string"
+                                    minLength: 1
+                                    maxLength: 350
+                                additionalProperties: false
+                                required:
+                                  - "Name"
+                                  - "Description"
+                              OtherFeeRateType:
+                                description: "Other fee rate type code which is not available in the standard code set"
+                                type: "object"
+                                title: "OtherFeeRateType"
+                                properties:
+                                  Code:
+                                    description: "The four letter Mnemonic used within an XML file to identify a code"
+                                    title: "Code"
+                                    type: "string"
+                                    pattern: "^\\w{0,4}$"
+                                    minLength: 0
+                                    maxLength: 4
+                                  Name:
+                                    description: "Long name associated with the code"
+                                    title: "Name"
+                                    type: "string"
+                                    minLength: 1
+                                    maxLength: 70
+                                  Description:
+                                    description: "Description to describe the purpose of the code"
+                                    title: "Description"
+                                    type: "string"
+                                    minLength: 1
+                                    maxLength: 350
+                                additionalProperties: false
+                                required:
+                                  - "Name"
+                                  - "Description"
+                              OtherApplicationFrequency:
+                                description: "Other application frequencies that are not available in the standard code list"
+                                type: "object"
+                                title: "OtherApplicationFrequency"
+                                properties:
+                                  Code:
+                                    description: "The four letter Mnemonic used within an XML file to identify a code"
+                                    title: "Code"
+                                    type: "string"
+                                    pattern: "^\\w{0,4}$"
+                                    minLength: 0
+                                    maxLength: 4
+                                  Name:
+                                    description: "Long name associated with the code"
+                                    title: "Name"
+                                    type: "string"
+                                    minLength: 1
+                                    maxLength: 70
+                                  Description:
+                                    description: "Description to describe the purpose of the code"
+                                    title: "Description"
+                                    type: "string"
+                                    minLength: 1
+                                    maxLength: 350
+                                additionalProperties: false
+                                required:
+                                  - "Name"
+                                  - "Description"
+                              OtherCalculationFrequency:
+                                description: "Other calculation frequency which is not available in the standard code set."
+                                type: "object"
+                                title: "OtherCalculationFrequency"
+                                properties:
+                                  Code:
+                                    description: "The four letter Mnemonic used within an XML file to identify a code"
+                                    title: "Code"
+                                    type: "string"
+                                    pattern: "^\\w{0,4}$"
+                                    minLength: 0
+                                    maxLength: 4
+                                  Name:
+                                    description: "Long name associated with the code"
+                                    title: "Name"
+                                    type: "string"
+                                    minLength: 1
+                                    maxLength: 70
+                                  Description:
+                                    description: "Description to describe the purpose of the code"
+                                    title: "Description"
+                                    type: "string"
+                                    minLength: 1
+                                    maxLength: 350
+                                additionalProperties: false
+                                required:
+                                  - "Name"
+                                  - "Description"
+                            required:
+                              - "FeeType"
+                              - "ApplicationFrequency"
+                          minItems: 1
+                      required:
+                        - "OverdraftFeeChargeDetail"
+                required:
+                  - "TierBandMethod"
+                  - "OverdraftTierBand"
+              minItems: 1
+          additionalProperties: false
+          required:
+            - "OverdraftTierBandSet"
+        OtherFeesCharges:
+          description: "Contains details of fees and charges which are not associated with either Overdraft or features/benefits"
+          type: "array"
+          title: "OtherFeesCharges"
+          items:
+            description: "Contains details of fees and charges which are not associated with either Overdraft or features/benefits"
+            type: "object"
+            properties:
+              TariffType:
+                description: "TariffType which defines the fee and charges."
+                title: "TariffType"
+                type: "string"
+                enum:
+                  - "Electronic"
+                  - "Mixed"
+                  - "Other"
+              TariffName:
+                description: "Name of the tariff"
+                title: "TariffName"
+                type: "string"
+                minLength: 1
+                maxLength: 350
+              OtherTariffType:
+                description: "Other tariff type which is not in the standard list."
+                type: "object"
+                title: "OtherTariffType"
+                properties:
+                  Code:
+                    description: "The four letter Mnemonic used within an XML file to identify a code"
+                    title: "Code"
+                    type: "string"
+                    pattern: "^\\w{0,4}$"
+                    minLength: 0
+                    maxLength: 4
+                  Name:
+                    description: "Long name associated with the code"
+                    title: "Name"
+                    type: "string"
+                    minLength: 1
+                    maxLength: 70
+                  Description:
+                    description: "Description to describe the purpose of the code"
+                    title: "Description"
+                    type: "string"
+                    minLength: 1
+                    maxLength: 350
+                additionalProperties: false
+                required:
+                  - "Name"
+                  - "Description"
+              FeeChargeDetail:
+                description: "Other fees/charges details"
+                type: "array"
+                title: "FeeChargeDetail"
+                items:
+                  description: "Other fees/charges details"
+                  type: "object"
+                  properties:
+                    FeeCategory:
+                      description: "Categorisation of fees and charges into standard categories."
+                      title: "FeeCategory"
+                      type: "string"
+                      enum:
+                        - "Other"
+                        - "Servicing"
+                    FeeType:
+                      description: "Fee/Charge Type"
+                      title: "FeeType"
+                      type: "string"
+                      enum:
+                        - "Other"
+                        - "ServiceCAccountFee"
+                        - "ServiceCAccountFeeMonthly"
+                        - "ServiceCAccountFeeQuarterly"
+                        - "ServiceCFixedTariff"
+                        - "ServiceCBusiDepAccBreakage"
+                        - "ServiceCMinimumMonthlyFee"
+                        - "ServiceCOther"
+                    NegotiableIndicator:
+                      description: "Fee/charge which is usually negotiable rather than a fixed amount"
+                      title: "NegotiableIndicator"
+                      type: "boolean"
+                    FeeAmount:
+                      description: "Fee Amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)"
+                      title: "FeeAmount"
+                      type: "string"
+                      pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                    FeeRate:
+                      description: "Rate charged for Fee/Charge (where it is charged in terms of a rate rather than an amount)"
+                      title: "FeeRate"
+                      type: "string"
+                      pattern: "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$"
+                    FeeRateType:
+                      description: "Rate type for Fee/Charge (where it is charged in terms of a rate rather than an amount)"
+                      title: "FeeRateType"
+                      type: "string"
+                      enum:
+                        - "Gross"
+                        - "Other"
+                    ApplicationFrequency:
+                      description: "How frequently the fee/charge is applied to the account"
+                      title: "ApplicationFrequency"
+                      type: "string"
+                      enum:
+                        - "OnClosing"
+                        - "OnOpening"
+                        - "ChargingPeriod"
+                        - "Daily"
+                        - "PerItem"
+                        - "Monthly"
+                        - "OnAnniversary"
+                        - "Other"
+                        - "PerHundredPounds"
+                        - "PerHour"
+                        - "PerOccurrence"
+                        - "PerSheet"
+                        - "PerTransaction"
+                        - "PerTransactionAmount"
+                        - "PerTransactionPercentage"
+                        - "Quarterly"
+                        - "SixMonthly"
+                        - "StatementMonthly"
+                        - "Weekly"
+                        - "Yearly"
+                    CalculationFrequency:
+                      description: "How frequently the fee/charge is calculated"
+                      title: "CalculationFrequency"
+                      type: "string"
+                      enum:
+                        - "OnClosing"
+                        - "OnOpening"
+                        - "ChargingPeriod"
+                        - "Daily"
+                        - "PerItem"
+                        - "Monthly"
+                        - "OnAnniversary"
+                        - "Other"
+                        - "PerHundredPounds"
+                        - "PerHour"
+                        - "PerOccurrence"
+                        - "PerSheet"
+                        - "PerTransaction"
+                        - "PerTransactionAmount"
+                        - "PerTransactionPercentage"
+                        - "Quarterly"
+                        - "SixMonthly"
+                        - "StatementMonthly"
+                        - "Weekly"
+                        - "Yearly"
+                    Notes:
+                      description: "Optional additional notes to supplement the fee/charge details."
+                      title: "Notes"
+                      type: "array"
+                      items:
+                        description: "maxLength 2000 text"
+                        type: "string"
+                        minLength: 1
+                        maxLength: 2000
+                    FeeChargeCap:
+                      description: "Details about any caps (maximum charges) that apply to a particular or group of fee/charge"
+                      type: "array"
+                      title: "FeeChargeCap"
+                      items:
+                        description: "Details about any caps (maximum charges) that apply to a particular or group of fee/charge"
+                        type: "object"
+                        properties:
+                          FeeType:
+                            description: "Fee/charge type which is being capped"
+                            title: "FeeType"
+                            type: "array"
+                            items:
+                              description: "Fee/charge type which is being capped"
+                              type: "string"
+                              enum:
+                                - "Other"
+                                - "ServiceCAccountFee"
+                                - "ServiceCAccountFeeMonthly"
+                                - "ServiceCAccountFeeQuarterly"
+                                - "ServiceCFixedTariff"
+                                - "ServiceCBusiDepAccBreakage"
+                                - "ServiceCMinimumMonthlyFee"
+                                - "ServiceCOther"
+                            minItems: 1
+                          MinMaxType:
+                            description: "Min Max type"
+                            title: "MinMaxType"
+                            type: "string"
+                            enum:
+                              - "Minimum"
+                              - "Maximum"
+                          FeeCapOccurrence:
+                            description: "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount"
+                            title: "FeeCapOccurrence"
+                            type: "number"
+                            format: "float"
+                          FeeCapAmount:
+                            description: "Cap amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)"
+                            title: "FeeCapAmount"
+                            type: "string"
+                            pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                          CappingPeriod:
+                            description: "Period e.g. day, week, month etc. for which the fee/charge is capped"
+                            title: "CappingPeriod"
+                            type: "string"
+                            enum:
+                              - "Day"
+                              - "Half Year"
+                              - "Month"
+                              - "Quarter"
+                              - "Week"
+                              - "Year"
+                          Notes:
+                            description: "Free text for adding  extra details for fee charge cap"
+                            title: "Notes"
+                            type: "array"
+                            items:
+                              description: "maxLength 2000 text"
+                              type: "string"
+                              minLength: 1
+                              maxLength: 2000
+                          OtherFeeType:
+                            description: "Other fee type code which is not available in the standard code set"
+                            type: "array"
+                            title: "OtherFeeType"
+                            items:
+                              description: "Other fee type code which is not available in the standard code set"
+                              type: "object"
+                              properties:
+                                Code:
+                                  description: "The four letter Mnemonic used within an XML file to identify a code"
+                                  title: "Code"
+                                  type: "string"
+                                  pattern: "^\\w{0,4}$"
+                                  minLength: 0
+                                  maxLength: 4
+                                Name:
+                                  description: "Long name associated with the code"
+                                  title: "Name"
+                                  type: "string"
+                                  minLength: 1
+                                  maxLength: 70
+                                Description:
+                                  description: "Description to describe the purpose of the code"
+                                  title: "Description"
+                                  type: "string"
+                                  minLength: 1
+                                  maxLength: 350
+                              required:
+                                - "Name"
+                                - "Description"
+                        required:
+                          - "FeeType"
+                          - "MinMaxType"
+                    OtherFeeCategoryType:
+                      type: "object"
+                      title: "OtherFeeCategoryType"
+                      properties:
+                        Code:
+                          description: "The four letter Mnemonic used within an XML file to identify a code"
+                          title: "Code"
+                          type: "string"
+                          pattern: "^\\w{0,4}$"
+                          minLength: 0
+                          maxLength: 4
+                        Name:
+                          description: "Long name associated with the code"
+                          title: "Name"
+                          type: "string"
+                          minLength: 1
+                          maxLength: 70
+                        Description:
+                          description: "Description to describe the purpose of the code"
+                          title: "Description"
+                          type: "string"
+                          minLength: 1
+                          maxLength: 350
+                      additionalProperties: false
+                      required:
+                        - "Name"
+                        - "Description"
+                    OtherFeeType:
+                      description: "Other Fee/charge type which is not available in the standard code set"
+                      type: "object"
+                      title: "OtherFeeType"
+                      properties:
+                        Code:
+                          description: "The four letter Mnemonic used within an XML file to identify a code"
+                          title: "Code"
+                          type: "string"
+                          pattern: "^\\w{0,4}$"
+                          minLength: 0
+                          maxLength: 4
+                        FeeCategory:
+                          description: "Categorisation of fees and charges into standard categories."
+                          title: "FeeCategory"
+                          type: "string"
+                          enum:
+                            - "Other"
+                            - "Servicing"
+                        Name:
+                          description: "Long name associated with the code"
+                          title: "Name"
+                          type: "string"
+                          minLength: 1
+                          maxLength: 70
+                        Description:
+                          description: "Description to describe the purpose of the code"
+                          title: "Description"
+                          type: "string"
+                          minLength: 1
+                          maxLength: 350
+                      additionalProperties: false
+                      required:
+                        - "FeeCategory"
+                        - "Name"
+                        - "Description"
+                    OtherFeeRateType:
+                      description: "Other fee rate type which is not available in the standard code set"
+                      type: "object"
+                      title: "OtherFeeRateType"
+                      properties:
+                        Code:
+                          description: "The four letter Mnemonic used within an XML file to identify a code"
+                          title: "Code"
+                          type: "string"
+                          pattern: "^\\w{0,4}$"
+                          minLength: 0
+                          maxLength: 4
+                        Name:
+                          description: "Long name associated with the code"
+                          title: "Name"
+                          type: "string"
+                          minLength: 1
+                          maxLength: 70
+                        Description:
+                          description: "Description to describe the purpose of the code"
+                          title: "Description"
+                          type: "string"
+                          minLength: 1
+                          maxLength: 350
+                      additionalProperties: false
+                      required:
+                        - "Name"
+                        - "Description"
+                    OtherApplicationFrequency:
+                      description: "Other application frequencies not covered in the standard code list"
+                      type: "object"
+                      title: "OtherApplicationFrequency"
+                      properties:
+                        Code:
+                          description: "The four letter Mnemonic used within an XML file to identify a code"
+                          title: "Code"
+                          type: "string"
+                          pattern: "^\\w{0,4}$"
+                          minLength: 0
+                          maxLength: 4
+                        Name:
+                          description: "Long name associated with the code"
+                          title: "Name"
+                          type: "string"
+                          minLength: 1
+                          maxLength: 70
+                        Description:
+                          description: "Description to describe the purpose of the code"
+                          title: "Description"
+                          type: "string"
+                          minLength: 1
+                          maxLength: 350
+                      additionalProperties: false
+                      required:
+                        - "Name"
+                        - "Description"
+                    OtherCalculationFrequency:
+                      description: "Other calculation frequency which is not available in standard code set."
+                      type: "object"
+                      title: "OtherCalculationFrequency"
+                      properties:
+                        Code:
+                          description: "The four letter Mnemonic used within an XML file to identify a code"
+                          title: "Code"
+                          type: "string"
+                          pattern: "^\\w{0,4}$"
+                          minLength: 0
+                          maxLength: 4
+                        Name:
+                          description: "Long name associated with the code"
+                          title: "Name"
+                          type: "string"
+                          minLength: 1
+                          maxLength: 70
+                        Description:
+                          description: "Description to describe the purpose of the code"
+                          title: "Description"
+                          type: "string"
+                          minLength: 1
+                          maxLength: 350
+                      additionalProperties: false
+                      required:
+                        - "Name"
+                        - "Description"
+                    FeeApplicableRange:
+                      description: "Range or amounts or rates for which the fee/charge applies"
+                      type: "object"
+                      title: "FeeApplicableRange"
+                      properties:
+                        MinimumAmount:
+                          description: "Minimum Amount on which fee/charge is applicable (where it is expressed as an amount)"
+                          title: "MinimumAmount"
+                          type: "string"
+                          pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                        MaximumAmount:
+                          description: "Maximum Amount on which fee is applicable (where it is expressed as an amount)"
+                          title: "MaximumAmount"
+                          type: "string"
+                          pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                        MinimumRate:
+                          description: "Minimum rate on which fee/charge is applicable(where it is expressed as an rate)"
+                          title: "MinimumRate"
+                          type: "string"
+                          pattern: "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$"
+                        MaximumRate:
+                          description: "Maximum rate on which fee/charge is applicable(where it is expressed as an rate)"
+                          title: "MaximumRate"
+                          type: "string"
+                          pattern: "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$"
+                      additionalProperties: false
+                  required:
+                    - "FeeCategory"
+                    - "FeeType"
+                    - "ApplicationFrequency"
+                minItems: 1
+              FeeChargeCap:
+                description: "Details about any caps (maximum charges) that apply to a particular or group of fee/charge"
+                type: "array"
+                title: "FeeChargeCap"
+                items:
+                  description: "Details about any caps (maximum charges) that apply to a particular or group of fee/charge"
+                  type: "object"
+                  properties:
+                    FeeType:
+                      description: "Fee/charge type which is being capped"
+                      title: "FeeType"
+                      type: "array"
+                      items:
+                        description: "Fee/charge type which is being capped"
+                        type: "string"
+                        enum:
+                          - "Other"
+                          - "ServiceCAccountFee"
+                          - "ServiceCAccountFeeMonthly"
+                          - "ServiceCAccountFeeQuarterly"
+                          - "ServiceCFixedTariff"
+                          - "ServiceCBusiDepAccBreakage"
+                          - "ServiceCMinimumMonthlyFee"
+                          - "ServiceCOther"
+                      minItems: 1
+                    MinMaxType:
+                      description: "Min Max type"
+                      title: "MinMaxType"
+                      type: "string"
+                      enum:
+                        - "Minimum"
+                        - "Maximum"
+                    FeeCapOccurrence:
+                      description: "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount"
+                      title: "FeeCapOccurrence"
+                      type: "number"
+                      format: "float"
+                    FeeCapAmount:
+                      description: "Cap amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)"
+                      title: "FeeCapAmount"
+                      type: "string"
+                      pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                    CappingPeriod:
+                      description: "Period e.g. day, week, month etc. for which the fee/charge is capped"
+                      title: "CappingPeriod"
+                      type: "string"
+                      enum:
+                        - "Day"
+                        - "Half Year"
+                        - "Month"
+                        - "Quarter"
+                        - "Week"
+                        - "Year"
+                    Notes:
+                      description: "Free text for adding  extra details for fee charge cap"
+                      title: "Notes"
+                      type: "array"
+                      items:
+                        description: "maxLength 2000 text"
+                        type: "string"
+                        minLength: 1
+                        maxLength: 2000
+                    OtherFeeType:
+                      description: "Other fee type code which is not available in the standard code set"
+                      type: "array"
+                      title: "OtherFeeType"
+                      items:
+                        description: "Other fee type code which is not available in the standard code set"
+                        type: "object"
+                        properties:
+                          Code:
+                            description: "The four letter Mnemonic used within an XML file to identify a code"
+                            title: "Code"
+                            type: "string"
+                            pattern: "^\\w{0,4}$"
+                            minLength: 0
+                            maxLength: 4
+                          Name:
+                            description: "Long name associated with the code"
+                            title: "Name"
+                            type: "string"
+                            minLength: 1
+                            maxLength: 70
+                          Description:
+                            description: "Description to describe the purpose of the code"
+                            title: "Description"
+                            type: "string"
+                            minLength: 1
+                            maxLength: 350
+                        required:
+                          - "Name"
+                          - "Description"
+                  required:
+                    - "FeeType"
+                    - "MinMaxType"
+            required:
+              - "FeeChargeDetail"
+      additionalProperties: false
+    OBBalanceType1Code:
+      description: "Balance type, in a coded form."
+      type: "string"
+      enum:
+        - "ClosingAvailable"
+        - "ClosingBooked"
+        - "ClosingCleared"
+        - "Expected"
+        - "ForwardAvailable"
+        - "Information"
+        - "InterimAvailable"
+        - "InterimBooked"
+        - "InterimCleared"
+        - "OpeningAvailable"
+        - "OpeningBooked"
+        - "OpeningCleared"
+        - "PreviouslyClosedBooked"
+    OBBankTransactionCodeStructure1:
+      type: "object"
+      required:
+        - "Code"
+        - "SubCode"
+      description: "Set of elements used to fully identify the type of underlying transaction resulting in an entry."
+      properties:
+        Code:
+          description: "Specifies the family within a domain."
+          type: "string"
+        SubCode:
+          description: "Specifies the sub-product family within a specific family."
+          type: "string"
+    OBBeneficiary5:
+      type: "object"
+      properties:
+        AccountId:
+          $ref: "#/components/schemas/AccountId"
+        BeneficiaryId:
+          $ref: "#/components/schemas/BeneficiaryId"
+        BeneficiaryType:
+          $ref: "#/components/schemas/OBBeneficiaryType1Code"
+        Reference:
+          $ref: "#/components/schemas/Reference"
+        SupplementaryData:
+          $ref: "#/components/schemas/OBSupplementaryData1"
+        CreditorAgent:
+          $ref: "#/components/schemas/OBBranchAndFinancialInstitutionIdentification6_0"
+        CreditorAccount:
+          $ref: "#/components/schemas/OBCashAccount5_0"
+      additionalProperties: false
+    OBBeneficiary5Basic:
+      type: "object"
+      properties:
+        AccountId:
+          $ref: "#/components/schemas/AccountId"
+        BeneficiaryId:
+          $ref: "#/components/schemas/BeneficiaryId"
+        BeneficiaryType:
+          $ref: "#/components/schemas/OBBeneficiaryType1Code"
+        Reference:
+          $ref: "#/components/schemas/Reference"
+        SupplementaryData:
+          $ref: "#/components/schemas/OBSupplementaryData1"
+      additionalProperties: false
+    OBBeneficiary5Detail:
+      type: "object"
+      properties:
+        AccountId:
+          $ref: "#/components/schemas/AccountId"
+        BeneficiaryId:
+          $ref: "#/components/schemas/BeneficiaryId"
+        BeneficiaryType:
+          $ref: "#/components/schemas/OBBeneficiaryType1Code"
+        Reference:
+          $ref: "#/components/schemas/Reference"
+        SupplementaryData:
+          $ref: "#/components/schemas/OBSupplementaryData1"
+        CreditorAgent:
+          $ref: "#/components/schemas/OBBranchAndFinancialInstitutionIdentification6_0"
+        CreditorAccount:
+          $ref: "#/components/schemas/OBCashAccount5_0"
+      additionalProperties: false
+      required:
+        - "CreditorAccount"
+    OBBranchAndFinancialInstitutionIdentification5_0:
+      type: "object"
+      required:
+        - "SchemeName"
+        - "Identification"
+      description: "Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account."
+      properties:
+        SchemeName:
+          $ref: "#/components/schemas/OBExternalFinancialInstitutionIdentification4Code"
+        Identification:
+          $ref: "#/components/schemas/Identification_1"
+    OBBranchAndFinancialInstitutionIdentification5_1:
+      type: "object"
+      required:
+        - "SchemeName"
+        - "Identification"
+      description: "Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account.\nThis is the servicer of the beneficiary account."
+      properties:
+        SchemeName:
+          $ref: "#/components/schemas/OBExternalFinancialInstitutionIdentification4Code"
+        Identification:
+          $ref: "#/components/schemas/Identification_1"
+    OBBranchAndFinancialInstitutionIdentification6_0:
+      type: "object"
+      description: "Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account.\nThis is the servicer of the beneficiary account."
+      properties:
+        SchemeName:
+          $ref: "#/components/schemas/OBExternalFinancialInstitutionIdentification4Code"
+        Identification:
+          $ref: "#/components/schemas/Identification_1"
+        Name:
+          $ref: "#/components/schemas/Name_1"
+        PostalAddress:
+          $ref: "#/components/schemas/OBPostalAddress6"
+    OBBranchAndFinancialInstitutionIdentification6_1:
+      type: "object"
+      description: "Financial institution servicing an account for the creditor."
+      properties:
+        SchemeName:
+          $ref: "#/components/schemas/OBExternalFinancialInstitutionIdentification4Code"
+        Identification:
+          $ref: "#/components/schemas/Identification_2"
+        Name:
+          $ref: "#/components/schemas/Name_1"
+        PostalAddress:
+          $ref: "#/components/schemas/OBPostalAddress6"
+    OBBranchAndFinancialInstitutionIdentification6_2:
+      type: "object"
+      description: "Financial institution servicing an account for the debtor."
+      properties:
+        SchemeName:
+          $ref: "#/components/schemas/OBExternalFinancialInstitutionIdentification4Code"
+        Identification:
+          $ref: "#/components/schemas/Identification_2"
+        Name:
+          $ref: "#/components/schemas/Name_1"
+        PostalAddress:
+          $ref: "#/components/schemas/OBPostalAddress6"
+    OBCashAccount5_0:
+      type: "object"
+      required:
+        - "SchemeName"
+        - "Identification"
+      description: "Provides the details to identify the beneficiary account."
+      properties:
+        SchemeName:
+          $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+        Identification:
+          $ref: "#/components/schemas/Identification_0"
+        Name:
+          $ref: "#/components/schemas/Name_0"
+        SecondaryIdentification:
+          $ref: "#/components/schemas/SecondaryIdentification"
+    OBCashAccount5_1:
+      type: "object"
+      required:
+        - "SchemeName"
+        - "Identification"
+      description: "Provides the details to identify the beneficiary account."
+      properties:
+        SchemeName:
+          $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+        Identification:
+          description: "Beneficiary account identification."
+          type: "string"
+          minLength: 1
+          maxLength: 256
+        Name:
+          $ref: "#/components/schemas/Name_0"
+        SecondaryIdentification:
+          $ref: "#/components/schemas/SecondaryIdentification"
+    OBCashAccount6_0:
+      type: "object"
+      description: "Unambiguous identification of the account of the creditor, in the case of a debit transaction."
+      properties:
+        SchemeName:
+          $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+        Identification:
+          $ref: "#/components/schemas/Identification_0"
+        Name:
+          $ref: "#/components/schemas/Name_0"
+        SecondaryIdentification:
+          $ref: "#/components/schemas/SecondaryIdentification"
+    OBCashAccount6_1:
+      type: "object"
+      description: "Unambiguous identification of the account of the debtor, in the case of a crebit transaction."
+      properties:
+        SchemeName:
+          $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+        Identification:
+          $ref: "#/components/schemas/Identification_0"
+        Name:
+          $ref: "#/components/schemas/Name_0"
+        SecondaryIdentification:
+          $ref: "#/components/schemas/SecondaryIdentification"
+    OBCreditDebitCode_0:
+      description: "Indicates whether the amount is a credit or a debit. \nUsage: A zero amount is considered to be a credit amount."
+      type: "string"
+      enum:
+        - "Credit"
+        - "Debit"
+    OBCreditDebitCode_1:
+      description: "Indicates whether the transaction is a credit or a debit entry."
+      type: "string"
+      enum:
+        - "Credit"
+        - "Debit"
+    OBCreditDebitCode_2:
+      description: "Indicates whether the balance is a credit or a debit balance. \nUsage: A zero balance is considered to be a credit balance."
+      type: "string"
+      enum:
+        - "Credit"
+        - "Debit"
+    OBCurrencyExchange5:
+      type: "object"
+      required:
+        - "SourceCurrency"
+        - "ExchangeRate"
+      description: "Set of elements used to provide details on the currency exchange."
+      properties:
+        SourceCurrency:
+          description: "Currency from which an amount is to be converted in a currency conversion."
+          type: "string"
+          pattern: "^[A-Z]{3,3}$"
+        TargetCurrency:
+          description: "Currency into which an amount is to be converted in a currency conversion."
+          type: "string"
+          pattern: "^[A-Z]{3,3}$"
+        UnitCurrency:
+          description: "Currency in which the rate of exchange is expressed in a currency exchange. In the example 1GBP = xxxCUR, the unit currency is GBP."
+          type: "string"
+          pattern: "^[A-Z]{3,3}$"
+        ExchangeRate:
+          description: "Factor used to convert an amount from one currency into another. This reflects the price at which one currency was bought with another currency.\nUsage: ExchangeRate expresses the ratio between UnitCurrency and QuotedCurrency (ExchangeRate = UnitCurrency/QuotedCurrency)."
+          type: "number"
+        ContractIdentification:
+          description: "Unique identification to unambiguously identify the foreign exchange contract."
+          type: "string"
+          minLength: 1
+          maxLength: 35
+        QuotationDate:
+          description: "Date and time at which an exchange rate is quoted.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+          type: "string"
+          format: "date-time"
+        InstructedAmount:
+          type: "object"
+          required:
+            - "Amount"
+            - "Currency"
+          description: "Amount of money to be moved between the debtor and creditor, before deduction of charges, expressed in the currency as ordered by the initiating party."
+          properties:
+            Amount:
+              $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+            Currency:
+              $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode_1"
+    OBEntryStatus1Code:
+      description: "Status of a transaction entry on the books of the account servicer."
+      type: "string"
+      enum:
+        - "Booked"
+        - "Pending"
+        - "Rejected"
+    OBTransactionMutability1Code:
+      description: "Specifies the Mutability of the Transaction record."
+      type: "string"
+      enum:
+        - "Mutable"
+        - "Immutable"
+    OBError1:
+      type: "object"
+      properties:
+        ErrorCode:
+          description: "Low level textual error code, e.g., UK.OBIE.Field.Missing"
+          type: "string"
+          x-namespaced-enum:
+            - "UK.OBIE.Field.Expected"
+            - "UK.OBIE.Field.Invalid"
+            - "UK.OBIE.Field.InvalidDate"
+            - "UK.OBIE.Field.Missing"
+            - "UK.OBIE.Field.Unexpected"
+            - "UK.OBIE.Header.Invalid"
+            - "UK.OBIE.Header.Missing"
+            - "UK.OBIE.Reauthenticate"
+            - "UK.OBIE.Resource.ConsentMismatch"
+            - "UK.OBIE.Resource.InvalidConsentStatus"
+            - "UK.OBIE.Resource.InvalidFormat"
+            - "UK.OBIE.Resource.NotFound"
+            - "UK.OBIE.Rules.AfterCutOffDateTime"
+            - "UK.OBIE.Rules.DuplicateReference"
+            - "UK.OBIE.Signature.Invalid"
+            - "UK.OBIE.Signature.InvalidClaim"
+            - "UK.OBIE.Signature.Malformed"
+            - "UK.OBIE.Signature.Missing"
+            - "UK.OBIE.Signature.MissingClaim"
+            - "UK.OBIE.Signature.Unexpected"
+            - "UK.OBIE.UnexpectedError"
+            - "UK.OBIE.Unsupported.AccountIdentifier"
+            - "UK.OBIE.Unsupported.AccountSecondaryIdentifier"
+            - "UK.OBIE.Unsupported.Currency"
+            - "UK.OBIE.Unsupported.Frequency"
+            - "UK.OBIE.Unsupported.LocalInstrument"
+            - "UK.OBIE.Unsupported.Scheme"
+        Message:
+          description: "A description of the error that occurred. e.g., 'A mandatory field isn't supplied' or 'RequestedExecutionDateTime must be in future'\nOBIE doesn't standardise this field"
+          type: "string"
+          minLength: 1
+          maxLength: 500
+        Path:
+          description: "Recommended but optional reference to the JSON Path of the field with error, e.g., Data.Initiation.InstructedAmount.Currency"
+          type: "string"
+          minLength: 1
+          maxLength: 500
+        Url:
+          description: "URL to help remediate the problem, or provide more information, or to API Reference, or help etc"
+          type: "string"
+      required:
+        - "ErrorCode"
+        - "Message"
+      additionalProperties: false
+      minProperties: 1
+    OBErrorResponse1:
+      description: "An array of detail error codes, and messages, and URLs to documentation to help remediation."
+      type: "object"
+      properties:
+        Code:
+          description: "High level textual error code, to help categorize the errors."
+          type: "string"
+          minLength: 1
+          maxLength: 40
+        Id:
+          description: "A unique reference for the error instance, for audit purposes, in case of unknown/unclassified errors."
+          type: "string"
+          minLength: 1
+          maxLength: 40
+        Message:
+          description: "Brief Error message, e.g., 'There is something wrong with the request parameters provided'"
+          type: "string"
+          minLength: 1
+          maxLength: 500
+        Errors:
+          items:
+            $ref: "#/components/schemas/OBError1"
+          type: "array"
+          minItems: 1
+      required:
+        - "Code"
+        - "Message"
+        - "Errors"
+      additionalProperties: false
+    OBExternalAccountIdentification4Code:
+      description: "Name of the identification scheme, in a coded form as published in an external list."
+      type: "string"
+      x-namespaced-enum:
+        - "UK.OBIE.BBAN"
+        - "UK.OBIE.IBAN"
+        - "UK.OBIE.PAN"
+        - "UK.OBIE.Paym"
+        - "UK.OBIE.SortCodeAccountNumber"
+    OBExternalAccountRole1Code:
+      description: "A party’s role with respect to the related account."
+      type: "string"
+      x-namespaced-enum:
+        - "UK.OBIE.Administrator"
+        - "UK.OBIE.Beneficiary"
+        - "UK.OBIE.CustodianForMinor"
+        - "UK.OBIE.Granter"
+        - "UK.OBIE.LegalGuardian"
+        - "UK.OBIE.OtherParty"
+        - "UK.OBIE.PowerOfAttorney"
+        - "UK.OBIE.Principal"
+        - "UK.OBIE.Protector"
+        - "UK.OBIE.RegisteredShareholderName"
+        - "UK.OBIE.SecondaryOwner"
+        - "UK.OBIE.SeniorManagingOfficial"
+        - "UK.OBIE.Settlor"
+        - "UK.OBIE.SuccessorOnDeath"
+    OBExternalAccountSubType1Code:
+      description: "Specifies the sub type of account (product family group)."
+      type: "string"
+      enum:
+        - "ChargeCard"
+        - "CreditCard"
+        - "CurrentAccount"
+        - "EMoney"
+        - "Loan"
+        - "Mortgage"
+        - "PrePaidCard"
+        - "Savings"
+    OBExternalAccountType1Code:
+      description: "Specifies the type of account (personal or business)."
+      type: "string"
+      enum:
+        - "Business"
+        - "Personal"
+    OBExternalDirectDebitStatus1Code:
+      description: "Specifies the status of the direct debit in code form."
+      type: "string"
+      enum:
+        - "Active"
+        - "Inactive"
+    OBExternalFinancialInstitutionIdentification4Code:
+      description: "Name of the identification scheme, in a coded form as published in an external list."
+      type: "string"
+      x-namespaced-enum:
+        - "UK.OBIE.BICFI"
+    OBExternalSwitchStatusCode:
+      description: "Specifies the switch status for the account, in a coded form."
+      type: "string"
+      x-namespaced-enum:
+        - "UK.CASS.NotSwitched"
+        - "UK.CASS.SwitchCompleted"
+    OBExternalLegalStructureType1Code:
+      description: "Legal standing of the party."
+      type: "string"
+      x-namespaced-enum:
+        - "UK.OBIE.CIC"
+        - "UK.OBIE.CIO"
+        - "UK.OBIE.Charity"
+        - "UK.OBIE.CoOp"
+        - "UK.OBIE.GeneralPartnership"
+        - "UK.OBIE.Individual"
+        - "UK.OBIE.LimitedLiabilityPartnership"
+        - "UK.OBIE.LimitedPartnership"
+        - "UK.OBIE.PrivateLimitedCompany"
+        - "UK.OBIE.PublicLimitedCompany"
+        - "UK.OBIE.ScottishLimitedPartnership"
+        - "UK.OBIE.Sole"
+    OBExternalPartyType1Code:
+      description: "Party type, in a coded form."
+      type: "string"
+      enum:
+        - "Delegate"
+        - "Joint"
+        - "Sole"
+    OBExternalScheduleType1Code:
+      description: "Specifies the scheduled payment date type requested"
+      type: "string"
+      enum:
+        - "Arrival"
+        - "Execution"
+    OBExternalStandingOrderStatus1Code:
+      description: "Specifies the status of the standing order in code form."
+      type: "string"
+      enum:
+        - "Active"
+        - "Inactive"
+    OBExternalStatementAmountType1Code:
+      description: "Amount type, in a coded form."
+      type: "string"
+      x-namespaced-enum:
+        - "UK.OBIE.ArrearsClosingBalance"
+        - "UK.OBIE.AvailableBalance"
+        - "UK.OBIE.AverageBalanceWhenInCredit"
+        - "UK.OBIE.AverageBalanceWhenInDebit"
+        - "UK.OBIE.AverageDailyBalance"
+        - "UK.OBIE.BalanceTransferClosingBalance"
+        - "UK.OBIE.CashClosingBalance"
+        - "UK.OBIE.ClosingBalance"
+        - "UK.OBIE.CreditLimit"
+        - "UK.OBIE.CurrentPayment"
+        - "UK.OBIE.DirectDebitPaymentDue"
+        - "UK.OBIE.FSCSInsurance"
+        - "UK.OBIE.MinimumPaymentDue"
+        - "UK.OBIE.PendingTransactionsBalance"
+        - "UK.OBIE.PreviousClosingBalance"
+        - "UK.OBIE.PreviousPayment"
+        - "UK.OBIE.PurchaseClosingBalance"
+        - "UK.OBIE.StartingBalance"
+        - "UK.OBIE.TotalAdjustments"
+        - "UK.OBIE.TotalCashAdvances"
+        - "UK.OBIE.TotalCharges"
+        - "UK.OBIE.TotalCredits"
+        - "UK.OBIE.TotalDebits"
+        - "UK.OBIE.TotalPurchases"
+    OBExternalStatementBenefitType1Code:
+      description: "Benefit type, in a coded form."
+      type: "string"
+      x-namespaced-enum:
+        - "UK.OBIE.Cashback"
+        - "UK.OBIE.Insurance"
+        - "UK.OBIE.TravelDiscount"
+        - "UK.OBIE.TravelInsurance"
+    OBExternalStatementDateTimeType1Code:
+      description: "Date time type, in a coded form."
+      type: "string"
+      x-namespaced-enum:
+        - "UK.OBIE.BalanceTransferPromoEnd"
+        - "UK.OBIE.DirectDebitDue"
+        - "UK.OBIE.LastPayment"
+        - "UK.OBIE.LastStatement"
+        - "UK.OBIE.NextStatement"
+        - "UK.OBIE.PaymentDue"
+        - "UK.OBIE.PurchasePromoEnd"
+        - "UK.OBIE.StatementAvailable"
+    OBExternalStatementFeeFrequency1Code:
+      description: "How frequently the fee is applied to the Account."
+      type: "string"
+      x-namespaced-enum:
+        - "UK.OBIE.ChargingPeriod"
+        - "UK.OBIE.PerTransactionAmount"
+        - "UK.OBIE.PerTransactionPercentage"
+        - "UK.OBIE.Quarterly"
+        - "UK.OBIE.StatementMonthly"
+        - "UK.OBIE.Weekly"
+    OBExternalStatementFeeRateType1Code:
+      description: "Description that may be available for the statement fee rate type."
+      type: "string"
+      x-namespaced-enum:
+        - "UK.OBIE.AER"
+        - "UK.OBIE.EAR"
+    OBExternalStatementFeeType1Code:
+      description: "Fee type, in a coded form."
+      type: "string"
+      x-namespaced-enum:
+        - "UK.OBIE.Annual"
+        - "UK.OBIE.BalanceTransfer"
+        - "UK.OBIE.CashAdvance"
+        - "UK.OBIE.CashTransaction"
+        - "UK.OBIE.ForeignCashTransaction"
+        - "UK.OBIE.ForeignTransaction"
+        - "UK.OBIE.Gambling"
+        - "UK.OBIE.LatePayment"
+        - "UK.OBIE.MoneyTransfer"
+        - "UK.OBIE.Monthly"
+        - "UK.OBIE.Overlimit"
+        - "UK.OBIE.PostalOrder"
+        - "UK.OBIE.PrizeEntry"
+        - "UK.OBIE.StatementCopy"
+        - "UK.OBIE.Total"
+    OBExternalStatementInterestFrequency1Code:
+      description: "Specifies the statement fee type requested"
+      type: "string"
+      x-namespaced-enum:
+        - "UK.OBIE.Daily"
+        - "UK.OBIE.HalfYearly"
+        - "UK.OBIE.Monthly"
+        - "UK.OBIE.PerStatementDate"
+        - "UK.OBIE.Quarterly"
+        - "UK.OBIE.Weekly"
+        - "UK.OBIE.Yearly"
+    OBExternalStatementInterestRateType1Code:
+      description: "Description that may be available for the statement Interest rate type."
+      type: "string"
+      x-namespaced-enum:
+        - "UK.OBIE.BOEBaseRate"
+        - "UK.OBIE.FixedRate"
+        - "UK.OBIE.Gross"
+        - "UK.OBIE.LoanProviderBaseRate"
+        - "UK.OBIE.Net"
+    OBExternalStatementInterestType1Code:
+      description: "Interest amount type, in a coded form."
+      type: "string"
+      x-namespaced-enum:
+        - "UK.OBIE.BalanceTransfer"
+        - "UK.OBIE.Cash"
+        - "UK.OBIE.EstimatedNext"
+        - "UK.OBIE.Purchase"
+        - "UK.OBIE.Total"
+    OBExternalStatementRateType1Code:
+      description: "Statement rate type, in a coded form."
+      type: "string"
+      x-namespaced-enum:
+        - "UK.OBIE.AnnualBalanceTransfer"
+        - "UK.OBIE.AnnualBalanceTransferAfterPromo"
+        - "UK.OBIE.AnnualBalanceTransferPromo"
+        - "UK.OBIE.AnnualCash"
+        - "UK.OBIE.AnnualPurchase"
+        - "UK.OBIE.AnnualPurchaseAfterPromo"
+        - "UK.OBIE.AnnualPurchasePromo"
+        - "UK.OBIE.MonthlyBalanceTransfer"
+        - "UK.OBIE.MonthlyCash"
+        - "UK.OBIE.MonthlyPurchase"
+    OBExternalStatementType1Code:
+      description: "Statement type, in a coded form."
+      type: "string"
+      enum:
+        - "AccountClosure"
+        - "AccountOpening"
+        - "Annual"
+        - "Interim"
+        - "RegularPeriodic"
+    OBExternalStatementValueType1Code:
+      description: "Statement value type, in a coded form."
+      type: "string"
+      x-namespaced-enum:
+        - "UK.OBIE.AirMilesPoints"
+        - "UK.OBIE.AirMilesPointsBalance"
+        - "UK.OBIE.Credits"
+        - "UK.OBIE.Debits"
+        - "UK.OBIE.HotelPoints"
+        - "UK.OBIE.HotelPointsBalance"
+        - "UK.OBIE.RetailShoppingPoints"
+        - "UK.OBIE.RetailShoppingPointsBalance"
+    OBMerchantDetails1:
+      type: "object"
+      description: "Details of the merchant involved in the transaction."
+      properties:
+        MerchantName:
+          description: "Name by which the merchant is known."
+          type: "string"
+          minLength: 1
+          maxLength: 350
+        MerchantCategoryCode:
+          description: "Category code conform to ISO 18245, related to the type of services or goods the merchant provides for the transaction."
+          type: "string"
+          minLength: 3
+          maxLength: 4
+    OBPCAData1:
+      type: "object"
+      title: "PCA"
+      properties:
+        ProductDetails:
+          type: "object"
+          title: "ProductDetails"
+          properties:
+            Segment:
+              description: "Market segmentation is a marketing term referring to the aggregating of prospective buyers into groups, or segments, that have common needs and respond similarly to a marketing action. Market segmentation enables companies to target different categories of consumers who perceive the full value of certain products and services differently from one another.\n\nRead more: Market Segmentation http://www.investopedia.com/terms/m/marketsegmentation.asp#ixzz4gfEEalTd \nWith respect to PCA products, they are segmented in relation to different markets that they wish to focus on. "
+              title: "Segment"
+              type: "array"
+              items:
+                description: "Market segmentation is a marketing term referring to the aggregating of prospective buyers into groups, or segments, that have common needs and respond similarly to a marketing action. Market segmentation enables companies to target different categories of consumers who perceive the full value of certain products and services differently from one another.\n\nRead more: Market Segmentation http://www.investopedia.com/terms/m/marketsegmentation.asp#ixzz4gfEEalTd \nWith respect to PCA products, they are segmented in relation to different markets that they wish to focus on. "
+                type: "string"
+                enum:
+                  - "Basic"
+                  - "BenefitAndReward"
+                  - "CreditInterest"
+                  - "Cashback"
+                  - "General"
+                  - "Graduate"
+                  - "Other"
+                  - "Overdraft"
+                  - "Packaged"
+                  - "Premium"
+                  - "Reward"
+                  - "Student"
+                  - "YoungAdult"
+                  - "Youth"
+            MonthlyMaximumCharge:
+              description: "The maximum relevant charges that could accrue as defined fully in Part 7 of the CMA order"
+              title: "MonthlyMaximumCharge"
+              type: "string"
+              pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+            Notes:
+              description: "Optional additional notes to supplement the Core product details"
+              title: "Notes"
+              type: "array"
+              items:
+                description: "maxLength 2000 text"
+                type: "string"
+                minLength: 1
+                maxLength: 2000
+          additionalProperties: false
+        CreditInterest:
+          description: "Details about the interest that may be payable to the PCA account holders"
+          type: "object"
+          title: "CreditInterest"
+          properties:
+            TierBandSet:
+              description: "The group of tiers or bands for which credit interest can be applied."
+              type: "array"
+              title: "TierBandSet"
+              items:
+                description: "The group of tiers or bands for which credit interest can be applied."
+                type: "object"
+                properties:
+                  TierBandMethod:
+                    description: "The methodology of how credit interest is charged. It can be:-\n\n1. Banded\nInterest rates are banded. i.e. Increasing rate on whole balance as balance increases.\n\n2. Tiered\nInterest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance.\n\n3. Whole\nThe same interest rate is applied irrespective of the PCA balance"
+                    title: "TierBandMethod"
+                    type: "string"
+                    enum:
+                      - "Tiered"
+                      - "Whole"
+                  CalculationMethod:
+                    description: "Methods of calculating interest"
+                    title: "CalculationMethod"
+                    type: "string"
+                    enum:
+                      - "Compound"
+                      - "SimpleInterest"
+                  Destination:
+                    description: "Describes whether accrued interest is payable only to the PCA or to another bank account"
+                    title: "Destination"
+                    type: "string"
+                    enum:
+                      - "PayAway"
+                      - "SelfCredit"
+                  Notes:
+                    description: "Optional additional notes to supplement the Tier Band Set details"
+                    title: "Notes"
+                    type: "array"
+                    items:
+                      description: "maxLength 2000 text"
+                      type: "string"
+                      minLength: 1
+                      maxLength: 2000
+                  TierBand:
+                    description: "Tier Band Details"
+                    type: "array"
+                    title: "TierBand"
+                    items:
+                      description: "Tier Band Details"
+                      type: "object"
+                      properties:
+                        Identification:
+                          description: "Unique and unambiguous identification of a  Tier Band for a PCA."
+                          title: "Identification"
+                          type: "string"
+                          minLength: 1
+                          maxLength: 35
+                        TierValueMinimum:
+                          description: "Minimum deposit value for which the credit interest tier applies."
+                          title: "TierValueMinimum"
+                          type: "string"
+                          pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                        TierValueMaximum:
+                          description: "Maximum deposit value for which the credit interest tier applies."
+                          title: "TierValueMaximum"
+                          type: "string"
+                          pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                        CalculationFrequency:
+                          description: "How often is credit interest calculated for the account."
+                          title: "CalculationFrequency"
+                          type: "string"
+                          enum:
+                            - "PerAcademicTerm"
+                            - "Daily"
+                            - "HalfYearly"
+                            - "Monthly"
+                            - "Other"
+                            - "Quarterly"
+                            - "PerStatementDate"
+                            - "Weekly"
+                            - "Yearly"
+                        ApplicationFrequency:
+                          description: "How often is interest applied to the PCA for this tier/band i.e. how often the financial institution pays accumulated interest to the customer's PCA."
+                          title: "ApplicationFrequency"
+                          type: "string"
+                          enum:
+                            - "PerAcademicTerm"
+                            - "Daily"
+                            - "HalfYearly"
+                            - "Monthly"
+                            - "Other"
+                            - "Quarterly"
+                            - "PerStatementDate"
+                            - "Weekly"
+                            - "Yearly"
+                        DepositInterestAppliedCoverage:
+                          description: "Amount on which Interest applied."
+                          title: "DepositInterestAppliedCoverage"
+                          type: "string"
+                          enum:
+                            - "Tiered"
+                            - "Whole"
+                        FixedVariableInterestRateType:
+                          description: "Type of interest rate, Fixed or Variable"
+                          title: "FixedVariableInterestRateType"
+                          type: "string"
+                          enum:
+                            - "Fixed"
+                            - "Variable"
+                        AER:
+                          description: "The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made. \n\nRead more: Annual Equivalent Rate (AER) http://www.investopedia.com/terms/a/aer.asp#ixzz4gfR7IO1A"
+                          title: "AER"
+                          type: "string"
+                          pattern: "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$"
+                        BankInterestRateType:
+                          description: "Interest rate types, other than AER, which financial institutions may use to describe the annual interest rate payable to the PCA."
+                          title: "BankInterestRateType"
+                          type: "string"
+                          enum:
+                            - "LinkedBaseRate"
+                            - "Gross"
+                            - "Net"
+                            - "Other"
+                        BankInterestRate:
+                          description: "Bank Interest for the PCA product"
+                          title: "BankInterestRate"
+                          type: "string"
+                          pattern: "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$"
+                        Notes:
+                          description: "Optional additional notes to supplement the Tier Band details"
+                          title: "Notes"
+                          type: "array"
+                          items:
+                            description: "maxLength 2000 text"
+                            type: "string"
+                            minLength: 1
+                            maxLength: 2000
+                        OtherBankInterestType:
+                          description: "Other interest rate types which are not available in the standard code list"
+                          type: "object"
+                          title: "OtherBankInterestType"
+                          properties:
+                            Code:
+                              description: "The four letter Mnemonic used within an XML file to identify a code"
+                              title: "Code"
+                              type: "string"
+                              pattern: "^\\w{0,4}$"
+                              minLength: 0
+                              maxLength: 4
+                            Name:
+                              description: "Long name associated with the code"
+                              title: "Name"
+                              type: "string"
+                              minLength: 1
+                              maxLength: 70
+                            Description:
+                              description: "Description to describe the purpose of the code"
+                              title: "Description"
+                              type: "string"
+                              minLength: 1
+                              maxLength: 350
+                          additionalProperties: false
+                          required:
+                            - "Name"
+                            - "Description"
+                        OtherApplicationFrequency:
+                          description: "Other application frequencies that are not available in the standard code list"
+                          type: "object"
+                          title: "OtherApplicationFrequency"
+                          properties:
+                            Code:
+                              description: "The four letter Mnemonic used within an XML file to identify a code"
+                              title: "Code"
+                              type: "string"
+                              pattern: "^\\w{0,4}$"
+                              minLength: 0
+                              maxLength: 4
+                            Name:
+                              description: "Long name associated with the code"
+                              title: "Name"
+                              type: "string"
+                              minLength: 1
+                              maxLength: 70
+                            Description:
+                              description: "Description to describe the purpose of the code"
+                              title: "Description"
+                              type: "string"
+                              minLength: 1
+                              maxLength: 350
+                          additionalProperties: false
+                          required:
+                            - "Name"
+                            - "Description"
+                        OtherCalculationFrequency:
+                          description: "Other calculation frequency which is not available in the standard code set."
+                          type: "object"
+                          title: "OtherCalculationFrequency"
+                          properties:
+                            Code:
+                              description: "The four letter Mnemonic used within an XML file to identify a code"
+                              title: "Code"
+                              type: "string"
+                              pattern: "^\\w{0,4}$"
+                              minLength: 0
+                              maxLength: 4
+                            Name:
+                              description: "Long name associated with the code"
+                              title: "Name"
+                              type: "string"
+                              minLength: 1
+                              maxLength: 70
+                            Description:
+                              description: "Description to describe the purpose of the code"
+                              title: "Description"
+                              type: "string"
+                              minLength: 1
+                              maxLength: 350
+                          additionalProperties: false
+                          required:
+                            - "Name"
+                            - "Description"
+                      required:
+                        - "TierValueMinimum"
+                        - "ApplicationFrequency"
+                        - "FixedVariableInterestRateType"
+                        - "AER"
+                    minItems: 1
+                required:
+                  - "TierBandMethod"
+                  - "TierBand"
+              minItems: 1
+          additionalProperties: false
+          required:
+            - "TierBandSet"
+        Overdraft:
+          description: "Details about Overdraft rates, fees & charges"
+          type: "object"
+          title: "Overdraft"
+          properties:
+            Notes:
+              description: "Associated Notes about the overdraft rates"
+              title: "Notes"
+              type: "array"
+              items:
+                description: "maxLength 2000 text"
+                type: "string"
+                minLength: 1
+                maxLength: 2000
+            OverdraftTierBandSet:
+              description: "Tier band set details"
+              type: "array"
+              title: "OverdraftTierBandSet"
+              items:
+                description: "Tier band set details"
+                type: "object"
+                properties:
+                  TierBandMethod:
+                    description: "The methodology of how overdraft is charged. It can be:\n'Whole'  Where the same charge/rate is applied to the entirety of the overdraft balance (where charges are applicable). \n'Tiered' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount tiers defined by the lending financial organisation\n'Banded' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount bands defined by a government organisation."
+                    title: "TierBandMethod"
+                    type: "string"
+                    enum:
+                      - "Tiered"
+                      - "Whole"
+                      - "Banded"
+                  OverdraftType:
+                    description: "An overdraft can either be 'committed' which means that the facility cannot be withdrawn without reasonable notification before it's agreed end date, or 'on demand' which means that the financial institution can demand repayment at any point in time."
+                    title: "OverdraftType"
+                    type: "string"
+                    enum:
+                      - "Committed"
+                      - "OnDemand"
+                      - "Other"
+                  Identification:
+                    description: "Unique and unambiguous identification of a  Tier Band for a overdraft product."
+                    title: "Identification"
+                    type: "string"
+                    minLength: 1
+                    maxLength: 35
+                  AuthorisedIndicator:
+                    description: "Indicates if the Overdraft is authorised (Y) or unauthorised (N)"
+                    title: "AuthorisedIndicator"
+                    type: "boolean"
+                  BufferAmount:
+                    description: "When a customer exceeds their credit limit, a financial institution will not charge the customer unauthorised overdraft charges if they do not exceed by more than the buffer amount. Note: Authorised overdraft charges may still apply."
+                    title: "BufferAmount"
+                    type: "string"
+                    pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                  Notes:
+                    description: "Optional additional notes to supplement the overdraft Tier Band Set details"
+                    title: "Notes"
+                    type: "array"
+                    items:
+                      description: "maxLength 2000 text"
+                      type: "string"
+                      minLength: 1
+                      maxLength: 2000
+                  OverdraftTierBand:
+                    description: "Provides overdraft details for a specific tier or band"
+                    type: "array"
+                    title: "OverdraftTierBand"
+                    items:
+                      description: "Provides overdraft details for a specific tier or band"
+                      type: "object"
+                      properties:
+                        Identification:
+                          description: "Unique and unambiguous identification of a  Tier Band for a overdraft."
+                          title: "Identification"
+                          type: "string"
+                          minLength: 1
+                          maxLength: 35
+                        TierValueMin:
+                          description: "Minimum value of Overdraft Tier/Band"
+                          title: "TierValueMin"
+                          type: "string"
+                          pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                        TierValueMax:
+                          description: "Maximum value of Overdraft Tier/Band"
+                          title: "TierValueMax"
+                          type: "string"
+                          pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                        OverdraftInterestChargingCoverage:
+                          description: "Interest charged on whole amount or tiered/banded"
+                          title: "OverdraftInterestChargingCoverage"
+                          type: "string"
+                          enum:
+                            - "Tiered"
+                            - "Whole"
+                        BankGuaranteedIndicator:
+                          description: "Indicates that a bank provides the overdraft limit up to TierValueMIn to all customers automatically"
+                          title: "BankGuaranteedIndicator"
+                          type: "boolean"
+                        EAR:
+                          description: "EAR means Effective Annual Rate and/or Equivalent Annual Rate (frequently\nused interchangeably), being the actual annual interest rate of an Overdraft."
+                          title: "EAR"
+                          type: "string"
+                          pattern: "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$"
+                        RepresentativeAPR:
+                          description: "An annual percentage rate (APR) is the annual rate charged for borrowing or earned through an investment. APR is expressed as a percentage that represents the actual yearly cost of funds over the term of a loan. This includes any fees or additional costs associated with the transaction but does not take compounding into account."
+                          title: "RepresentativeAPR"
+                          type: "string"
+                          pattern: "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$"
+                        Notes:
+                          description: "Optional additional notes to supplement the Tier/band details"
+                          title: "Notes"
+                          type: "array"
+                          items:
+                            description: "maxLength 2000 text"
+                            type: "string"
+                            minLength: 1
+                            maxLength: 2000
+                        OverdraftFeesCharges:
+                          description: "Overdraft fees and charges"
+                          type: "array"
+                          title: "OverdraftFeesCharges"
+                          items:
+                            description: "Overdraft fees and charges"
+                            type: "object"
+                            properties:
+                              OverdraftFeeChargeCap:
+                                description: "Details about any caps (maximum charges) that apply to a particular fee/charge"
+                                type: "array"
+                                title: "OverdraftFeeChargeCap"
+                                items:
+                                  description: "Details about any caps (maximum charges) that apply to a particular fee/charge"
+                                  type: "object"
+                                  properties:
+                                    FeeType:
+                                      description: "Fee/charge type which is being capped"
+                                      title: "FeeType"
+                                      type: "array"
+                                      items:
+                                        description: "Overdraft fee type"
+                                        type: "string"
+                                        enum:
+                                          - "ArrangedOverdraft"
+                                          - "EmergencyBorrowing"
+                                          - "BorrowingItem"
+                                          - "OverdraftRenewal"
+                                          - "AnnualReview"
+                                          - "OverdraftSetup"
+                                          - "Surcharge"
+                                          - "TempOverdraft"
+                                          - "UnauthorisedBorrowing"
+                                          - "UnauthorisedPaidTrans"
+                                          - "Other"
+                                          - "UnauthorisedUnpaidTrans"
+                                      minItems: 1
+                                    OverdraftControlIndicator:
+                                      description: "Specifies for the overdraft control feature/benefit"
+                                      title: "OverdraftControlIndicator"
+                                      type: "boolean"
+                                    MinMaxType:
+                                      description: "Indicates that this is the minimum/ maximum fee/charge that can be applied by the financial institution"
+                                      title: "MinMaxType"
+                                      type: "string"
+                                      enum:
+                                        - "Minimum"
+                                        - "Maximum"
+                                    FeeCapOccurrence:
+                                      description: "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount"
+                                      title: "FeeCapOccurrence"
+                                      type: "number"
+                                      format: "float"
+                                    FeeCapAmount:
+                                      description: "Cap amount charged for a fee/charge"
+                                      title: "FeeCapAmount"
+                                      type: "string"
+                                      pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                                    CappingPeriod:
+                                      description: "Period e.g. day, week, month etc. for which the fee/charge is capped"
+                                      title: "CappingPeriod"
+                                      type: "string"
+                                      enum:
+                                        - "AcademicTerm"
+                                        - "Day"
+                                        - "Half Year"
+                                        - "Month"
+                                        - "Quarter"
+                                        - "Week"
+                                        - "Year"
+                                    Notes:
+                                      description: "Notes related to Overdraft fee charge cap"
+                                      title: "Notes"
+                                      type: "array"
+                                      items:
+                                        description: "maxLength 2000 text"
+                                        type: "string"
+                                        minLength: 1
+                                        maxLength: 2000
+                                    OtherFeeType:
+                                      description: "Other fee type code which is not available in the standard code set"
+                                      type: "array"
+                                      title: "OtherFeeType"
+                                      items:
+                                        description: "Other fee type code which is not available in the standard code set"
+                                        type: "object"
+                                        properties:
+                                          Code:
+                                            description: "The four letter Mnemonic used within an XML file to identify a code"
+                                            title: "Code"
+                                            type: "string"
+                                            pattern: "^\\w{0,4}$"
+                                            minLength: 0
+                                            maxLength: 4
+                                          Name:
+                                            description: "Long name associated with the code"
+                                            title: "Name"
+                                            type: "string"
+                                            minLength: 1
+                                            maxLength: 70
+                                          Description:
+                                            description: "Description to describe the purpose of the code"
+                                            title: "Description"
+                                            type: "string"
+                                            minLength: 1
+                                            maxLength: 350
+                                        required:
+                                          - "Name"
+                                          - "Description"
+                                  required:
+                                    - "FeeType"
+                                    - "MinMaxType"
+                              OverdraftFeeChargeDetail:
+                                description: "Details about the fees/charges"
+                                type: "array"
+                                title: "OverdraftFeeChargeDetail"
+                                items:
+                                  description: "Details about the fees/charges"
+                                  type: "object"
+                                  properties:
+                                    FeeType:
+                                      description: "Overdraft fee type"
+                                      title: "FeeType"
+                                      type: "string"
+                                      enum:
+                                        - "ArrangedOverdraft"
+                                        - "EmergencyBorrowing"
+                                        - "BorrowingItem"
+                                        - "OverdraftRenewal"
+                                        - "AnnualReview"
+                                        - "OverdraftSetup"
+                                        - "Surcharge"
+                                        - "TempOverdraft"
+                                        - "UnauthorisedBorrowing"
+                                        - "UnauthorisedPaidTrans"
+                                        - "Other"
+                                        - "UnauthorisedUnpaidTrans"
+                                    OverdraftControlIndicator:
+                                      description: "Specifies for the overdraft control feature/benefit"
+                                      title: "OverdraftControlIndicator"
+                                      type: "boolean"
+                                    IncrementalBorrowingAmount:
+                                      description: "Every additional tranche of an overdraft balance to which an overdraft fee is applied"
+                                      title: "IncrementalBorrowingAmount"
+                                      type: "string"
+                                      pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                                    FeeAmount:
+                                      description: "Amount charged for an overdraft fee/charge (where it is charged in terms of an amount rather than a rate)"
+                                      title: "FeeAmount"
+                                      type: "string"
+                                      pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                                    FeeRate:
+                                      description: "Rate charged for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)"
+                                      title: "FeeRate"
+                                      type: "string"
+                                      pattern: "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$"
+                                    FeeRateType:
+                                      description: "Rate type for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)"
+                                      title: "FeeRateType"
+                                      type: "string"
+                                      enum:
+                                        - "LinkedBaseRate"
+                                        - "Gross"
+                                        - "Net"
+                                        - "Other"
+                                    ApplicationFrequency:
+                                      description: "Frequency at which the overdraft charge is applied to the account"
+                                      title: "ApplicationFrequency"
+                                      type: "string"
+                                      enum:
+                                        - "AccountClosing"
+                                        - "AccountOpening"
+                                        - "AcademicTerm"
+                                        - "ChargingPeriod"
+                                        - "Daily"
+                                        - "PerItem"
+                                        - "Monthly"
+                                        - "OnAccountAnniversary"
+                                        - "Other"
+                                        - "PerHour"
+                                        - "PerOccurrence"
+                                        - "PerSheet"
+                                        - "PerTransaction"
+                                        - "PerTransactionAmount"
+                                        - "PerTransactionPercentage"
+                                        - "Quarterly"
+                                        - "SixMonthly"
+                                        - "StatementMonthly"
+                                        - "Weekly"
+                                        - "Yearly"
+                                    CalculationFrequency:
+                                      description: "How often is the overdraft fee/charge calculated for the account."
+                                      title: "CalculationFrequency"
+                                      type: "string"
+                                      enum:
+                                        - "AccountClosing"
+                                        - "AccountOpening"
+                                        - "AcademicTerm"
+                                        - "ChargingPeriod"
+                                        - "Daily"
+                                        - "PerItem"
+                                        - "Monthly"
+                                        - "OnAccountAnniversary"
+                                        - "Other"
+                                        - "PerHour"
+                                        - "PerOccurrence"
+                                        - "PerSheet"
+                                        - "PerTransaction"
+                                        - "PerTransactionAmount"
+                                        - "PerTransactionPercentage"
+                                        - "Quarterly"
+                                        - "SixMonthly"
+                                        - "StatementMonthly"
+                                        - "Weekly"
+                                        - "Yearly"
+                                    Notes:
+                                      description: "Free text for capturing any other info related to Overdraft Fees Charge Details"
+                                      title: "Notes"
+                                      type: "array"
+                                      items:
+                                        description: "maxLength 2000 text"
+                                        type: "string"
+                                        minLength: 1
+                                        maxLength: 2000
+                                    OtherFeeType:
+                                      description: "Other Fee type which is not available in the standard code set"
+                                      type: "object"
+                                      title: "OtherFeeType"
+                                      properties:
+                                        Code:
+                                          description: "The four letter Mnemonic used within an XML file to identify a code"
+                                          title: "Code"
+                                          type: "string"
+                                          pattern: "^\\w{0,4}$"
+                                          minLength: 0
+                                          maxLength: 4
+                                        Name:
+                                          description: "Long name associated with the code"
+                                          title: "Name"
+                                          type: "string"
+                                          minLength: 1
+                                          maxLength: 70
+                                        Description:
+                                          description: "Description to describe the purpose of the code"
+                                          title: "Description"
+                                          type: "string"
+                                          minLength: 1
+                                          maxLength: 350
+                                      additionalProperties: false
+                                      required:
+                                        - "Name"
+                                        - "Description"
+                                    OtherFeeRateType:
+                                      description: "Other fee rate type code which is not available in the standard code set"
+                                      type: "object"
+                                      title: "OtherFeeRateType"
+                                      properties:
+                                        Code:
+                                          description: "The four letter Mnemonic used within an XML file to identify a code"
+                                          title: "Code"
+                                          type: "string"
+                                          pattern: "^\\w{0,4}$"
+                                          minLength: 0
+                                          maxLength: 4
+                                        Name:
+                                          description: "Long name associated with the code"
+                                          title: "Name"
+                                          type: "string"
+                                          minLength: 1
+                                          maxLength: 70
+                                        Description:
+                                          description: "Description to describe the purpose of the code"
+                                          title: "Description"
+                                          type: "string"
+                                          minLength: 1
+                                          maxLength: 350
+                                      additionalProperties: false
+                                      required:
+                                        - "Name"
+                                        - "Description"
+                                    OtherApplicationFrequency:
+                                      description: "Other application frequencies that are not available in the standard code list"
+                                      type: "object"
+                                      title: "OtherApplicationFrequency"
+                                      properties:
+                                        Code:
+                                          description: "The four letter Mnemonic used within an XML file to identify a code"
+                                          title: "Code"
+                                          type: "string"
+                                          pattern: "^\\w{0,4}$"
+                                          minLength: 0
+                                          maxLength: 4
+                                        Name:
+                                          description: "Long name associated with the code"
+                                          title: "Name"
+                                          type: "string"
+                                          minLength: 1
+                                          maxLength: 70
+                                        Description:
+                                          description: "Description to describe the purpose of the code"
+                                          title: "Description"
+                                          type: "string"
+                                          minLength: 1
+                                          maxLength: 350
+                                      additionalProperties: false
+                                      required:
+                                        - "Name"
+                                        - "Description"
+                                    OtherCalculationFrequency:
+                                      description: "Other calculation frequency which is not available in the standard code set."
+                                      type: "object"
+                                      title: "OtherCalculationFrequency"
+                                      properties:
+                                        Code:
+                                          description: "The four letter Mnemonic used within an XML file to identify a code"
+                                          title: "Code"
+                                          type: "string"
+                                          pattern: "^\\w{0,4}$"
+                                          minLength: 0
+                                          maxLength: 4
+                                        Name:
+                                          description: "Long name associated with the code"
+                                          title: "Name"
+                                          type: "string"
+                                          minLength: 1
+                                          maxLength: 70
+                                        Description:
+                                          description: "Description to describe the purpose of the code"
+                                          title: "Description"
+                                          type: "string"
+                                          minLength: 1
+                                          maxLength: 350
+                                      additionalProperties: false
+                                      required:
+                                        - "Name"
+                                        - "Description"
+                                    OverdraftFeeChargeCap:
+                                      description: "Details about any caps (maximum charges) that apply to a particular fee/charge"
+                                      type: "object"
+                                      title: "OverdraftFeeChargeCap"
+                                      properties:
+                                        FeeType:
+                                          description: "Fee/charge type which is being capped"
+                                          title: "FeeType"
+                                          type: "array"
+                                          items:
+                                            description: "Overdraft fee type"
+                                            type: "string"
+                                            enum:
+                                              - "ArrangedOverdraft"
+                                              - "EmergencyBorrowing"
+                                              - "BorrowingItem"
+                                              - "OverdraftRenewal"
+                                              - "AnnualReview"
+                                              - "OverdraftSetup"
+                                              - "Surcharge"
+                                              - "TempOverdraft"
+                                              - "UnauthorisedBorrowing"
+                                              - "UnauthorisedPaidTrans"
+                                              - "Other"
+                                              - "UnauthorisedUnpaidTrans"
+                                          minItems: 1
+                                        OverdraftControlIndicator:
+                                          description: "Specifies for the overdraft control feature/benefit"
+                                          title: "OverdraftControlIndicator"
+                                          type: "boolean"
+                                        MinMaxType:
+                                          description: "Indicates that this is the minimum/ maximum fee/charge that can be applied by the financial institution"
+                                          title: "MinMaxType"
+                                          type: "string"
+                                          enum:
+                                            - "Minimum"
+                                            - "Maximum"
+                                        FeeCapOccurrence:
+                                          description: "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount"
+                                          title: "FeeCapOccurrence"
+                                          type: "number"
+                                          format: "float"
+                                        FeeCapAmount:
+                                          description: "Cap amount charged for a fee/charge"
+                                          title: "FeeCapAmount"
+                                          type: "string"
+                                          pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                                        CappingPeriod:
+                                          description: "Period e.g. day, week, month etc. for which the fee/charge is capped"
+                                          title: "CappingPeriod"
+                                          type: "string"
+                                          enum:
+                                            - "AcademicTerm"
+                                            - "Day"
+                                            - "Half Year"
+                                            - "Month"
+                                            - "Quarter"
+                                            - "Week"
+                                            - "Year"
+                                        Notes:
+                                          description: "Notes related to Overdraft fee charge cap"
+                                          title: "Notes"
+                                          type: "array"
+                                          items:
+                                            description: "maxLength 2000 text"
+                                            type: "string"
+                                            minLength: 1
+                                            maxLength: 2000
+                                        OtherFeeType:
+                                          description: "Other fee type code which is not available in the standard code set"
+                                          type: "array"
+                                          title: "OtherFeeType"
+                                          items:
+                                            description: "Other fee type code which is not available in the standard code set"
+                                            type: "object"
+                                            properties:
+                                              Code:
+                                                description: "The four letter Mnemonic used within an XML file to identify a code"
+                                                title: "Code"
+                                                type: "string"
+                                                pattern: "^\\w{0,4}$"
+                                                minLength: 0
+                                                maxLength: 4
+                                              Name:
+                                                description: "Long name associated with the code"
+                                                title: "Name"
+                                                type: "string"
+                                                minLength: 1
+                                                maxLength: 70
+                                              Description:
+                                                description: "Description to describe the purpose of the code"
+                                                title: "Description"
+                                                type: "string"
+                                                minLength: 1
+                                                maxLength: 350
+                                            required:
+                                              - "Name"
+                                              - "Description"
+                                      additionalProperties: false
+                                      required:
+                                        - "FeeType"
+                                        - "MinMaxType"
+                                  required:
+                                    - "FeeType"
+                                    - "ApplicationFrequency"
+                                minItems: 1
+                            required:
+                              - "OverdraftFeeChargeDetail"
+                      required:
+                        - "TierValueMin"
+                    minItems: 1
+                  OverdraftFeesCharges:
+                    description: "Overdraft fees and charges details"
+                    type: "array"
+                    title: "OverdraftFeesCharges"
+                    items:
+                      description: "Overdraft fees and charges details"
+                      type: "object"
+                      properties:
+                        OverdraftFeeChargeCap:
+                          description: "Details about any caps (maximum charges) that apply to a particular fee/charge"
+                          type: "array"
+                          title: "OverdraftFeeChargeCap"
+                          items:
+                            description: "Details about any caps (maximum charges) that apply to a particular fee/charge"
+                            type: "object"
+                            properties:
+                              FeeType:
+                                description: "Fee/charge type which is being capped"
+                                title: "FeeType"
+                                type: "array"
+                                items:
+                                  description: "Overdraft fee type"
+                                  type: "string"
+                                  enum:
+                                    - "ArrangedOverdraft"
+                                    - "EmergencyBorrowing"
+                                    - "BorrowingItem"
+                                    - "OverdraftRenewal"
+                                    - "AnnualReview"
+                                    - "OverdraftSetup"
+                                    - "Surcharge"
+                                    - "TempOverdraft"
+                                    - "UnauthorisedBorrowing"
+                                    - "UnauthorisedPaidTrans"
+                                    - "Other"
+                                    - "UnauthorisedUnpaidTrans"
+                                minItems: 1
+                              OverdraftControlIndicator:
+                                description: "Specifies for the overdraft control feature/benefit"
+                                title: "OverdraftControlIndicator"
+                                type: "boolean"
+                              MinMaxType:
+                                description: "Indicates that this is the minimum/ maximum fee/charge that can be applied by the financial institution"
+                                title: "MinMaxType"
+                                type: "string"
+                                enum:
+                                  - "Minimum"
+                                  - "Maximum"
+                              FeeCapOccurrence:
+                                description: "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount"
+                                title: "FeeCapOccurrence"
+                                type: "number"
+                                format: "float"
+                              FeeCapAmount:
+                                description: "Cap amount charged for a fee/charge"
+                                title: "FeeCapAmount"
+                                type: "string"
+                                pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                              CappingPeriod:
+                                description: "Period e.g. day, week, month etc. for which the fee/charge is capped"
+                                title: "CappingPeriod"
+                                type: "string"
+                                enum:
+                                  - "AcademicTerm"
+                                  - "Day"
+                                  - "Half Year"
+                                  - "Month"
+                                  - "Quarter"
+                                  - "Week"
+                                  - "Year"
+                              Notes:
+                                description: "Notes related to Overdraft fee charge cap"
+                                title: "Notes"
+                                type: "array"
+                                items:
+                                  description: "maxLength 2000 text"
+                                  type: "string"
+                                  minLength: 1
+                                  maxLength: 2000
+                              OtherFeeType:
+                                description: "Other fee type code which is not available in the standard code set"
+                                type: "array"
+                                title: "OtherFeeType"
+                                items:
+                                  description: "Other fee type code which is not available in the standard code set"
+                                  type: "object"
+                                  properties:
+                                    Code:
+                                      description: "The four letter Mnemonic used within an XML file to identify a code"
+                                      title: "Code"
+                                      type: "string"
+                                      pattern: "^\\w{0,4}$"
+                                      minLength: 0
+                                      maxLength: 4
+                                    Name:
+                                      description: "Long name associated with the code"
+                                      title: "Name"
+                                      type: "string"
+                                      minLength: 1
+                                      maxLength: 70
+                                    Description:
+                                      description: "Description to describe the purpose of the code"
+                                      title: "Description"
+                                      type: "string"
+                                      minLength: 1
+                                      maxLength: 350
+                                  required:
+                                    - "Name"
+                                    - "Description"
+                            required:
+                              - "FeeType"
+                              - "MinMaxType"
+                        OverdraftFeeChargeDetail:
+                          description: "Details about the fees/charges"
+                          type: "array"
+                          title: "OverdraftFeeChargeDetail"
+                          items:
+                            description: "Details about the fees/charges"
+                            type: "object"
+                            properties:
+                              FeeType:
+                                description: "Overdraft fee type"
+                                title: "FeeType"
+                                type: "string"
+                                enum:
+                                  - "ArrangedOverdraft"
+                                  - "EmergencyBorrowing"
+                                  - "BorrowingItem"
+                                  - "OverdraftRenewal"
+                                  - "AnnualReview"
+                                  - "OverdraftSetup"
+                                  - "Surcharge"
+                                  - "TempOverdraft"
+                                  - "UnauthorisedBorrowing"
+                                  - "UnauthorisedPaidTrans"
+                                  - "Other"
+                                  - "UnauthorisedUnpaidTrans"
+                              OverdraftControlIndicator:
+                                description: "Specifies for the overdraft control feature/benefit"
+                                title: "OverdraftControlIndicator"
+                                type: "boolean"
+                              IncrementalBorrowingAmount:
+                                description: "Every additional tranche of an overdraft balance to which an overdraft fee is applied"
+                                title: "IncrementalBorrowingAmount"
+                                type: "string"
+                                pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                              FeeAmount:
+                                description: "Amount charged for an overdraft fee/charge (where it is charged in terms of an amount rather than a rate)"
+                                title: "FeeAmount"
+                                type: "string"
+                                pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                              FeeRate:
+                                description: "Rate charged for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)"
+                                title: "FeeRate"
+                                type: "string"
+                                pattern: "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$"
+                              FeeRateType:
+                                description: "Rate type for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)"
+                                title: "FeeRateType"
+                                type: "string"
+                                enum:
+                                  - "LinkedBaseRate"
+                                  - "Gross"
+                                  - "Net"
+                                  - "Other"
+                              ApplicationFrequency:
+                                description: "Frequency at which the overdraft charge is applied to the account"
+                                title: "ApplicationFrequency"
+                                type: "string"
+                                enum:
+                                  - "AccountClosing"
+                                  - "AccountOpening"
+                                  - "AcademicTerm"
+                                  - "ChargingPeriod"
+                                  - "Daily"
+                                  - "PerItem"
+                                  - "Monthly"
+                                  - "OnAccountAnniversary"
+                                  - "Other"
+                                  - "PerHour"
+                                  - "PerOccurrence"
+                                  - "PerSheet"
+                                  - "PerTransaction"
+                                  - "PerTransactionAmount"
+                                  - "PerTransactionPercentage"
+                                  - "Quarterly"
+                                  - "SixMonthly"
+                                  - "StatementMonthly"
+                                  - "Weekly"
+                                  - "Yearly"
+                              CalculationFrequency:
+                                description: "How often is the overdraft fee/charge calculated for the account."
+                                title: "CalculationFrequency"
+                                type: "string"
+                                enum:
+                                  - "AccountClosing"
+                                  - "AccountOpening"
+                                  - "AcademicTerm"
+                                  - "ChargingPeriod"
+                                  - "Daily"
+                                  - "PerItem"
+                                  - "Monthly"
+                                  - "OnAccountAnniversary"
+                                  - "Other"
+                                  - "PerHour"
+                                  - "PerOccurrence"
+                                  - "PerSheet"
+                                  - "PerTransaction"
+                                  - "PerTransactionAmount"
+                                  - "PerTransactionPercentage"
+                                  - "Quarterly"
+                                  - "SixMonthly"
+                                  - "StatementMonthly"
+                                  - "Weekly"
+                                  - "Yearly"
+                              Notes:
+                                description: "Free text for capturing any other info related to Overdraft Fees Charge Details"
+                                title: "Notes"
+                                type: "array"
+                                items:
+                                  description: "maxLength 2000 text"
+                                  type: "string"
+                                  minLength: 1
+                                  maxLength: 2000
+                              OtherFeeType:
+                                description: "Other Fee type which is not available in the standard code set"
+                                type: "object"
+                                title: "OtherFeeType"
+                                properties:
+                                  Code:
+                                    description: "The four letter Mnemonic used within an XML file to identify a code"
+                                    title: "Code"
+                                    type: "string"
+                                    pattern: "^\\w{0,4}$"
+                                    minLength: 0
+                                    maxLength: 4
+                                  Name:
+                                    description: "Long name associated with the code"
+                                    title: "Name"
+                                    type: "string"
+                                    minLength: 1
+                                    maxLength: 70
+                                  Description:
+                                    description: "Description to describe the purpose of the code"
+                                    title: "Description"
+                                    type: "string"
+                                    minLength: 1
+                                    maxLength: 350
+                                additionalProperties: false
+                                required:
+                                  - "Name"
+                                  - "Description"
+                              OtherFeeRateType:
+                                description: "Other fee rate type code which is not available in the standard code set"
+                                type: "object"
+                                title: "OtherFeeRateType"
+                                properties:
+                                  Code:
+                                    description: "The four letter Mnemonic used within an XML file to identify a code"
+                                    title: "Code"
+                                    type: "string"
+                                    pattern: "^\\w{0,4}$"
+                                    minLength: 0
+                                    maxLength: 4
+                                  Name:
+                                    description: "Long name associated with the code"
+                                    title: "Name"
+                                    type: "string"
+                                    minLength: 1
+                                    maxLength: 70
+                                  Description:
+                                    description: "Description to describe the purpose of the code"
+                                    title: "Description"
+                                    type: "string"
+                                    minLength: 1
+                                    maxLength: 350
+                                additionalProperties: false
+                                required:
+                                  - "Name"
+                                  - "Description"
+                              OtherApplicationFrequency:
+                                description: "Other application frequencies that are not available in the standard code list"
+                                type: "object"
+                                title: "OtherApplicationFrequency"
+                                properties:
+                                  Code:
+                                    description: "The four letter Mnemonic used within an XML file to identify a code"
+                                    title: "Code"
+                                    type: "string"
+                                    pattern: "^\\w{0,4}$"
+                                    minLength: 0
+                                    maxLength: 4
+                                  Name:
+                                    description: "Long name associated with the code"
+                                    title: "Name"
+                                    type: "string"
+                                    minLength: 1
+                                    maxLength: 70
+                                  Description:
+                                    description: "Description to describe the purpose of the code"
+                                    title: "Description"
+                                    type: "string"
+                                    minLength: 1
+                                    maxLength: 350
+                                additionalProperties: false
+                                required:
+                                  - "Name"
+                                  - "Description"
+                              OtherCalculationFrequency:
+                                description: "Other calculation frequency which is not available in the standard code set."
+                                type: "object"
+                                title: "OtherCalculationFrequency"
+                                properties:
+                                  Code:
+                                    description: "The four letter Mnemonic used within an XML file to identify a code"
+                                    title: "Code"
+                                    type: "string"
+                                    pattern: "^\\w{0,4}$"
+                                    minLength: 0
+                                    maxLength: 4
+                                  Name:
+                                    description: "Long name associated with the code"
+                                    title: "Name"
+                                    type: "string"
+                                    minLength: 1
+                                    maxLength: 70
+                                  Description:
+                                    description: "Description to describe the purpose of the code"
+                                    title: "Description"
+                                    type: "string"
+                                    minLength: 1
+                                    maxLength: 350
+                                additionalProperties: false
+                                required:
+                                  - "Name"
+                                  - "Description"
+                              OverdraftFeeChargeCap:
+                                description: "Details about any caps (maximum charges) that apply to a particular fee/charge"
+                                type: "object"
+                                title: "OverdraftFeeChargeCap"
+                                properties:
+                                  FeeType:
+                                    description: "Fee/charge type which is being capped"
+                                    title: "FeeType"
+                                    type: "array"
+                                    items:
+                                      description: "Overdraft fee type"
+                                      type: "string"
+                                      enum:
+                                        - "ArrangedOverdraft"
+                                        - "EmergencyBorrowing"
+                                        - "BorrowingItem"
+                                        - "OverdraftRenewal"
+                                        - "AnnualReview"
+                                        - "OverdraftSetup"
+                                        - "Surcharge"
+                                        - "TempOverdraft"
+                                        - "UnauthorisedBorrowing"
+                                        - "UnauthorisedPaidTrans"
+                                        - "Other"
+                                        - "UnauthorisedUnpaidTrans"
+                                    minItems: 1
+                                  OverdraftControlIndicator:
+                                    description: "Specifies for the overdraft control feature/benefit"
+                                    title: "OverdraftControlIndicator"
+                                    type: "boolean"
+                                  MinMaxType:
+                                    description: "Indicates that this is the minimum/ maximum fee/charge that can be applied by the financial institution"
+                                    title: "MinMaxType"
+                                    type: "string"
+                                    enum:
+                                      - "Minimum"
+                                      - "Maximum"
+                                  FeeCapOccurrence:
+                                    description: "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount"
+                                    title: "FeeCapOccurrence"
+                                    type: "number"
+                                    format: "float"
+                                  FeeCapAmount:
+                                    description: "Cap amount charged for a fee/charge"
+                                    title: "FeeCapAmount"
+                                    type: "string"
+                                    pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                                  CappingPeriod:
+                                    description: "Period e.g. day, week, month etc. for which the fee/charge is capped"
+                                    title: "CappingPeriod"
+                                    type: "string"
+                                    enum:
+                                      - "AcademicTerm"
+                                      - "Day"
+                                      - "Half Year"
+                                      - "Month"
+                                      - "Quarter"
+                                      - "Week"
+                                      - "Year"
+                                  Notes:
+                                    description: "Notes related to Overdraft fee charge cap"
+                                    title: "Notes"
+                                    type: "array"
+                                    items:
+                                      description: "maxLength 2000 text"
+                                      type: "string"
+                                      minLength: 1
+                                      maxLength: 2000
+                                  OtherFeeType:
+                                    description: "Other fee type code which is not available in the standard code set"
+                                    type: "array"
+                                    title: "OtherFeeType"
+                                    items:
+                                      description: "Other fee type code which is not available in the standard code set"
+                                      type: "object"
+                                      properties:
+                                        Code:
+                                          description: "The four letter Mnemonic used within an XML file to identify a code"
+                                          title: "Code"
+                                          type: "string"
+                                          pattern: "^\\w{0,4}$"
+                                          minLength: 0
+                                          maxLength: 4
+                                        Name:
+                                          description: "Long name associated with the code"
+                                          title: "Name"
+                                          type: "string"
+                                          minLength: 1
+                                          maxLength: 70
+                                        Description:
+                                          description: "Description to describe the purpose of the code"
+                                          title: "Description"
+                                          type: "string"
+                                          minLength: 1
+                                          maxLength: 350
+                                      required:
+                                        - "Name"
+                                        - "Description"
+                                additionalProperties: false
+                                required:
+                                  - "FeeType"
+                                  - "MinMaxType"
+                            required:
+                              - "FeeType"
+                              - "ApplicationFrequency"
+                          minItems: 1
+                      required:
+                        - "OverdraftFeeChargeDetail"
+                required:
+                  - "TierBandMethod"
+                  - "OverdraftTierBand"
+              minItems: 1
+          additionalProperties: false
+          required:
+            - "OverdraftTierBandSet"
+        OtherFeesCharges:
+          description: "Contains details of fees and charges which are not associated with either borrowing or features/benefits"
+          type: "object"
+          title: "OtherFeesCharges"
+          properties:
+            FeeChargeDetail:
+              description: "Other fees/charges details"
+              type: "array"
+              title: "FeeChargeDetail"
+              items:
+                description: "Other fees/charges details"
+                type: "object"
+                properties:
+                  FeeCategory:
+                    description: "Categorisation of fees and charges into standard categories."
+                    title: "FeeCategory"
+                    type: "string"
+                    enum:
+                      - "Other"
+                      - "Servicing"
+                  FeeType:
+                    description: "Fee/Charge Type"
+                    title: "FeeType"
+                    type: "string"
+                    enum:
+                      - "ServiceCAccountFee"
+                      - "ServiceCAccountFeeMonthly"
+                      - "ServiceCOther"
+                      - "Other"
+                  FeeAmount:
+                    description: "Fee Amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)"
+                    title: "FeeAmount"
+                    type: "string"
+                    pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                  FeeRate:
+                    description: "Rate charged for Fee/Charge (where it is charged in terms of a rate rather than an amount)"
+                    title: "FeeRate"
+                    type: "string"
+                    pattern: "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$"
+                  FeeRateType:
+                    description: "Rate type for Fee/Charge (where it is charged in terms of a rate rather than an amount)"
+                    title: "FeeRateType"
+                    type: "string"
+                    enum:
+                      - "LinkedBaseRate"
+                      - "Gross"
+                      - "Net"
+                      - "Other"
+                  ApplicationFrequency:
+                    description: "How frequently the fee/charge is applied to the account"
+                    title: "ApplicationFrequency"
+                    type: "string"
+                    enum:
+                      - "AccountClosing"
+                      - "AccountOpening"
+                      - "AcademicTerm"
+                      - "ChargingPeriod"
+                      - "Daily"
+                      - "PerItem"
+                      - "Monthly"
+                      - "OnAccountAnniversary"
+                      - "Other"
+                      - "PerHour"
+                      - "PerOccurrence"
+                      - "PerSheet"
+                      - "PerTransaction"
+                      - "PerTransactionAmount"
+                      - "PerTransactionPercentage"
+                      - "Quarterly"
+                      - "SixMonthly"
+                      - "StatementMonthly"
+                      - "Weekly"
+                      - "Yearly"
+                  CalculationFrequency:
+                    description: "How frequently the fee/charge is calculated"
+                    title: "CalculationFrequency"
+                    type: "string"
+                    enum:
+                      - "AccountClosing"
+                      - "AccountOpening"
+                      - "AcademicTerm"
+                      - "ChargingPeriod"
+                      - "Daily"
+                      - "PerItem"
+                      - "Monthly"
+                      - "OnAccountAnniversary"
+                      - "Other"
+                      - "PerHour"
+                      - "PerOccurrence"
+                      - "PerSheet"
+                      - "PerTransaction"
+                      - "PerTransactionAmount"
+                      - "PerTransactionPercentage"
+                      - "Quarterly"
+                      - "SixMonthly"
+                      - "StatementMonthly"
+                      - "Weekly"
+                      - "Yearly"
+                  Notes:
+                    description: "Optional additional notes to supplement the fee/charge details."
+                    title: "Notes"
+                    type: "array"
+                    items:
+                      description: "maxLength 2000 text"
+                      type: "string"
+                      minLength: 1
+                      maxLength: 2000
+                  OtherFeeCategoryType:
+                    type: "object"
+                    title: "OtherFeeCategoryType"
+                    properties:
+                      Code:
+                        description: "The four letter Mnemonic used within an XML file to identify a code"
+                        title: "Code"
+                        type: "string"
+                        pattern: "^\\w{0,4}$"
+                        minLength: 0
+                        maxLength: 4
+                      Name:
+                        description: "Long name associated with the code"
+                        title: "Name"
+                        type: "string"
+                        minLength: 1
+                        maxLength: 70
+                      Description:
+                        description: "Description to describe the purpose of the code"
+                        title: "Description"
+                        type: "string"
+                        minLength: 1
+                        maxLength: 350
+                    additionalProperties: false
+                    required:
+                      - "Name"
+                      - "Description"
+                  OtherFeeType:
+                    description: "Other Fee/charge type which is not available in the standard code set"
+                    type: "object"
+                    title: "OtherFeeType"
+                    properties:
+                      Code:
+                        description: "The four letter Mnemonic used within an XML file to identify a code"
+                        title: "Code"
+                        type: "string"
+                        pattern: "^\\w{0,4}$"
+                        minLength: 0
+                        maxLength: 4
+                      FeeCategory:
+                        description: "Categorisation of fees and charges into standard categories."
+                        title: "FeeCategory"
+                        type: "string"
+                        enum:
+                          - "Other"
+                          - "Servicing"
+                      Name:
+                        description: "Long name associated with the code"
+                        title: "Name"
+                        type: "string"
+                        minLength: 1
+                        maxLength: 70
+                      Description:
+                        description: "Description to describe the purpose of the code"
+                        title: "Description"
+                        type: "string"
+                        minLength: 1
+                        maxLength: 350
+                    additionalProperties: false
+                    required:
+                      - "FeeCategory"
+                      - "Name"
+                      - "Description"
+                  OtherFeeRateType:
+                    description: "Other fee rate type which is not available in the standard code set"
+                    type: "object"
+                    title: "OtherFeeRateType"
+                    properties:
+                      Code:
+                        description: "The four letter Mnemonic used within an XML file to identify a code"
+                        title: "Code"
+                        type: "string"
+                        pattern: "^\\w{0,4}$"
+                        minLength: 0
+                        maxLength: 4
+                      Name:
+                        description: "Long name associated with the code"
+                        title: "Name"
+                        type: "string"
+                        minLength: 1
+                        maxLength: 70
+                      Description:
+                        description: "Description to describe the purpose of the code"
+                        title: "Description"
+                        type: "string"
+                        minLength: 1
+                        maxLength: 350
+                    additionalProperties: false
+                    required:
+                      - "Name"
+                      - "Description"
+                  OtherApplicationFrequency:
+                    description: "Other application frequencies not covered in the standard code list"
+                    type: "object"
+                    title: "OtherApplicationFrequency"
+                    properties:
+                      Code:
+                        description: "The four letter Mnemonic used within an XML file to identify a code"
+                        title: "Code"
+                        type: "string"
+                        pattern: "^\\w{0,4}$"
+                        minLength: 0
+                        maxLength: 4
+                      Name:
+                        description: "Long name associated with the code"
+                        title: "Name"
+                        type: "string"
+                        minLength: 1
+                        maxLength: 70
+                      Description:
+                        description: "Description to describe the purpose of the code"
+                        title: "Description"
+                        type: "string"
+                        minLength: 1
+                        maxLength: 350
+                    additionalProperties: false
+                    required:
+                      - "Name"
+                      - "Description"
+                  OtherCalculationFrequency:
+                    description: "Other calculation frequency which is not available in standard code set."
+                    type: "object"
+                    title: "OtherCalculationFrequency"
+                    properties:
+                      Code:
+                        description: "The four letter Mnemonic used within an XML file to identify a code"
+                        title: "Code"
+                        type: "string"
+                        pattern: "^\\w{0,4}$"
+                        minLength: 0
+                        maxLength: 4
+                      Name:
+                        description: "Long name associated with the code"
+                        title: "Name"
+                        type: "string"
+                        minLength: 1
+                        maxLength: 70
+                      Description:
+                        description: "Description to describe the purpose of the code"
+                        title: "Description"
+                        type: "string"
+                        minLength: 1
+                        maxLength: 350
+                    additionalProperties: false
+                    required:
+                      - "Name"
+                      - "Description"
+                  FeeChargeCap:
+                    description: "Details about any caps (maximum charges) that apply to a particular fee/charge"
+                    type: "array"
+                    title: "FeeChargeCap"
+                    items:
+                      description: "Details about any caps (maximum charges) that apply to a particular fee/charge"
+                      type: "object"
+                      properties:
+                        FeeType:
+                          description: "Fee/charge type which is being capped"
+                          title: "FeeType"
+                          type: "array"
+                          items:
+                            description: "Fee/charge type which is being capped"
+                            type: "string"
+                            enum:
+                              - "ServiceCAccountFee"
+                              - "ServiceCAccountFeeMonthly"
+                              - "ServiceCOther"
+                              - "Other"
+                          minItems: 1
+                        MinMaxType:
+                          description: "Indicates that this is the minimum/ maximum fee/charge that can be applied by the financial institution"
+                          title: "MinMaxType"
+                          type: "string"
+                          enum:
+                            - "Minimum"
+                            - "Maximum"
+                        FeeCapOccurrence:
+                          description: "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount"
+                          title: "FeeCapOccurrence"
+                          type: "number"
+                          format: "float"
+                        FeeCapAmount:
+                          description: "Cap amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)"
+                          title: "FeeCapAmount"
+                          type: "string"
+                          pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                        CappingPeriod:
+                          description: "Period e.g. day, week, month etc. for which the fee/charge is capped"
+                          title: "CappingPeriod"
+                          type: "string"
+                          enum:
+                            - "AcademicTerm"
+                            - "Day"
+                            - "Half Year"
+                            - "Month"
+                            - "Quarter"
+                            - "Week"
+                            - "Year"
+                        Notes:
+                          description: "Free text for adding  extra details for fee charge cap"
+                          title: "Notes"
+                          type: "array"
+                          items:
+                            description: "maxLength 2000 text"
+                            type: "string"
+                            minLength: 1
+                            maxLength: 2000
+                        OtherFeeType:
+                          description: "Other fee type code which is not available in the standard code set"
+                          type: "array"
+                          title: "OtherFeeType"
+                          items:
+                            description: "Other fee type code which is not available in the standard code set"
+                            type: "object"
+                            properties:
+                              Code:
+                                description: "The four letter Mnemonic used within an XML file to identify a code"
+                                title: "Code"
+                                type: "string"
+                                pattern: "^\\w{0,4}$"
+                                minLength: 0
+                                maxLength: 4
+                              Name:
+                                description: "Long name associated with the code"
+                                title: "Name"
+                                type: "string"
+                                minLength: 1
+                                maxLength: 70
+                              Description:
+                                description: "Description to describe the purpose of the code"
+                                title: "Description"
+                                type: "string"
+                                minLength: 1
+                                maxLength: 350
+                            required:
+                              - "Name"
+                              - "Description"
+                      required:
+                        - "FeeType"
+                        - "MinMaxType"
+                  FeeApplicableRange:
+                    description: "Range or amounts or rates for which the fee/charge applies"
+                    type: "object"
+                    title: "FeeApplicableRange"
+                    properties:
+                      MinimumAmount:
+                        description: "Minimum Amount on which fee/charge is applicable (where it is expressed as an amount)"
+                        title: "MinimumAmount"
+                        type: "string"
+                        pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                      MaximumAmount:
+                        description: "Maximum Amount on which fee is applicable (where it is expressed as an amount)"
+                        title: "MaximumAmount"
+                        type: "string"
+                        pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                      MinimumRate:
+                        description: "Minimum rate on which fee/charge is applicable(where it is expressed as an rate)"
+                        title: "MinimumRate"
+                        type: "string"
+                        pattern: "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$"
+                      MaximumRate:
+                        description: "Maximum rate on which fee/charge is applicable(where it is expressed as an rate)"
+                        title: "MaximumRate"
+                        type: "string"
+                        pattern: "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$"
+                    additionalProperties: false
+                required:
+                  - "FeeCategory"
+                  - "FeeType"
+                  - "ApplicationFrequency"
+              minItems: 1
+            FeeChargeCap:
+              description: "Details about any caps (maximum charges) that apply to a particular fee/charge"
+              type: "array"
+              title: "FeeChargeCap"
+              items:
+                description: "Details about any caps (maximum charges) that apply to a particular fee/charge"
+                type: "object"
+                properties:
+                  FeeType:
+                    description: "Fee/charge type which is being capped"
+                    title: "FeeType"
+                    type: "array"
+                    items:
+                      description: "Fee/charge type which is being capped"
+                      type: "string"
+                      enum:
+                        - "ServiceCAccountFee"
+                        - "ServiceCAccountFeeMonthly"
+                        - "ServiceCOther"
+                        - "Other"
+                    minItems: 1
+                  MinMaxType:
+                    description: "Indicates that this is the minimum/ maximum fee/charge that can be applied by the financial institution"
+                    title: "MinMaxType"
+                    type: "string"
+                    enum:
+                      - "Minimum"
+                      - "Maximum"
+                  FeeCapOccurrence:
+                    description: "fee/charges are captured dependent on the number of occurrences rather than capped at a particular amount"
+                    title: "FeeCapOccurrence"
+                    type: "number"
+                    format: "float"
+                  FeeCapAmount:
+                    description: "Cap amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)"
+                    title: "FeeCapAmount"
+                    type: "string"
+                    pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                  CappingPeriod:
+                    description: "Period e.g. day, week, month etc. for which the fee/charge is capped"
+                    title: "CappingPeriod"
+                    type: "string"
+                    enum:
+                      - "AcademicTerm"
+                      - "Day"
+                      - "Half Year"
+                      - "Month"
+                      - "Quarter"
+                      - "Week"
+                      - "Year"
+                  Notes:
+                    description: "Free text for adding  extra details for fee charge cap"
+                    title: "Notes"
+                    type: "array"
+                    items:
+                      description: "maxLength 2000 text"
+                      type: "string"
+                      minLength: 1
+                      maxLength: 2000
+                  OtherFeeType:
+                    description: "Other fee type code which is not available in the standard code set"
+                    type: "array"
+                    title: "OtherFeeType"
+                    items:
+                      description: "Other fee type code which is not available in the standard code set"
+                      type: "object"
+                      properties:
+                        Code:
+                          description: "The four letter Mnemonic used within an XML file to identify a code"
+                          title: "Code"
+                          type: "string"
+                          pattern: "^\\w{0,4}$"
+                          minLength: 0
+                          maxLength: 4
+                        Name:
+                          description: "Long name associated with the code"
+                          title: "Name"
+                          type: "string"
+                          minLength: 1
+                          maxLength: 70
+                        Description:
+                          description: "Description to describe the purpose of the code"
+                          title: "Description"
+                          type: "string"
+                          minLength: 1
+                          maxLength: 350
+                      required:
+                        - "Name"
+                        - "Description"
+                required:
+                  - "FeeType"
+                  - "MinMaxType"
+          additionalProperties: false
+          required:
+            - "FeeChargeDetail"
+      additionalProperties: false
+    OBParty2:
+      type: "object"
+      required:
+        - "PartyId"
+      properties:
+        PartyId:
+          $ref: "#/components/schemas/PartyId"
+        PartyNumber:
+          $ref: "#/components/schemas/PartyNumber"
+        PartyType:
+          $ref: "#/components/schemas/OBExternalPartyType1Code"
+        Name:
+          $ref: "#/components/schemas/Name_3"
+        FullLegalName:
+          $ref: "#/components/schemas/FullLegalName"
+        LegalStructure:
+          $ref: "#/components/schemas/OBExternalLegalStructureType1Code"
+        BeneficialOwnership:
+          type: "boolean"
+        AccountRole:
+          $ref: "#/components/schemas/OBExternalAccountRole1Code"
+        EmailAddress:
+          $ref: "#/components/schemas/EmailAddress"
+        Phone:
+          $ref: "#/components/schemas/PhoneNumber_0"
+        Mobile:
+          $ref: "#/components/schemas/PhoneNumber_1"
+        Relationships:
+          $ref: "#/components/schemas/OBPartyRelationships1"
+        Address:
+          type: "array"
+          items:
+            type: "object"
+            description: "Postal address of a party."
+            required:
+              - "Country"
+            properties:
+              AddressType:
+                $ref: "#/components/schemas/OBAddressTypeCode"
+              AddressLine:
+                type: "array"
+                items:
+                  description: "Information that locates and identifies a specific address, as defined by postal services, that is presented in free format text."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 70
+                minItems: 0
+                maxItems: 5
+              StreetName:
+                $ref: "#/components/schemas/StreetName"
+              BuildingNumber:
+                $ref: "#/components/schemas/BuildingNumber"
+              PostCode:
+                $ref: "#/components/schemas/PostCode"
+              TownName:
+                $ref: "#/components/schemas/TownName"
+              CountrySubDivision:
+                $ref: "#/components/schemas/CountrySubDivision"
+              Country:
+                $ref: "#/components/schemas/CountryCode"
+      additionalProperties: false
+    OBPartyRelationships1:
+      type: "object"
+      description: "The Party's relationships with other resources."
+      properties:
+        Account:
+          type: "object"
+          required:
+            - "Related"
+            - "Id"
+          description: "Relationship to the Account resource."
+          properties:
+            Related:
+              description: "Absolute URI to the related resource."
+              type: "string"
+              format: "uri"
+            Id:
+              description: "Unique identification as assigned by the ASPSP to uniquely identify the related resource."
+              type: "string"
+              minLength: 1
+              maxLength: 40
+    OBPostalAddress6:
+      type: "object"
+      description: "Information that locates and identifies a specific address, as defined by postal services."
+      properties:
+        AddressType:
+          $ref: "#/components/schemas/OBAddressTypeCode"
+        Department:
+          description: "Identification of a division of a large organisation or building."
+          type: "string"
+          minLength: 1
+          maxLength: 70
+        SubDepartment:
+          description: "Identification of a sub-division of a large organisation or building."
+          type: "string"
+          minLength: 1
+          maxLength: 70
+        StreetName:
+          $ref: "#/components/schemas/StreetName"
+        BuildingNumber:
+          $ref: "#/components/schemas/BuildingNumber"
+        PostCode:
+          $ref: "#/components/schemas/PostCode"
+        TownName:
+          $ref: "#/components/schemas/TownName"
+        CountrySubDivision:
+          description: "Identifies a subdivision of a country such as state, region, county."
+          type: "string"
+          minLength: 1
+          maxLength: 35
+        Country:
+          description: "Nation with its own government."
+          type: "string"
+          pattern: "^[A-Z]{2,2}$"
+        AddressLine:
+          type: "array"
+          items:
+            description: "Information that locates and identifies a specific address, as defined by postal services, presented in free format text."
+            type: "string"
+            minLength: 1
+            maxLength: 70
+          minItems: 0
+          maxItems: 7
+    OBRate1_0:
+      description: "Rate charged for Statement Fee (where it is charged in terms of a rate rather than an amount)"
+      type: "number"
+    OBRate1_1:
+      description: "field representing a percentage (e.g. 0.05 represents 5% and 0.9525 represents 95.25%). Note the number of decimal places may vary."
+      type: "number"
+    OBReadAccount6:
+      type: "object"
+      required:
+        - "Data"
+      properties:
+        Data:
+          type: "object"
+          properties:
+            Account:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/OBAccount6"
+        Links:
+          $ref: "#/components/schemas/Links"
+        Meta:
+          $ref: "#/components/schemas/Meta"
+      additionalProperties: false
+    OBReadBalance1:
+      type: "object"
+      required:
+        - "Data"
+      properties:
+        Data:
+          type: "object"
+          required:
+            - "Balance"
+          properties:
+            Balance:
+              type: "array"
+              items:
+                type: "object"
+                description: "Set of elements used to define the balance details."
+                required:
+                  - "AccountId"
+                  - "CreditDebitIndicator"
+                  - "Type"
+                  - "DateTime"
+                  - "Amount"
+                properties:
+                  AccountId:
+                    $ref: "#/components/schemas/AccountId"
+                  CreditDebitIndicator:
+                    $ref: "#/components/schemas/OBCreditDebitCode_2"
+                  Type:
+                    $ref: "#/components/schemas/OBBalanceType1Code"
+                  DateTime:
+                    description: "Indicates the date (and time) of the balance.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                    type: "string"
+                    format: "date-time"
+                  Amount:
+                    type: "object"
+                    required:
+                      - "Amount"
+                      - "Currency"
+                    description: "Amount of money of the cash balance."
+                    properties:
+                      Amount:
+                        $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+                      Currency:
+                        $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode_1"
+                  CreditLine:
+                    type: "array"
+                    items:
+                      type: "object"
+                      description: "Set of elements used to provide details on the credit line."
+                      required:
+                        - "Included"
+                      properties:
+                        Included:
+                          description: "Indicates whether or not the credit line is included in the balance of the account.\nUsage: If not present, credit line is not included in the balance amount of the account."
+                          type: "boolean"
+                        Type:
+                          description: "Limit type, in a coded form."
+                          type: "string"
+                          enum:
+                            - "Available"
+                            - "Credit"
+                            - "Emergency"
+                            - "Pre-Agreed"
+                            - "Temporary"
+                        Amount:
+                          type: "object"
+                          required:
+                            - "Amount"
+                            - "Currency"
+                          description: "Amount of money of the credit line."
+                          properties:
+                            Amount:
+                              $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+                            Currency:
+                              $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode_1"
+              minItems: 1
+        Links:
+          $ref: "#/components/schemas/Links"
+        Meta:
+          $ref: "#/components/schemas/Meta"
+      additionalProperties: false
+    OBReadBeneficiary5:
+      type: "object"
+      required:
+        - "Data"
+      properties:
+        Data:
+          type: "object"
+          properties:
+            Beneficiary:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/OBBeneficiary5"
+        Links:
+          $ref: "#/components/schemas/Links"
+        Meta:
+          $ref: "#/components/schemas/Meta"
+      additionalProperties: false
+    OBReadConsent1:
+      type: "object"
+      required:
+        - "Data"
+        - "Risk"
+      properties:
+        Data:
+          type: "object"
+          required:
+            - "Permissions"
+          properties:
+            Permissions:
+              type: "array"
+              items:
+                description: "Specifies the Open Banking account access data types. This is a list of the data clusters being consented by the PSU, and requested for authorisation with the ASPSP."
+                type: "string"
+                enum:
+                  - "ReadAccountsBasic"
+                  - "ReadAccountsDetail"
+                  - "ReadBalances"
+                  - "ReadBeneficiariesBasic"
+                  - "ReadBeneficiariesDetail"
+                  - "ReadDirectDebits"
+                  - "ReadOffers"
+                  - "ReadPAN"
+                  - "ReadParty"
+                  - "ReadPartyPSU"
+                  - "ReadProducts"
+                  - "ReadScheduledPaymentsBasic"
+                  - "ReadScheduledPaymentsDetail"
+                  - "ReadStandingOrdersBasic"
+                  - "ReadStandingOrdersDetail"
+                  - "ReadStatementsBasic"
+                  - "ReadStatementsDetail"
+                  - "ReadTransactionsBasic"
+                  - "ReadTransactionsCredits"
+                  - "ReadTransactionsDebits"
+                  - "ReadTransactionsDetail"
+              minItems: 1
+            ExpirationDateTime:
+              description: "Specified date and time the permissions will expire.\nIf this is not populated, the permissions will be open ended.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            TransactionFromDateTime:
+              description: "Specified start date and time for the transaction query period.\nIf this is not populated, the start date will be open ended, and data will be returned from the earliest available transaction.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            TransactionToDateTime:
+              description: "Specified end date and time for the transaction query period.\nIf this is not populated, the end date will be open ended, and data will be returned to the latest available transaction.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+        Risk:
+          $ref: "#/components/schemas/OBRisk2"
+      additionalProperties: false
+    OBReadConsentResponse1:
+      type: "object"
+      required:
+        - "Data"
+        - "Risk"
+      properties:
+        Data:
+          type: "object"
+          required:
+            - "ConsentId"
+            - "CreationDateTime"
+            - "Status"
+            - "StatusUpdateDateTime"
+            - "Permissions"
+          properties:
+            ConsentId:
+              description: "Unique identification as assigned to identify the account access consent resource."
+              type: "string"
+              minLength: 1
+              maxLength: 128
+            CreationDateTime:
+              $ref: "#/components/schemas/CreationDateTime"
+            Status:
+              description: "Specifies the status of consent resource in code form."
+              type: "string"
+              enum:
+                - "Authorised"
+                - "AwaitingAuthorisation"
+                - "Rejected"
+                - "Revoked"
+            StatusUpdateDateTime:
+              $ref: "#/components/schemas/StatusUpdateDateTime"
+            Permissions:
+              type: "array"
+              items:
+                description: "Specifies the Open Banking account access data types. This is a list of the data clusters being consented by the PSU, and requested for authorisation with the ASPSP."
+                type: "string"
+                enum:
+                  - "ReadAccountsBasic"
+                  - "ReadAccountsDetail"
+                  - "ReadBalances"
+                  - "ReadBeneficiariesBasic"
+                  - "ReadBeneficiariesDetail"
+                  - "ReadDirectDebits"
+                  - "ReadOffers"
+                  - "ReadPAN"
+                  - "ReadParty"
+                  - "ReadPartyPSU"
+                  - "ReadProducts"
+                  - "ReadScheduledPaymentsBasic"
+                  - "ReadScheduledPaymentsDetail"
+                  - "ReadStandingOrdersBasic"
+                  - "ReadStandingOrdersDetail"
+                  - "ReadStatementsBasic"
+                  - "ReadStatementsDetail"
+                  - "ReadTransactionsBasic"
+                  - "ReadTransactionsCredits"
+                  - "ReadTransactionsDebits"
+                  - "ReadTransactionsDetail"
+              minItems: 1
+            ExpirationDateTime:
+              description: "Specified date and time the permissions will expire.\nIf this is not populated, the permissions will be open ended.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            TransactionFromDateTime:
+              description: "Specified start date and time for the transaction query period.\nIf this is not populated, the start date will be open ended, and data will be returned from the earliest available transaction.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            TransactionToDateTime:
+              description: "Specified end date and time for the transaction query period.\nIf this is not populated, the end date will be open ended, and data will be returned to the latest available transaction.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+        Risk:
+          $ref: "#/components/schemas/OBRisk2"
+        Links:
+          $ref: "#/components/schemas/Links"
+        Meta:
+          $ref: "#/components/schemas/Meta"
+      additionalProperties: false
+    OBReadDataStatement2:
+      type: "object"
+      properties:
+        Statement:
+          type: "array"
+          items:
+            $ref: "#/components/schemas/OBStatement2"
+      additionalProperties: false
+    OBReadDataTransaction6:
+      type: "object"
+      properties:
+        Transaction:
+          type: "array"
+          items:
+            $ref: "#/components/schemas/OBTransaction6"
+      additionalProperties: false
+    OBReadDirectDebit2:
+      type: "object"
+      required:
+        - "Data"
+      properties:
+        Data:
+          type: "object"
+          properties:
+            DirectDebit:
+              type: "array"
+              items:
+                type: "object"
+                description: "Account to or from which a cash entry is made."
+                required:
+                  - "AccountId"
+                  - "MandateIdentification"
+                  - "Name"
+                properties:
+                  AccountId:
+                    $ref: "#/components/schemas/AccountId"
+                  DirectDebitId:
+                    $ref: "#/components/schemas/DirectDebitId"
+                  MandateIdentification:
+                    $ref: "#/components/schemas/MandateIdentification"
+                  DirectDebitStatusCode:
+                    $ref: "#/components/schemas/OBExternalDirectDebitStatus1Code"
+                  Name:
+                    $ref: "#/components/schemas/Name_2"
+                  PreviousPaymentDateTime:
+                    $ref: "#/components/schemas/PreviousPaymentDateTime"
+                  Frequency:
+                    description: "Regularity with which direct debit instructions are to be created and processed."
+                    type: "string"
+                    x-namespaced-enum:
+                      - "UK.OBIE.Annual"
+                      - "UK.OBIE.Daily"
+                      - "UK.OBIE.Fortnightly"
+                      - "UK.OBIE.HalfYearly"
+                      - "UK.OBIE.Monthly"
+                      - "UK.OBIE.NotKnown"
+                      - "UK.OBIE.Quarterly"
+                      - "UK.OBIE.Weekly"
+                  PreviousPaymentAmount:
+                    $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount_0"
+        Links:
+          $ref: "#/components/schemas/Links"
+        Meta:
+          $ref: "#/components/schemas/Meta"
+      additionalProperties: false
+    OBReadOffer1:
+      type: "object"
+      required:
+        - "Data"
+      properties:
+        Data:
+          type: "object"
+          properties:
+            Offer:
+              type: "array"
+              items:
+                type: "object"
+                required:
+                  - "AccountId"
+                properties:
+                  AccountId:
+                    $ref: "#/components/schemas/AccountId"
+                  OfferId:
+                    description: "A unique and immutable identifier used to identify the offer resource. This identifier has no meaning to the account owner."
+                    type: "string"
+                    minLength: 1
+                    maxLength: 40
+                  OfferType:
+                    description: "Offer type, in a coded form."
+                    type: "string"
+                    enum:
+                      - "BalanceTransfer"
+                      - "LimitIncrease"
+                      - "MoneyTransfer"
+                      - "Other"
+                      - "PromotionalRate"
+                  Description:
+                    description: "Further details of the offer."
+                    type: "string"
+                    minLength: 1
+                    maxLength: 500
+                  StartDateTime:
+                    description: "Date and time at which the offer starts.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                    type: "string"
+                    format: "date-time"
+                  EndDateTime:
+                    description: "Date and time at which the offer ends.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                    type: "string"
+                    format: "date-time"
+                  Rate:
+                    description: "Rate associated with the offer type."
+                    type: "string"
+                    pattern: "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$"
+                  Value:
+                    description: "Value associated with the offer type."
+                    type: "integer"
+                  Term:
+                    description: "Further details of the term of the offer."
+                    type: "string"
+                    minLength: 1
+                    maxLength: 500
+                  URL:
+                    description: "URL (Uniform Resource Locator) where documentation on the offer can be found"
+                    type: "string"
+                    minLength: 1
+                    maxLength: 256
+                  Amount:
+                    type: "object"
+                    required:
+                      - "Amount"
+                      - "Currency"
+                    description: "Amount of money associated with the offer type."
+                    properties:
+                      Amount:
+                        $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+                      Currency:
+                        $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode_1"
+                  Fee:
+                    type: "object"
+                    required:
+                      - "Amount"
+                      - "Currency"
+                    description: "Fee associated with the offer type."
+                    properties:
+                      Amount:
+                        $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+                      Currency:
+                        $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode_1"
+        Links:
+          $ref: "#/components/schemas/Links"
+        Meta:
+          $ref: "#/components/schemas/Meta"
+      additionalProperties: false
+    OBReadParty2:
+      type: "object"
+      required:
+        - "Data"
+      properties:
+        Data:
+          type: "object"
+          properties:
+            Party:
+              $ref: "#/components/schemas/OBParty2"
+        Links:
+          $ref: "#/components/schemas/Links"
+        Meta:
+          $ref: "#/components/schemas/Meta"
+      additionalProperties: false
+    OBReadParty3:
+      type: "object"
+      required:
+        - "Data"
+      properties:
+        Data:
+          type: "object"
+          properties:
+            Party:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/OBParty2"
+        Links:
+          $ref: "#/components/schemas/Links"
+        Meta:
+          $ref: "#/components/schemas/Meta"
+      additionalProperties: false
+    OBReadProduct2:
+      type: "object"
+      required:
+        - "Data"
+      description: "Product details of Other Product which is not avaiable in the standard list"
+      properties:
+        Data:
+          type: "object"
+          description: "Aligning with the read write specs structure."
+          properties:
+            Product:
+              type: "array"
+              items:
+                type: "object"
+                description: "Product details associated with the Account"
+                required:
+                  - "AccountId"
+                  - "ProductType"
+                properties:
+                  ProductName:
+                    description: "The name of the Product used for marketing purposes from a customer perspective. I.e. what the customer would recognise."
+                    type: "string"
+                    minLength: 1
+                    maxLength: 350
+                  ProductId:
+                    description: "The unique ID that has been internally assigned by the financial institution to each of the current account banking products they market to their retail and/or small to medium enterprise (SME) customers."
+                    type: "string"
+                    minLength: 1
+                    maxLength: 40
+                  AccountId:
+                    $ref: "#/components/schemas/AccountId"
+                  SecondaryProductId:
+                    description: "Any secondary Identification which  supports Product Identifier to uniquely identify the current account banking products."
+                    type: "string"
+                    minLength: 1
+                    maxLength: 70
+                  ProductType:
+                    description: "Product type : Personal Current Account, Business Current Account"
+                    type: "string"
+                    enum:
+                      - "BusinessCurrentAccount"
+                      - "CommercialCreditCard"
+                      - "Other"
+                      - "PersonalCurrentAccount"
+                      - "SMELoan"
+                  MarketingStateId:
+                    description: "Unique and unambiguous identification of a  Product Marketing State."
+                    type: "string"
+                    minLength: 1
+                    maxLength: 35
+                  OtherProductType:
+                    type: "object"
+                    required:
+                      - "Name"
+                      - "Description"
+                    description: "Other product type details associated with the account."
+                    properties:
+                      Name:
+                        description: "Long name associated with the product"
+                        type: "string"
+                        minLength: 1
+                        maxLength: 350
+                      Description:
+                        description: "Description of the Product associated with the account"
+                        type: "string"
+                        minLength: 1
+                        maxLength: 350
+                      ProductDetails:
+                        type: "object"
+                        properties:
+                          Segment:
+                            type: "array"
+                            items:
+                              description: "Market segmentation is a marketing term referring to the aggregating of prospective buyers into groups, or segments, that have common needs and respond similarly to a marketing action. Market segmentation enables companies to target different categories of consumers who perceive the full value of certain products and services differently from one another.\nRead more: Market Segmentation http://www.investopedia.com/terms/m/marketsegmentation.asp#ixzz4gfEEalTd "
+                              type: "string"
+                              enum:
+                                - "GEAS"
+                                - "GEBA"
+                                - "GEBR"
+                                - "GEBU"
+                                - "GECI"
+                                - "GECS"
+                                - "GEFB"
+                                - "GEFG"
+                                - "GEG"
+                                - "GEGR"
+                                - "GEGS"
+                                - "GEOT"
+                                - "GEOV"
+                                - "GEPA"
+                                - "GEPR"
+                                - "GERE"
+                                - "GEST"
+                                - "GEYA"
+                                - "GEYO"
+                                - "PSCA"
+                                - "PSES"
+                                - "PSNC"
+                                - "PSNP"
+                                - "PSRG"
+                                - "PSSS"
+                                - "PSST"
+                                - "PSSW"
+                          FeeFreeLength:
+                            description: "The length/duration of the fee free period"
+                            type: "integer"
+                          FeeFreeLengthPeriod:
+                            description: "The unit of period (days, weeks, months etc.) of the promotional length"
+                            type: "string"
+                            enum:
+                              - "PACT"
+                              - "PDAY"
+                              - "PHYR"
+                              - "PMTH"
+                              - "PQTR"
+                              - "PWEK"
+                              - "PYER"
+                          MonthlyMaximumCharge:
+                            description: "The maximum relevant charges that could accrue as defined fully in Part 7 of the CMA order"
+                            type: "string"
+                            pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                          Notes:
+                            type: "array"
+                            items:
+                              description: "Optional additional notes to supplement the Core product details"
+                              type: "string"
+                              minLength: 1
+                              maxLength: 2000
+                          OtherSegment:
+                            $ref: "#/components/schemas/OB_OtherCodeType1_0"
+                      CreditInterest:
+                        type: "object"
+                        required:
+                          - "TierBandSet"
+                        description: "Details about the interest that may be payable to the Account holders"
+                        properties:
+                          TierBandSet:
+                            type: "array"
+                            items:
+                              type: "object"
+                              description: "The group of tiers or bands for which credit interest can be applied."
+                              required:
+                                - "TierBandMethod"
+                                - "Destination"
+                                - "TierBand"
+                              properties:
+                                TierBandMethod:
+                                  description: "The methodology of how credit interest is paid/applied. It can be:-\n1. Banded\nInterest rates are banded. i.e. Increasing rate on whole balance as balance increases.\n2. Tiered\nInterest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance.\n3. Whole\nThe same interest rate is applied irrespective of the product holder's account balance"
+                                  type: "string"
+                                  enum:
+                                    - "INBA"
+                                    - "INTI"
+                                    - "INWH"
+                                CalculationMethod:
+                                  $ref: "#/components/schemas/OB_InterestCalculationMethod1Code"
+                                Destination:
+                                  description: "Describes whether accrued interest is payable only to the BCA or to another bank account"
+                                  type: "string"
+                                  enum:
+                                    - "INOT"
+                                    - "INPA"
+                                    - "INSC"
+                                Notes:
+                                  type: "array"
+                                  items:
+                                    description: "Optional additional notes to supplement the Tier Band Set details"
+                                    type: "string"
+                                    minLength: 1
+                                    maxLength: 2000
+                                OtherCalculationMethod:
+                                  $ref: "#/components/schemas/OB_OtherCodeType1_0"
+                                OtherDestination:
+                                  $ref: "#/components/schemas/OB_OtherCodeType1_0"
+                                TierBand:
+                                  type: "array"
+                                  items:
+                                    type: "object"
+                                    description: "Tier Band Details"
+                                    required:
+                                      - "TierValueMinimum"
+                                      - "ApplicationFrequency"
+                                      - "FixedVariableInterestRateType"
+                                      - "AER"
+                                    properties:
+                                      Identification:
+                                        description: "Unique and unambiguous identification of a  Tier Band for the Product."
+                                        type: "string"
+                                        minLength: 1
+                                        maxLength: 35
+                                      TierValueMinimum:
+                                        description: "Minimum deposit value for which the credit interest tier applies."
+                                        type: "string"
+                                        pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                                      TierValueMaximum:
+                                        description: "Maximum deposit value for which the credit interest tier applies."
+                                        type: "string"
+                                        pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                                      CalculationFrequency:
+                                        description: "How often is credit interest calculated for the account."
+                                        type: "string"
+                                        enum:
+                                          - "FQAT"
+                                          - "FQDY"
+                                          - "FQHY"
+                                          - "FQMY"
+                                          - "FQOT"
+                                          - "FQQY"
+                                          - "FQSD"
+                                          - "FQWY"
+                                          - "FQYY"
+                                      ApplicationFrequency:
+                                        description: "How often is interest applied to the Product for this tier/band i.e. how often the financial institution pays accumulated interest to the customer's account."
+                                        type: "string"
+                                        enum:
+                                          - "FQAT"
+                                          - "FQDY"
+                                          - "FQHY"
+                                          - "FQMY"
+                                          - "FQOT"
+                                          - "FQQY"
+                                          - "FQSD"
+                                          - "FQWY"
+                                          - "FQYY"
+                                      DepositInterestAppliedCoverage:
+                                        description: "Amount on which Interest applied."
+                                        type: "string"
+                                        enum:
+                                          - "INBA"
+                                          - "INTI"
+                                          - "INWH"
+                                      FixedVariableInterestRateType:
+                                        $ref: "#/components/schemas/OB_InterestFixedVariableType1Code"
+                                      AER:
+                                        description: "The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made. \nRead more: Annual Equivalent Rate (AER) http://www.investopedia.com/terms/a/aer.asp#ixzz4gfR7IO1A"
+                                        type: "string"
+                                        pattern: "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$"
+                                      BankInterestRateType:
+                                        description: "Interest rate types, other than AER, which financial institutions may use to describe the annual interest rate payable to the account holder's account."
+                                        type: "string"
+                                        enum:
+                                          - "INBB"
+                                          - "INFR"
+                                          - "INGR"
+                                          - "INLR"
+                                          - "INNE"
+                                          - "INOT"
+                                      BankInterestRate:
+                                        description: "Bank Interest for the product"
+                                        type: "string"
+                                        pattern: "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$"
+                                      Notes:
+                                        type: "array"
+                                        items:
+                                          description: "Optional additional notes to supplement the Tier Band details"
+                                          type: "string"
+                                          minLength: 1
+                                          maxLength: 2000
+                                      OtherBankInterestType:
+                                        type: "object"
+                                        required:
+                                          - "Name"
+                                          - "Description"
+                                        description: "Other interest rate types which are not available in the standard code list"
+                                        properties:
+                                          Code:
+                                            $ref: "#/components/schemas/OB_CodeMnemonic"
+                                          Name:
+                                            $ref: "#/components/schemas/Name_4"
+                                          Description:
+                                            $ref: "#/components/schemas/Description_3"
+                                      OtherApplicationFrequency:
+                                        $ref: "#/components/schemas/OB_OtherCodeType1_1"
+                                      OtherCalculationFrequency:
+                                        $ref: "#/components/schemas/OB_OtherCodeType1_2"
+                                  minItems: 1
+                            minItems: 1
+                      Overdraft:
+                        type: "object"
+                        required:
+                          - "OverdraftTierBandSet"
+                        description: "Borrowing details"
+                        properties:
+                          Notes:
+                            type: "array"
+                            items:
+                              description: "Associated Notes about the overdraft rates"
+                              type: "string"
+                              minLength: 1
+                              maxLength: 2000
+                          OverdraftTierBandSet:
+                            type: "array"
+                            items:
+                              type: "object"
+                              description: "Tier band set details"
+                              required:
+                                - "TierBandMethod"
+                                - "OverdraftTierBand"
+                              properties:
+                                TierBandMethod:
+                                  description: "The methodology of how overdraft is charged. It can be:\n'Whole'  Where the same charge/rate is applied to the entirety of the overdraft balance (where charges are applicable). \n'Tiered' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount tiers defined by the lending financial organisation\n'Banded' Where different charges/rates are applied dependent on overdraft maximum and minimum balance amount bands defined by a government organisation."
+                                  type: "string"
+                                  enum:
+                                    - "INBA"
+                                    - "INTI"
+                                    - "INWH"
+                                OverdraftType:
+                                  description: "An overdraft can either be 'committed' which means that the facility cannot be withdrawn without reasonable notification before it's agreed end date, or 'on demand' which means that the financial institution can demand repayment at any point in time."
+                                  type: "string"
+                                  enum:
+                                    - "OVCO"
+                                    - "OVOD"
+                                    - "OVOT"
+                                Identification:
+                                  description: "Unique and unambiguous identification of a  Tier Band for a overdraft product."
+                                  type: "string"
+                                  minLength: 1
+                                  maxLength: 35
+                                AuthorisedIndicator:
+                                  description: "Indicates if the Overdraft is authorised (Y) or unauthorised (N)"
+                                  type: "boolean"
+                                BufferAmount:
+                                  description: "When a customer exceeds their credit limit, a financial institution will not charge the customer unauthorised overdraft charges if they do not exceed by more than the buffer amount. Note: Authorised overdraft charges may still apply."
+                                  type: "string"
+                                  pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                                Notes:
+                                  type: "array"
+                                  items:
+                                    description: "Optional additional notes to supplement the overdraft Tier Band Set details"
+                                    type: "string"
+                                    minLength: 1
+                                    maxLength: 2000
+                                OverdraftTierBand:
+                                  type: "array"
+                                  items:
+                                    type: "object"
+                                    description: "Provides overdraft details for a specific tier or band"
+                                    required:
+                                      - "TierValueMin"
+                                    properties:
+                                      Identification:
+                                        description: "Unique and unambiguous identification of a  Tier Band for a overdraft."
+                                        type: "string"
+                                        minLength: 1
+                                        maxLength: 35
+                                      TierValueMin:
+                                        description: "Minimum value of Overdraft Tier/Band"
+                                        type: "string"
+                                        pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                                      TierValueMax:
+                                        description: "Maximum value of Overdraft Tier/Band"
+                                        type: "string"
+                                        pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                                      EAR:
+                                        description: "EAR means Effective Annual Rate and/or Equivalent Annual Rate (frequently\nused interchangeably), being the actual annual interest rate of an Overdraft."
+                                        type: "string"
+                                        pattern: "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$"
+                                      AgreementLengthMin:
+                                        description: "Specifies the minimum length of a band for a fixed overdraft agreement"
+                                        type: "integer"
+                                      AgreementLengthMax:
+                                        description: "Specifies the maximum length of a band for a fixed overdraft agreement"
+                                        type: "integer"
+                                      AgreementPeriod:
+                                        description: "Specifies the period of a fixed length overdraft agreement"
+                                        type: "string"
+                                        enum:
+                                          - "PACT"
+                                          - "PDAY"
+                                          - "PHYR"
+                                          - "PMTH"
+                                          - "PQTR"
+                                          - "PWEK"
+                                          - "PYER"
+                                      OverdraftInterestChargingCoverage:
+                                        description: "Refers to which interest rate is applied when interests are tiered. For example, if an overdraft balance is �2k and the interest tiers are:- 0-�500 0.1%, 500-1000 0.2%, 1000-10000 0.5%, then the applicable interest rate could either be 0.5% of the entire balance (since the account balance sits in the top interest tier) or (0.1%*500)+(0.2%*500)+(0.5%*1000). In the 1st situation, we say the interest is applied to the �Whole� of the account balance,  and in the 2nd that it is �Tiered�."
+                                        type: "string"
+                                        enum:
+                                          - "INBA"
+                                          - "INTI"
+                                          - "INWH"
+                                      BankGuaranteedIndicator:
+                                        description: "Indicates whether the advertised overdraft rate is guaranteed to be offered to a borrower by the bank e.g. if it�s part of a government scheme, or whether the rate may vary dependent on the applicant�s circumstances."
+                                        type: "boolean"
+                                      Notes:
+                                        type: "array"
+                                        items:
+                                          description: "Optional additional notes to supplement the Tier/band details"
+                                          type: "string"
+                                          minLength: 1
+                                          maxLength: 2000
+                                      OverdraftFeesCharges:
+                                        type: "array"
+                                        items:
+                                          type: "object"
+                                          description: "Overdraft fees and charges"
+                                          required:
+                                            - "OverdraftFeeChargeDetail"
+                                          properties:
+                                            OverdraftFeeChargeCap:
+                                              type: "array"
+                                              items:
+                                                type: "object"
+                                                description: "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate."
+                                                required:
+                                                  - "FeeType"
+                                                  - "MinMaxType"
+                                                properties:
+                                                  FeeType:
+                                                    type: "array"
+                                                    items:
+                                                      description: "Fee/charge type which is being capped"
+                                                      type: "string"
+                                                      enum:
+                                                        - "FBAO"
+                                                        - "FBAR"
+                                                        - "FBEB"
+                                                        - "FBIT"
+                                                        - "FBOR"
+                                                        - "FBOS"
+                                                        - "FBSC"
+                                                        - "FBTO"
+                                                        - "FBUB"
+                                                        - "FBUT"
+                                                        - "FTOT"
+                                                        - "FTUT"
+                                                    minItems: 1
+                                                  MinMaxType:
+                                                    $ref: "#/components/schemas/OB_MinMaxType1Code"
+                                                  FeeCapOccurrence:
+                                                    $ref: "#/components/schemas/Number_0"
+                                                  FeeCapAmount:
+                                                    $ref: "#/components/schemas/OB_Amount1_0"
+                                                  CappingPeriod:
+                                                    $ref: "#/components/schemas/OB_Period1Code"
+                                                  Notes:
+                                                    type: "array"
+                                                    items:
+                                                      description: "Notes related to Overdraft fee charge cap"
+                                                      type: "string"
+                                                      minLength: 1
+                                                      maxLength: 2000
+                                                  OtherFeeType:
+                                                    type: "array"
+                                                    items:
+                                                      type: "object"
+                                                      description: "Other fee type code which is not available in the standard code set"
+                                                      required:
+                                                        - "Name"
+                                                        - "Description"
+                                                      properties:
+                                                        Code:
+                                                          $ref: "#/components/schemas/OB_CodeMnemonic"
+                                                        Name:
+                                                          $ref: "#/components/schemas/Name_4"
+                                                        Description:
+                                                          $ref: "#/components/schemas/Description_3"
+                                            OverdraftFeeChargeDetail:
+                                              type: "array"
+                                              items:
+                                                type: "object"
+                                                description: "Details about the fees/charges"
+                                                required:
+                                                  - "FeeType"
+                                                  - "ApplicationFrequency"
+                                                properties:
+                                                  FeeType:
+                                                    $ref: "#/components/schemas/OB_OverdraftFeeType1Code"
+                                                  NegotiableIndicator:
+                                                    description: "Indicates whether fee and charges are negotiable"
+                                                    type: "boolean"
+                                                  OverdraftControlIndicator:
+                                                    description: "Indicates if the fee/charge is already covered by an 'Overdraft Control' fee or not."
+                                                    type: "boolean"
+                                                  IncrementalBorrowingAmount:
+                                                    $ref: "#/components/schemas/OB_Amount1_1"
+                                                  FeeAmount:
+                                                    $ref: "#/components/schemas/OB_Amount1_2"
+                                                  FeeRate:
+                                                    $ref: "#/components/schemas/OB_Rate1_0"
+                                                  FeeRateType:
+                                                    $ref: "#/components/schemas/OB_InterestRateType1Code_0"
+                                                  ApplicationFrequency:
+                                                    $ref: "#/components/schemas/OB_FeeFrequency1Code_0"
+                                                  CalculationFrequency:
+                                                    $ref: "#/components/schemas/OB_FeeFrequency1Code_1"
+                                                  Notes:
+                                                    type: "array"
+                                                    items:
+                                                      description: "Free text for capturing any other info related to Overdraft Fees Charge Details"
+                                                      type: "string"
+                                                      minLength: 1
+                                                      maxLength: 2000
+                                                  OverdraftFeeChargeCap:
+                                                    type: "array"
+                                                    items:
+                                                      type: "object"
+                                                      description: "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate."
+                                                      required:
+                                                        - "FeeType"
+                                                        - "MinMaxType"
+                                                      properties:
+                                                        FeeType:
+                                                          type: "array"
+                                                          items:
+                                                            description: "Fee/charge type which is being capped"
+                                                            type: "string"
+                                                            enum:
+                                                              - "FBAO"
+                                                              - "FBAR"
+                                                              - "FBEB"
+                                                              - "FBIT"
+                                                              - "FBOR"
+                                                              - "FBOS"
+                                                              - "FBSC"
+                                                              - "FBTO"
+                                                              - "FBUB"
+                                                              - "FBUT"
+                                                              - "FTOT"
+                                                              - "FTUT"
+                                                          minItems: 1
+                                                        MinMaxType:
+                                                          $ref: "#/components/schemas/OB_MinMaxType1Code"
+                                                        FeeCapOccurrence:
+                                                          $ref: "#/components/schemas/Number_0"
+                                                        FeeCapAmount:
+                                                          $ref: "#/components/schemas/OB_Amount1_0"
+                                                        CappingPeriod:
+                                                          $ref: "#/components/schemas/OB_Period1Code"
+                                                        Notes:
+                                                          type: "array"
+                                                          items:
+                                                            description: "Notes related to Overdraft fee charge cap"
+                                                            type: "string"
+                                                            minLength: 1
+                                                            maxLength: 2000
+                                                        OtherFeeType:
+                                                          type: "array"
+                                                          items:
+                                                            type: "object"
+                                                            description: "Other fee type code which is not available in the standard code set"
+                                                            required:
+                                                              - "Name"
+                                                              - "Description"
+                                                            properties:
+                                                              Code:
+                                                                $ref: "#/components/schemas/OB_CodeMnemonic"
+                                                              Name:
+                                                                $ref: "#/components/schemas/Name_4"
+                                                              Description:
+                                                                $ref: "#/components/schemas/Description_3"
+                                                  OtherFeeType:
+                                                    $ref: "#/components/schemas/OB_OtherCodeType1_3"
+                                                  OtherFeeRateType:
+                                                    $ref: "#/components/schemas/OB_OtherCodeType1_4"
+                                                  OtherApplicationFrequency:
+                                                    $ref: "#/components/schemas/OB_OtherCodeType1_1"
+                                                  OtherCalculationFrequency:
+                                                    $ref: "#/components/schemas/OB_OtherCodeType1_2"
+                                              minItems: 1
+                                  minItems: 1
+                                OverdraftFeesCharges:
+                                  type: "array"
+                                  items:
+                                    type: "object"
+                                    description: "Overdraft fees and charges details"
+                                    required:
+                                      - "OverdraftFeeChargeDetail"
+                                    properties:
+                                      OverdraftFeeChargeCap:
+                                        type: "array"
+                                        items:
+                                          type: "object"
+                                          description: "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate."
+                                          required:
+                                            - "FeeType"
+                                            - "MinMaxType"
+                                          properties:
+                                            FeeType:
+                                              type: "array"
+                                              items:
+                                                description: "Fee/charge type which is being capped"
+                                                type: "string"
+                                                enum:
+                                                  - "FBAO"
+                                                  - "FBAR"
+                                                  - "FBEB"
+                                                  - "FBIT"
+                                                  - "FBOR"
+                                                  - "FBOS"
+                                                  - "FBSC"
+                                                  - "FBTO"
+                                                  - "FBUB"
+                                                  - "FBUT"
+                                                  - "FTOT"
+                                                  - "FTUT"
+                                              minItems: 1
+                                            MinMaxType:
+                                              $ref: "#/components/schemas/OB_MinMaxType1Code"
+                                            FeeCapOccurrence:
+                                              $ref: "#/components/schemas/Number_0"
+                                            FeeCapAmount:
+                                              $ref: "#/components/schemas/OB_Amount1_0"
+                                            CappingPeriod:
+                                              $ref: "#/components/schemas/OB_Period1Code"
+                                            Notes:
+                                              type: "array"
+                                              items:
+                                                description: "Notes related to Overdraft fee charge cap"
+                                                type: "string"
+                                                minLength: 1
+                                                maxLength: 2000
+                                            OtherFeeType:
+                                              type: "array"
+                                              items:
+                                                type: "object"
+                                                description: "Other fee type code which is not available in the standard code set"
+                                                required:
+                                                  - "Name"
+                                                  - "Description"
+                                                properties:
+                                                  Code:
+                                                    $ref: "#/components/schemas/OB_CodeMnemonic"
+                                                  Name:
+                                                    $ref: "#/components/schemas/Name_4"
+                                                  Description:
+                                                    $ref: "#/components/schemas/Description_3"
+                                      OverdraftFeeChargeDetail:
+                                        type: "array"
+                                        items:
+                                          type: "object"
+                                          description: "Details about the fees/charges"
+                                          required:
+                                            - "FeeType"
+                                            - "ApplicationFrequency"
+                                          properties:
+                                            FeeType:
+                                              $ref: "#/components/schemas/OB_OverdraftFeeType1Code"
+                                            NegotiableIndicator:
+                                              description: "Indicates whether fee and charges are negotiable"
+                                              type: "boolean"
+                                            OverdraftControlIndicator:
+                                              description: "Indicates if the fee/charge is already covered by an 'Overdraft Control' fee or not."
+                                              type: "boolean"
+                                            IncrementalBorrowingAmount:
+                                              $ref: "#/components/schemas/OB_Amount1_1"
+                                            FeeAmount:
+                                              $ref: "#/components/schemas/OB_Amount1_2"
+                                            FeeRate:
+                                              $ref: "#/components/schemas/OB_Rate1_0"
+                                            FeeRateType:
+                                              $ref: "#/components/schemas/OB_InterestRateType1Code_0"
+                                            ApplicationFrequency:
+                                              $ref: "#/components/schemas/OB_FeeFrequency1Code_0"
+                                            CalculationFrequency:
+                                              $ref: "#/components/schemas/OB_FeeFrequency1Code_1"
+                                            Notes:
+                                              type: "array"
+                                              items:
+                                                description: "Free text for capturing any other info related to Overdraft Fees Charge Details"
+                                                type: "string"
+                                                minLength: 1
+                                                maxLength: 2000
+                                            OverdraftFeeChargeCap:
+                                              type: "array"
+                                              items:
+                                                type: "object"
+                                                description: "Details about any caps (maximum charges) that apply to a particular fee/charge. Capping can either be based on an amount (in gbp), an amount (in items) or a rate."
+                                                required:
+                                                  - "FeeType"
+                                                  - "MinMaxType"
+                                                properties:
+                                                  FeeType:
+                                                    type: "array"
+                                                    items:
+                                                      description: "Fee/charge type which is being capped"
+                                                      type: "string"
+                                                      enum:
+                                                        - "FBAO"
+                                                        - "FBAR"
+                                                        - "FBEB"
+                                                        - "FBIT"
+                                                        - "FBOR"
+                                                        - "FBOS"
+                                                        - "FBSC"
+                                                        - "FBTO"
+                                                        - "FBUB"
+                                                        - "FBUT"
+                                                        - "FTOT"
+                                                        - "FTUT"
+                                                    minItems: 1
+                                                  MinMaxType:
+                                                    $ref: "#/components/schemas/OB_MinMaxType1Code"
+                                                  FeeCapOccurrence:
+                                                    $ref: "#/components/schemas/Number_0"
+                                                  FeeCapAmount:
+                                                    $ref: "#/components/schemas/OB_Amount1_0"
+                                                  CappingPeriod:
+                                                    $ref: "#/components/schemas/OB_Period1Code"
+                                                  Notes:
+                                                    type: "array"
+                                                    items:
+                                                      description: "Notes related to Overdraft fee charge cap"
+                                                      type: "string"
+                                                      minLength: 1
+                                                      maxLength: 2000
+                                                  OtherFeeType:
+                                                    type: "array"
+                                                    items:
+                                                      type: "object"
+                                                      description: "Other fee type code which is not available in the standard code set"
+                                                      required:
+                                                        - "Name"
+                                                        - "Description"
+                                                      properties:
+                                                        Code:
+                                                          $ref: "#/components/schemas/OB_CodeMnemonic"
+                                                        Name:
+                                                          $ref: "#/components/schemas/Name_4"
+                                                        Description:
+                                                          $ref: "#/components/schemas/Description_3"
+                                            OtherFeeType:
+                                              $ref: "#/components/schemas/OB_OtherCodeType1_3"
+                                            OtherFeeRateType:
+                                              $ref: "#/components/schemas/OB_OtherCodeType1_4"
+                                            OtherApplicationFrequency:
+                                              $ref: "#/components/schemas/OB_OtherCodeType1_1"
+                                            OtherCalculationFrequency:
+                                              $ref: "#/components/schemas/OB_OtherCodeType1_2"
+                                        minItems: 1
+                            minItems: 1
+                      LoanInterest:
+                        type: "object"
+                        required:
+                          - "LoanInterestTierBandSet"
+                        description: "Details about the interest that may be payable to the SME Loan holders"
+                        properties:
+                          Notes:
+                            type: "array"
+                            items:
+                              description: "Optional additional notes to supplement the LoanInterest"
+                              type: "string"
+                              minLength: 1
+                              maxLength: 2000
+                          LoanInterestTierBandSet:
+                            type: "array"
+                            items:
+                              type: "object"
+                              description: "The group of tiers or bands for which debit interest can be applied."
+                              required:
+                                - "TierBandMethod"
+                                - "CalculationMethod"
+                                - "LoanInterestTierBand"
+                              properties:
+                                TierBandMethod:
+                                  description: "The methodology of how credit interest is charged. It can be:-\n1. Banded\nInterest rates are banded. i.e. Increasing rate on whole balance as balance increases.\n2. Tiered\nInterest rates are tiered. i.e. increasing rate for each tier as balance increases, but interest paid on tier fixed for that tier and not on whole balance.\n3. Whole\nThe same interest rate is applied irrespective of the SME Loan balance"
+                                  type: "string"
+                                  enum:
+                                    - "INBA"
+                                    - "INTI"
+                                    - "INWH"
+                                Identification:
+                                  description: "Loan interest tierbandset identification. Used by  loan providers for internal use purpose."
+                                  type: "string"
+                                  minLength: 1
+                                  maxLength: 35
+                                CalculationMethod:
+                                  $ref: "#/components/schemas/OB_InterestCalculationMethod1Code"
+                                Notes:
+                                  type: "array"
+                                  items:
+                                    description: "Optional additional notes to supplement the Tier Band Set details"
+                                    type: "string"
+                                    minLength: 1
+                                    maxLength: 2000
+                                OtherCalculationMethod:
+                                  $ref: "#/components/schemas/OB_OtherCodeType1_0"
+                                LoanInterestTierBand:
+                                  type: "array"
+                                  items:
+                                    type: "object"
+                                    description: "Tier Band Details"
+                                    required:
+                                      - "TierValueMinimum"
+                                      - "TierValueMinTerm"
+                                      - "MinTermPeriod"
+                                      - "FixedVariableInterestRateType"
+                                      - "RepAPR"
+                                    properties:
+                                      Identification:
+                                        description: "Unique and unambiguous identification of a  Tier Band for a SME Loan."
+                                        type: "string"
+                                        minLength: 1
+                                        maxLength: 35
+                                      TierValueMinimum:
+                                        description: "Minimum loan value for which the loan interest tier applies."
+                                        type: "string"
+                                        pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                                      TierValueMaximum:
+                                        description: "Maximum loan value for which the loan interest tier applies."
+                                        type: "string"
+                                        pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                                      TierValueMinTerm:
+                                        description: "Minimum loan term for which the loan interest tier applies."
+                                        type: "integer"
+                                      MinTermPeriod:
+                                        description: "The unit of period (days, weeks, months etc.) of the Minimum Term"
+                                        type: "string"
+                                        enum:
+                                          - "PACT"
+                                          - "PDAY"
+                                          - "PHYR"
+                                          - "PMTH"
+                                          - "PQTR"
+                                          - "PWEK"
+                                          - "PYER"
+                                      TierValueMaxTerm:
+                                        description: "Maximum loan term for which the loan interest tier applies."
+                                        type: "integer"
+                                      MaxTermPeriod:
+                                        description: "The unit of period (days, weeks, months etc.) of the Maximum Term"
+                                        type: "string"
+                                        enum:
+                                          - "PACT"
+                                          - "PDAY"
+                                          - "PHYR"
+                                          - "PMTH"
+                                          - "PQTR"
+                                          - "PWEK"
+                                          - "PYER"
+                                      FixedVariableInterestRateType:
+                                        $ref: "#/components/schemas/OB_InterestFixedVariableType1Code"
+                                      RepAPR:
+                                        description: "The annual equivalent rate (AER) is interest that is calculated under the assumption that any interest paid is combined with the original balance and the next interest payment will be based on the slightly higher account balance. Overall, this means that interest can be compounded several times in a year depending on the number of times that interest payments are made. \nFor SME Loan, this APR is the representative APR which includes any account fees."
+                                        type: "string"
+                                        pattern: "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$"
+                                      LoanProviderInterestRateType:
+                                        description: "Interest rate types, other than APR, which financial institutions may use to describe the annual interest rate payable for the SME Loan."
+                                        type: "string"
+                                        enum:
+                                          - "INBB"
+                                          - "INFR"
+                                          - "INGR"
+                                          - "INLR"
+                                          - "INNE"
+                                          - "INOT"
+                                      LoanProviderInterestRate:
+                                        description: "Loan provider Interest for the SME Loan product"
+                                        type: "string"
+                                        pattern: "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$"
+                                      Notes:
+                                        type: "array"
+                                        items:
+                                          description: "Optional additional notes to supplement the Tier Band details"
+                                          type: "string"
+                                          minLength: 1
+                                          maxLength: 2000
+                                      OtherLoanProviderInterestRateType:
+                                        type: "object"
+                                        required:
+                                          - "Name"
+                                          - "Description"
+                                        description: "Other loan interest rate types which are not available in the standard code list"
+                                        properties:
+                                          Code:
+                                            $ref: "#/components/schemas/OB_CodeMnemonic"
+                                          Name:
+                                            $ref: "#/components/schemas/Name_4"
+                                          Description:
+                                            $ref: "#/components/schemas/Description_3"
+                                      LoanInterestFeesCharges:
+                                        type: "array"
+                                        items:
+                                          type: "object"
+                                          description: "Contains details of fees and charges which are not associated with either LoanRepayment or features/benefits"
+                                          required:
+                                            - "LoanInterestFeeChargeDetail"
+                                          properties:
+                                            LoanInterestFeeChargeDetail:
+                                              type: "array"
+                                              items:
+                                                type: "object"
+                                                description: "Other fees/charges details"
+                                                required:
+                                                  - "FeeType"
+                                                  - "ApplicationFrequency"
+                                                  - "CalculationFrequency"
+                                                properties:
+                                                  FeeType:
+                                                    $ref: "#/components/schemas/OB_FeeType1Code"
+                                                  NegotiableIndicator:
+                                                    description: "Fee/charge which is usually negotiable rather than a fixed amount"
+                                                    type: "boolean"
+                                                  FeeAmount:
+                                                    $ref: "#/components/schemas/OB_Amount1_3"
+                                                  FeeRate:
+                                                    $ref: "#/components/schemas/OB_Rate1_1"
+                                                  FeeRateType:
+                                                    $ref: "#/components/schemas/OB_InterestRateType1Code_1"
+                                                  ApplicationFrequency:
+                                                    $ref: "#/components/schemas/OB_FeeFrequency1Code_2"
+                                                  CalculationFrequency:
+                                                    $ref: "#/components/schemas/OB_FeeFrequency1Code_3"
+                                                  Notes:
+                                                    type: "array"
+                                                    items:
+                                                      description: "Optional additional notes to supplement the fee/charge details."
+                                                      type: "string"
+                                                      minLength: 1
+                                                      maxLength: 2000
+                                                  OtherFeeType:
+                                                    $ref: "#/components/schemas/OB_OtherFeeChargeDetailType"
+                                                  OtherFeeRateType:
+                                                    $ref: "#/components/schemas/OB_OtherCodeType1_5"
+                                                  OtherApplicationFrequency:
+                                                    $ref: "#/components/schemas/OB_OtherCodeType1_6"
+                                                  OtherCalculationFrequency:
+                                                    $ref: "#/components/schemas/OB_OtherCodeType1_7"
+                                              minItems: 1
+                                            LoanInterestFeeChargeCap:
+                                              type: "array"
+                                              items:
+                                                type: "object"
+                                                description: "Details about any caps (minimum/maximum charges) that apply to a particular fee/charge"
+                                                required:
+                                                  - "FeeType"
+                                                  - "MinMaxType"
+                                                properties:
+                                                  FeeType:
+                                                    type: "array"
+                                                    items:
+                                                      description: "Fee/charge type which is being capped"
+                                                      type: "string"
+                                                      enum:
+                                                        - "FEPF"
+                                                        - "FTOT"
+                                                        - "FYAF"
+                                                        - "FYAM"
+                                                        - "FYAQ"
+                                                        - "FYCP"
+                                                        - "FYDB"
+                                                        - "FYMI"
+                                                        - "FYXX"
+                                                    minItems: 1
+                                                  MinMaxType:
+                                                    $ref: "#/components/schemas/OB_MinMaxType1Code"
+                                                  FeeCapOccurrence:
+                                                    $ref: "#/components/schemas/Number_1"
+                                                  FeeCapAmount:
+                                                    $ref: "#/components/schemas/OB_Amount1_4"
+                                                  CappingPeriod:
+                                                    $ref: "#/components/schemas/OB_FeeFrequency1Code_4"
+                                                  Notes:
+                                                    type: "array"
+                                                    items:
+                                                      description: "Free text for adding  extra details for fee charge cap"
+                                                      type: "string"
+                                                      minLength: 1
+                                                      maxLength: 2000
+                                                  OtherFeeType:
+                                                    type: "array"
+                                                    items:
+                                                      type: "object"
+                                                      description: "Other fee type code which is not available in the standard code set"
+                                                      required:
+                                                        - "Name"
+                                                        - "Description"
+                                                      properties:
+                                                        Code:
+                                                          $ref: "#/components/schemas/OB_CodeMnemonic"
+                                                        Name:
+                                                          $ref: "#/components/schemas/Name_4"
+                                                        Description:
+                                                          $ref: "#/components/schemas/Description_3"
+                                  minItems: 1
+                                LoanInterestFeesCharges:
+                                  type: "array"
+                                  items:
+                                    type: "object"
+                                    description: "Contains details of fees and charges which are not associated with either LoanRepayment or features/benefits"
+                                    required:
+                                      - "LoanInterestFeeChargeDetail"
+                                    properties:
+                                      LoanInterestFeeChargeDetail:
+                                        type: "array"
+                                        items:
+                                          type: "object"
+                                          description: "Other fees/charges details"
+                                          required:
+                                            - "FeeType"
+                                            - "ApplicationFrequency"
+                                            - "CalculationFrequency"
+                                          properties:
+                                            FeeType:
+                                              $ref: "#/components/schemas/OB_FeeType1Code"
+                                            NegotiableIndicator:
+                                              description: "Fee/charge which is usually negotiable rather than a fixed amount"
+                                              type: "boolean"
+                                            FeeAmount:
+                                              $ref: "#/components/schemas/OB_Amount1_3"
+                                            FeeRate:
+                                              $ref: "#/components/schemas/OB_Rate1_1"
+                                            FeeRateType:
+                                              $ref: "#/components/schemas/OB_InterestRateType1Code_1"
+                                            ApplicationFrequency:
+                                              $ref: "#/components/schemas/OB_FeeFrequency1Code_2"
+                                            CalculationFrequency:
+                                              $ref: "#/components/schemas/OB_FeeFrequency1Code_3"
+                                            Notes:
+                                              type: "array"
+                                              items:
+                                                description: "Optional additional notes to supplement the fee/charge details."
+                                                type: "string"
+                                                minLength: 1
+                                                maxLength: 2000
+                                            OtherFeeType:
+                                              $ref: "#/components/schemas/OB_OtherFeeChargeDetailType"
+                                            OtherFeeRateType:
+                                              $ref: "#/components/schemas/OB_OtherCodeType1_5"
+                                            OtherApplicationFrequency:
+                                              $ref: "#/components/schemas/OB_OtherCodeType1_6"
+                                            OtherCalculationFrequency:
+                                              $ref: "#/components/schemas/OB_OtherCodeType1_7"
+                                        minItems: 1
+                                      LoanInterestFeeChargeCap:
+                                        type: "array"
+                                        items:
+                                          type: "object"
+                                          description: "Details about any caps (minimum/maximum charges) that apply to a particular fee/charge"
+                                          required:
+                                            - "FeeType"
+                                            - "MinMaxType"
+                                          properties:
+                                            FeeType:
+                                              type: "array"
+                                              items:
+                                                description: "Fee/charge type which is being capped"
+                                                type: "string"
+                                                enum:
+                                                  - "FEPF"
+                                                  - "FTOT"
+                                                  - "FYAF"
+                                                  - "FYAM"
+                                                  - "FYAQ"
+                                                  - "FYCP"
+                                                  - "FYDB"
+                                                  - "FYMI"
+                                                  - "FYXX"
+                                              minItems: 1
+                                            MinMaxType:
+                                              $ref: "#/components/schemas/OB_MinMaxType1Code"
+                                            FeeCapOccurrence:
+                                              $ref: "#/components/schemas/Number_1"
+                                            FeeCapAmount:
+                                              $ref: "#/components/schemas/OB_Amount1_4"
+                                            CappingPeriod:
+                                              $ref: "#/components/schemas/OB_FeeFrequency1Code_4"
+                                            Notes:
+                                              type: "array"
+                                              items:
+                                                description: "Free text for adding  extra details for fee charge cap"
+                                                type: "string"
+                                                minLength: 1
+                                                maxLength: 2000
+                                            OtherFeeType:
+                                              type: "array"
+                                              items:
+                                                type: "object"
+                                                description: "Other fee type code which is not available in the standard code set"
+                                                required:
+                                                  - "Name"
+                                                  - "Description"
+                                                properties:
+                                                  Code:
+                                                    $ref: "#/components/schemas/OB_CodeMnemonic"
+                                                  Name:
+                                                    $ref: "#/components/schemas/Name_4"
+                                                  Description:
+                                                    $ref: "#/components/schemas/Description_3"
+                            minItems: 1
+                      Repayment:
+                        type: "object"
+                        description: "Repayment details of the Loan product"
+                        properties:
+                          RepaymentType:
+                            description: "Repayment type"
+                            type: "string"
+                            enum:
+                              - "USBA"
+                              - "USBU"
+                              - "USCI"
+                              - "USCS"
+                              - "USER"
+                              - "USFA"
+                              - "USFB"
+                              - "USFI"
+                              - "USIO"
+                              - "USOT"
+                              - "USPF"
+                              - "USRW"
+                              - "USSL"
+                          RepaymentFrequency:
+                            description: "Repayment frequency"
+                            type: "string"
+                            enum:
+                              - "SMDA"
+                              - "SMFL"
+                              - "SMFO"
+                              - "SMHY"
+                              - "SMMO"
+                              - "SMOT"
+                              - "SMQU"
+                              - "SMWE"
+                              - "SMYE"
+                          AmountType:
+                            description: "The repayment is for paying just the interest only or both interest and capital or bullet amount or balance to date etc"
+                            type: "string"
+                            enum:
+                              - "RABD"
+                              - "RABL"
+                              - "RACI"
+                              - "RAFC"
+                              - "RAIO"
+                              - "RALT"
+                              - "USOT"
+                          Notes:
+                            type: "array"
+                            items:
+                              description: "Optional additional notes to supplement the Repayment"
+                              type: "string"
+                              minLength: 1
+                              maxLength: 2000
+                          OtherRepaymentType:
+                            type: "object"
+                            required:
+                              - "Name"
+                              - "Description"
+                            description: "Other repayment type which is not in the standard code list"
+                            properties:
+                              Code:
+                                $ref: "#/components/schemas/OB_CodeMnemonic"
+                              Name:
+                                $ref: "#/components/schemas/Name_4"
+                              Description:
+                                $ref: "#/components/schemas/Description_3"
+                          OtherRepaymentFrequency:
+                            type: "object"
+                            required:
+                              - "Name"
+                              - "Description"
+                            description: "Other repayment frequency which is not in the standard code list"
+                            properties:
+                              Code:
+                                $ref: "#/components/schemas/OB_CodeMnemonic"
+                              Name:
+                                $ref: "#/components/schemas/Name_4"
+                              Description:
+                                $ref: "#/components/schemas/Description_3"
+                          OtherAmountType:
+                            type: "object"
+                            required:
+                              - "Name"
+                              - "Description"
+                            description: "Other amount type which is not in the standard code list"
+                            properties:
+                              Code:
+                                $ref: "#/components/schemas/OB_CodeMnemonic"
+                              Name:
+                                $ref: "#/components/schemas/Name_4"
+                              Description:
+                                $ref: "#/components/schemas/Description_3"
+                          RepaymentFeeCharges:
+                            type: "object"
+                            required:
+                              - "RepaymentFeeChargeDetail"
+                            description: "Applicable fee/charges for repayment such as prepayment, full early repayment or non repayment."
+                            properties:
+                              RepaymentFeeChargeDetail:
+                                type: "array"
+                                items:
+                                  type: "object"
+                                  description: "Details about specific fees/charges that are applied for repayment"
+                                  required:
+                                    - "FeeType"
+                                    - "ApplicationFrequency"
+                                    - "CalculationFrequency"
+                                  properties:
+                                    FeeType:
+                                      $ref: "#/components/schemas/OB_FeeType1Code"
+                                    NegotiableIndicator:
+                                      description: "Fee/charge which is usually negotiable rather than a fixed amount"
+                                      type: "boolean"
+                                    FeeAmount:
+                                      $ref: "#/components/schemas/OB_Amount1_3"
+                                    FeeRate:
+                                      $ref: "#/components/schemas/OB_Rate1_1"
+                                    FeeRateType:
+                                      $ref: "#/components/schemas/OB_InterestRateType1Code_1"
+                                    ApplicationFrequency:
+                                      $ref: "#/components/schemas/OB_FeeFrequency1Code_2"
+                                    CalculationFrequency:
+                                      $ref: "#/components/schemas/OB_FeeFrequency1Code_3"
+                                    Notes:
+                                      type: "array"
+                                      items:
+                                        description: "Optional additional notes to supplement the fee/charge details."
+                                        type: "string"
+                                        minLength: 1
+                                        maxLength: 2000
+                                    OtherFeeType:
+                                      $ref: "#/components/schemas/OB_OtherFeeChargeDetailType"
+                                    OtherFeeRateType:
+                                      $ref: "#/components/schemas/OB_OtherCodeType1_8"
+                                    OtherApplicationFrequency:
+                                      $ref: "#/components/schemas/OB_OtherCodeType1_6"
+                                    OtherCalculationFrequency:
+                                      $ref: "#/components/schemas/OB_OtherCodeType1_7"
+                                minItems: 1
+                              RepaymentFeeChargeCap:
+                                type: "array"
+                                items:
+                                  type: "object"
+                                  description: "RepaymentFeeChargeCap sets daily, weekly, monthly, yearly limits on the fees that are charged"
+                                  required:
+                                    - "FeeType"
+                                    - "MinMaxType"
+                                  properties:
+                                    FeeType:
+                                      type: "array"
+                                      items:
+                                        description: "Fee/charge type which is being capped"
+                                        type: "string"
+                                        enum:
+                                          - "FEPF"
+                                          - "FTOT"
+                                          - "FYAF"
+                                          - "FYAM"
+                                          - "FYAQ"
+                                          - "FYCP"
+                                          - "FYDB"
+                                          - "FYMI"
+                                          - "FYXX"
+                                      minItems: 1
+                                    MinMaxType:
+                                      $ref: "#/components/schemas/OB_MinMaxType1Code"
+                                    FeeCapOccurrence:
+                                      $ref: "#/components/schemas/Number_1"
+                                    FeeCapAmount:
+                                      $ref: "#/components/schemas/OB_Amount1_4"
+                                    CappingPeriod:
+                                      $ref: "#/components/schemas/OB_Period1Code"
+                                    Notes:
+                                      type: "array"
+                                      items:
+                                        description: "Free text for adding  extra details for fee charge cap"
+                                        type: "string"
+                                        minLength: 1
+                                        maxLength: 2000
+                                    OtherFeeType:
+                                      type: "array"
+                                      items:
+                                        type: "object"
+                                        description: "Other fee type code which is not available in the standard code set"
+                                        required:
+                                          - "Name"
+                                          - "Description"
+                                        properties:
+                                          Code:
+                                            $ref: "#/components/schemas/OB_CodeMnemonic"
+                                          Name:
+                                            $ref: "#/components/schemas/Name_4"
+                                          Description:
+                                            $ref: "#/components/schemas/Description_3"
+                          RepaymentHoliday:
+                            type: "array"
+                            items:
+                              type: "object"
+                              description: "Details of capital repayment holiday if any"
+                              properties:
+                                MaxHolidayLength:
+                                  description: "The maximum length/duration of a Repayment Holiday"
+                                  type: "integer"
+                                MaxHolidayPeriod:
+                                  description: "The unit of period (days, weeks, months etc.) of the repayment holiday"
+                                  type: "string"
+                                  enum:
+                                    - "PACT"
+                                    - "PDAY"
+                                    - "PHYR"
+                                    - "PMTH"
+                                    - "PQTR"
+                                    - "PWEK"
+                                    - "PYER"
+                                Notes:
+                                  type: "array"
+                                  items:
+                                    description: "Free text for adding details for repayment holiday"
+                                    type: "string"
+                                    minLength: 1
+                                    maxLength: 2000
+                      OtherFeesCharges:
+                        type: "array"
+                        items:
+                          type: "object"
+                          description: "Contains details of fees and charges which are not associated with either Overdraft or features/benefits"
+                          required:
+                            - "FeeChargeDetail"
+                          properties:
+                            TariffType:
+                              description: "TariffType which defines the fee and charges."
+                              type: "string"
+                              enum:
+                                - "TTEL"
+                                - "TTMX"
+                                - "TTOT"
+                            TariffName:
+                              description: "Name of the tariff"
+                              type: "string"
+                              minLength: 1
+                              maxLength: 350
+                            OtherTariffType:
+                              type: "object"
+                              required:
+                                - "Name"
+                                - "Description"
+                              description: "Other tariff type which is not in the standard list."
+                              properties:
+                                Code:
+                                  $ref: "#/components/schemas/OB_CodeMnemonic"
+                                Name:
+                                  $ref: "#/components/schemas/Name_4"
+                                Description:
+                                  $ref: "#/components/schemas/Description_3"
+                            FeeChargeDetail:
+                              type: "array"
+                              items:
+                                type: "object"
+                                description: "Other fees/charges details"
+                                required:
+                                  - "FeeCategory"
+                                  - "FeeType"
+                                  - "ApplicationFrequency"
+                                properties:
+                                  FeeCategory:
+                                    $ref: "#/components/schemas/OB_FeeCategory1Code"
+                                  FeeType:
+                                    $ref: "#/components/schemas/OB_FeeType1Code"
+                                  NegotiableIndicator:
+                                    description: "Fee/charge which is usually negotiable rather than a fixed amount"
+                                    type: "boolean"
+                                  FeeAmount:
+                                    $ref: "#/components/schemas/OB_Amount1_3"
+                                  FeeRate:
+                                    $ref: "#/components/schemas/OB_Rate1_1"
+                                  FeeRateType:
+                                    $ref: "#/components/schemas/OB_InterestRateType1Code_1"
+                                  ApplicationFrequency:
+                                    $ref: "#/components/schemas/OB_FeeFrequency1Code_2"
+                                  CalculationFrequency:
+                                    $ref: "#/components/schemas/OB_FeeFrequency1Code_3"
+                                  Notes:
+                                    type: "array"
+                                    items:
+                                      description: "Optional additional notes to supplement the fee/charge details."
+                                      type: "string"
+                                      minLength: 1
+                                      maxLength: 2000
+                                  FeeChargeCap:
+                                    type: "array"
+                                    items:
+                                      type: "object"
+                                      description: "Details about any caps (maximum charges) that apply to a particular or group of fee/charge"
+                                      required:
+                                        - "FeeType"
+                                        - "MinMaxType"
+                                      properties:
+                                        FeeType:
+                                          type: "array"
+                                          items:
+                                            description: "Fee/charge type which is being capped"
+                                            type: "string"
+                                            enum:
+                                              - "FEPF"
+                                              - "FTOT"
+                                              - "FYAF"
+                                              - "FYAM"
+                                              - "FYAQ"
+                                              - "FYCP"
+                                              - "FYDB"
+                                              - "FYMI"
+                                              - "FYXX"
+                                          minItems: 1
+                                        MinMaxType:
+                                          $ref: "#/components/schemas/OB_MinMaxType1Code"
+                                        FeeCapOccurrence:
+                                          $ref: "#/components/schemas/Number_1"
+                                        FeeCapAmount:
+                                          $ref: "#/components/schemas/OB_Amount1_4"
+                                        CappingPeriod:
+                                          $ref: "#/components/schemas/OB_Period1Code"
+                                        Notes:
+                                          type: "array"
+                                          items:
+                                            description: "Free text for adding  extra details for fee charge cap"
+                                            type: "string"
+                                            minLength: 1
+                                            maxLength: 2000
+                                        OtherFeeType:
+                                          type: "array"
+                                          items:
+                                            type: "object"
+                                            description: "Other fee type code which is not available in the standard code set"
+                                            required:
+                                              - "Name"
+                                              - "Description"
+                                            properties:
+                                              Code:
+                                                $ref: "#/components/schemas/OB_CodeMnemonic"
+                                              Name:
+                                                $ref: "#/components/schemas/Name_4"
+                                              Description:
+                                                $ref: "#/components/schemas/Description_3"
+                                  OtherFeeCategoryType:
+                                    $ref: "#/components/schemas/OB_OtherCodeType1_0"
+                                  OtherFeeType:
+                                    $ref: "#/components/schemas/OB_OtherFeeChargeDetailType"
+                                  OtherFeeRateType:
+                                    $ref: "#/components/schemas/OB_OtherCodeType1_8"
+                                  OtherApplicationFrequency:
+                                    $ref: "#/components/schemas/OB_OtherCodeType1_6"
+                                  OtherCalculationFrequency:
+                                    $ref: "#/components/schemas/OB_OtherCodeType1_7"
+                                  FeeApplicableRange:
+                                    type: "object"
+                                    description: "Range or amounts or rates for which the fee/charge applies"
+                                    properties:
+                                      MinimumAmount:
+                                        description: "Minimum Amount on which fee/charge is applicable (where it is expressed as an amount)"
+                                        type: "string"
+                                        pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                                      MaximumAmount:
+                                        description: "Maximum Amount on which fee is applicable (where it is expressed as an amount)"
+                                        type: "string"
+                                        pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+                                      MinimumRate:
+                                        description: "Minimum rate on which fee/charge is applicable(where it is expressed as an rate)"
+                                        type: "string"
+                                        pattern: "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$"
+                                      MaximumRate:
+                                        description: "Maximum rate on which fee/charge is applicable(where it is expressed as an rate)"
+                                        type: "string"
+                                        pattern: "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$"
+                              minItems: 1
+                            FeeChargeCap:
+                              type: "array"
+                              items:
+                                type: "object"
+                                description: "Details about any caps (maximum charges) that apply to a particular or group of fee/charge"
+                                required:
+                                  - "FeeType"
+                                  - "MinMaxType"
+                                properties:
+                                  FeeType:
+                                    type: "array"
+                                    items:
+                                      description: "Fee/charge type which is being capped"
+                                      type: "string"
+                                      enum:
+                                        - "FEPF"
+                                        - "FTOT"
+                                        - "FYAF"
+                                        - "FYAM"
+                                        - "FYAQ"
+                                        - "FYCP"
+                                        - "FYDB"
+                                        - "FYMI"
+                                        - "FYXX"
+                                    minItems: 1
+                                  MinMaxType:
+                                    $ref: "#/components/schemas/OB_MinMaxType1Code"
+                                  FeeCapOccurrence:
+                                    $ref: "#/components/schemas/Number_1"
+                                  FeeCapAmount:
+                                    $ref: "#/components/schemas/OB_Amount1_4"
+                                  CappingPeriod:
+                                    $ref: "#/components/schemas/OB_Period1Code"
+                                  Notes:
+                                    type: "array"
+                                    items:
+                                      description: "Free text for adding  extra details for fee charge cap"
+                                      type: "string"
+                                      minLength: 1
+                                      maxLength: 2000
+                                  OtherFeeType:
+                                    type: "array"
+                                    items:
+                                      type: "object"
+                                      description: "Other fee type code which is not available in the standard code set"
+                                      required:
+                                        - "Name"
+                                        - "Description"
+                                      properties:
+                                        Code:
+                                          $ref: "#/components/schemas/OB_CodeMnemonic"
+                                        Name:
+                                          $ref: "#/components/schemas/Name_4"
+                                        Description:
+                                          $ref: "#/components/schemas/Description_3"
+                      SupplementaryData:
+                        $ref: "#/components/schemas/OBSupplementaryData1"
+                  BCA:
+                    $ref: "#/components/schemas/OBBCAData1"
+                  PCA:
+                    $ref: "#/components/schemas/OBPCAData1"
+        Links:
+          $ref: "#/components/schemas/Links"
+        Meta:
+          $ref: "#/components/schemas/Meta"
+      additionalProperties: false
+    OBReadScheduledPayment3:
+      type: "object"
+      required:
+        - "Data"
+      properties:
+        Data:
+          type: "object"
+          properties:
+            ScheduledPayment:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/OBScheduledPayment3"
+        Links:
+          $ref: "#/components/schemas/Links"
+        Meta:
+          $ref: "#/components/schemas/Meta"
+      additionalProperties: false
+    OBReadStandingOrder6:
+      type: "object"
+      required:
+        - "Data"
+      properties:
+        Data:
+          type: "object"
+          properties:
+            StandingOrder:
+              type: "array"
+              items:
+                $ref: "#/components/schemas/OBStandingOrder6"
+        Links:
+          $ref: "#/components/schemas/Links"
+        Meta:
+          $ref: "#/components/schemas/Meta"
+      additionalProperties: false
+    OBReadStatement2:
+      type: "object"
+      required:
+        - "Data"
+      properties:
+        Data:
+          $ref: "#/components/schemas/OBReadDataStatement2"
+        Links:
+          $ref: "#/components/schemas/Links"
+        Meta:
+          $ref: "#/components/schemas/Meta"
+      additionalProperties: false
+    OBReadTransaction6:
+      type: "object"
+      required:
+        - "Data"
+      properties:
+        Data:
+          $ref: "#/components/schemas/OBReadDataTransaction6"
+        Links:
+          $ref: "#/components/schemas/Links"
+        Meta:
+          $ref: "#/components/schemas/Meta"
+      additionalProperties: false
+    OBRisk2:
+      description: "The Risk section is sent by the initiating party to the ASPSP. It is used to specify additional details for risk scoring for Account Info."
+      type: "object"
+      properties: { }
+      additionalProperties: false
+    OBScheduledPayment3:
+      type: "object"
+      required:
+        - "AccountId"
+        - "ScheduledPaymentDateTime"
+        - "ScheduledType"
+        - "InstructedAmount"
+      properties:
+        AccountId:
+          $ref: "#/components/schemas/AccountId"
+        ScheduledPaymentId:
+          $ref: "#/components/schemas/ScheduledPaymentId"
+        ScheduledPaymentDateTime:
+          $ref: "#/components/schemas/ScheduledPaymentDateTime"
+        ScheduledType:
+          $ref: "#/components/schemas/OBExternalScheduleType1Code"
+        Reference:
+          $ref: "#/components/schemas/Reference"
+        DebtorReference:
+          $ref: "#/components/schemas/DebtorReference"
+        InstructedAmount:
+          $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount_1"
+        CreditorAgent:
+          $ref: "#/components/schemas/OBBranchAndFinancialInstitutionIdentification5_1"
+        CreditorAccount:
+          $ref: "#/components/schemas/OBCashAccount5_1"
+      additionalProperties: false
+    OBScheduledPayment3Basic:
+      type: "object"
+      required:
+        - "AccountId"
+        - "ScheduledPaymentDateTime"
+        - "ScheduledType"
+        - "InstructedAmount"
+      properties:
+        AccountId:
+          $ref: "#/components/schemas/AccountId"
+        ScheduledPaymentId:
+          $ref: "#/components/schemas/ScheduledPaymentId"
+        ScheduledPaymentDateTime:
+          $ref: "#/components/schemas/ScheduledPaymentDateTime"
+        ScheduledType:
+          $ref: "#/components/schemas/OBExternalScheduleType1Code"
+        Reference:
+          $ref: "#/components/schemas/Reference"
+        DebtorReference:
+          $ref: "#/components/schemas/DebtorReference"
+        InstructedAmount:
+          $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount_1"
+      additionalProperties: false
+    OBScheduledPayment3Detail:
+      type: "object"
+      required:
+        - "AccountId"
+        - "ScheduledPaymentDateTime"
+        - "ScheduledType"
+        - "InstructedAmount"
+        - "CreditorAccount"
+      properties:
+        AccountId:
+          $ref: "#/components/schemas/AccountId"
+        ScheduledPaymentId:
+          $ref: "#/components/schemas/ScheduledPaymentId"
+        ScheduledPaymentDateTime:
+          $ref: "#/components/schemas/ScheduledPaymentDateTime"
+        ScheduledType:
+          $ref: "#/components/schemas/OBExternalScheduleType1Code"
+        Reference:
+          $ref: "#/components/schemas/Reference"
+        DebtorReference:
+          $ref: "#/components/schemas/DebtorReference"
+        InstructedAmount:
+          $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount_1"
+        CreditorAgent:
+          $ref: "#/components/schemas/OBBranchAndFinancialInstitutionIdentification5_1"
+        CreditorAccount:
+          $ref: "#/components/schemas/OBCashAccount5_1"
+      additionalProperties: false
+    OBStandingOrder6:
+      type: "object"
+      required:
+        - "AccountId"
+        - "Frequency"
+      properties:
+        AccountId:
+          $ref: "#/components/schemas/AccountId"
+        StandingOrderId:
+          $ref: "#/components/schemas/StandingOrderId"
+        Frequency:
+          $ref: "#/components/schemas/Frequency_1"
+        Reference:
+          $ref: "#/components/schemas/Reference"
+        FirstPaymentDateTime:
+          $ref: "#/components/schemas/FirstPaymentDateTime"
+        NextPaymentDateTime:
+          $ref: "#/components/schemas/NextPaymentDateTime"
+        LastPaymentDateTime:
+          $ref: "#/components/schemas/LastPaymentDateTime"
+        FinalPaymentDateTime:
+          $ref: "#/components/schemas/FinalPaymentDateTime"
+        NumberOfPayments:
+          $ref: "#/components/schemas/NumberOfPayments"
+        StandingOrderStatusCode:
+          $ref: "#/components/schemas/OBExternalStandingOrderStatus1Code"
+        FirstPaymentAmount:
+          $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount_2"
+        NextPaymentAmount:
+          $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount_3"
+        LastPaymentAmount:
+          $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount_11"
+        FinalPaymentAmount:
+          $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount_4"
+        CreditorAgent:
+          $ref: "#/components/schemas/OBBranchAndFinancialInstitutionIdentification5_1"
+        CreditorAccount:
+          $ref: "#/components/schemas/OBCashAccount5_1"
+        SupplementaryData:
+          $ref: "#/components/schemas/OBSupplementaryData1"
+      additionalProperties: false
+    OBStandingOrder6Basic:
+      type: "object"
+      required:
+        - "AccountId"
+        - "Frequency"
+      properties:
+        AccountId:
+          $ref: "#/components/schemas/AccountId"
+        StandingOrderId:
+          $ref: "#/components/schemas/StandingOrderId"
+        Frequency:
+          $ref: "#/components/schemas/Frequency_1"
+        Reference:
+          $ref: "#/components/schemas/Reference"
+        FirstPaymentDateTime:
+          $ref: "#/components/schemas/FirstPaymentDateTime"
+        NextPaymentDateTime:
+          $ref: "#/components/schemas/NextPaymentDateTime"
+        LastPaymentDateTime:
+          $ref: "#/components/schemas/LastPaymentDateTime"
+        FinalPaymentDateTime:
+          $ref: "#/components/schemas/FinalPaymentDateTime"
+        NumberOfPayments:
+          $ref: "#/components/schemas/NumberOfPayments"
+        StandingOrderStatusCode:
+          $ref: "#/components/schemas/OBExternalStandingOrderStatus1Code"
+        FirstPaymentAmount:
+          $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount_2"
+        NextPaymentAmount:
+          $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount_3"
+        LastPaymentAmount:
+          $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount_11"
+        FinalPaymentAmount:
+          $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount_4"
+        SupplementaryData:
+          $ref: "#/components/schemas/OBSupplementaryData1"
+      additionalProperties: false
+    OBStandingOrder6Detail:
+      type: "object"
+      required:
+        - "AccountId"
+        - "Frequency"
+        - "CreditorAccount"
+      properties:
+        AccountId:
+          $ref: "#/components/schemas/AccountId"
+        StandingOrderId:
+          $ref: "#/components/schemas/StandingOrderId"
+        Frequency:
+          $ref: "#/components/schemas/Frequency_1"
+        Reference:
+          $ref: "#/components/schemas/Reference"
+        FirstPaymentDateTime:
+          $ref: "#/components/schemas/FirstPaymentDateTime"
+        NextPaymentDateTime:
+          $ref: "#/components/schemas/NextPaymentDateTime"
+        LastPaymentDateTime:
+          $ref: "#/components/schemas/LastPaymentDateTime"
+        FinalPaymentDateTime:
+          $ref: "#/components/schemas/FinalPaymentDateTime"
+        NumberOfPayments:
+          $ref: "#/components/schemas/NumberOfPayments"
+        StandingOrderStatusCode:
+          $ref: "#/components/schemas/OBExternalStandingOrderStatus1Code"
+        FirstPaymentAmount:
+          $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount_2"
+        NextPaymentAmount:
+          $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount_3"
+        LastPaymentAmount:
+          $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount_11"
+        FinalPaymentAmount:
+          $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount_4"
+        CreditorAgent:
+          $ref: "#/components/schemas/OBBranchAndFinancialInstitutionIdentification5_1"
+        CreditorAccount:
+          $ref: "#/components/schemas/OBCashAccount5_1"
+        SupplementaryData:
+          $ref: "#/components/schemas/OBSupplementaryData1"
+      additionalProperties: false
+    OBStatement2:
+      type: "object"
+      description: "Provides further details on a statement resource."
+      required:
+        - "AccountId"
+        - "Type"
+        - "StartDateTime"
+        - "EndDateTime"
+        - "CreationDateTime"
+      properties:
+        AccountId:
+          $ref: "#/components/schemas/AccountId"
+        StatementId:
+          $ref: "#/components/schemas/StatementId"
+        StatementReference:
+          $ref: "#/components/schemas/StatementReference"
+        Type:
+          $ref: "#/components/schemas/OBExternalStatementType1Code"
+        StartDateTime:
+          $ref: "#/components/schemas/StartDateTime"
+        EndDateTime:
+          $ref: "#/components/schemas/EndDateTime"
+        CreationDateTime:
+          $ref: "#/components/schemas/CreationDateTime"
+        StatementDescription:
+          type: "array"
+          items:
+            description: "Other descriptions that may be available for the statement resource."
+            type: "string"
+            minLength: 1
+            maxLength: 500
+        StatementBenefit:
+          type: "array"
+          items:
+            type: "object"
+            description: "Set of elements used to provide details of a benefit or reward amount for the statement resource."
+            required:
+              - "Type"
+              - "Amount"
+            properties:
+              Type:
+                $ref: "#/components/schemas/OBExternalStatementBenefitType1Code"
+              Amount:
+                $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount_5"
+        StatementFee:
+          type: "array"
+          items:
+            type: "object"
+            description: "Set of elements used to provide details of a fee for the statement resource."
+            required:
+              - "CreditDebitIndicator"
+              - "Type"
+              - "Amount"
+            properties:
+              Description:
+                $ref: "#/components/schemas/Description_1"
+              CreditDebitIndicator:
+                $ref: "#/components/schemas/OBCreditDebitCode_0"
+              Type:
+                $ref: "#/components/schemas/OBExternalStatementFeeType1Code"
+              Rate:
+                $ref: "#/components/schemas/OBRate1_0"
+              RateType:
+                $ref: "#/components/schemas/OBExternalStatementFeeRateType1Code"
+              Frequency:
+                $ref: "#/components/schemas/OBExternalStatementFeeFrequency1Code"
+              Amount:
+                $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount_6"
+        StatementInterest:
+          type: "array"
+          items:
+            type: "object"
+            description: "Set of elements used to provide details of a generic interest amount related to the statement resource."
+            required:
+              - "CreditDebitIndicator"
+              - "Type"
+              - "Amount"
+            properties:
+              Description:
+                $ref: "#/components/schemas/Description_2"
+              CreditDebitIndicator:
+                $ref: "#/components/schemas/OBCreditDebitCode_0"
+              Type:
+                $ref: "#/components/schemas/OBExternalStatementInterestType1Code"
+              Rate:
+                $ref: "#/components/schemas/OBRate1_1"
+              RateType:
+                $ref: "#/components/schemas/OBExternalStatementInterestRateType1Code"
+              Frequency:
+                $ref: "#/components/schemas/OBExternalStatementInterestFrequency1Code"
+              Amount:
+                $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount_7"
+        StatementAmount:
+          type: "array"
+          items:
+            type: "object"
+            description: "Set of elements used to provide details of a generic amount for the statement resource."
+            required:
+              - "CreditDebitIndicator"
+              - "Type"
+              - "Amount"
+            properties:
+              CreditDebitIndicator:
+                $ref: "#/components/schemas/OBCreditDebitCode_0"
+              Type:
+                $ref: "#/components/schemas/OBExternalStatementAmountType1Code"
+              Amount:
+                $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount_8"
+        StatementDateTime:
+          type: "array"
+          items:
+            type: "object"
+            description: "Set of elements used to provide details of a generic date time for the statement resource."
+            required:
+              - "DateTime"
+              - "Type"
+            properties:
+              DateTime:
+                $ref: "#/components/schemas/DateTime"
+              Type:
+                $ref: "#/components/schemas/OBExternalStatementDateTimeType1Code"
+        StatementRate:
+          type: "array"
+          items:
+            type: "object"
+            description: "Set of elements used to provide details of a generic rate related to the statement resource."
+            required:
+              - "Rate"
+              - "Type"
+            properties:
+              Rate:
+                $ref: "#/components/schemas/Rate"
+              Type:
+                $ref: "#/components/schemas/OBExternalStatementRateType1Code"
+        StatementValue:
+          type: "array"
+          items:
+            type: "object"
+            description: "Set of elements used to provide details of a generic number value related to the statement resource."
+            required:
+              - "Value"
+              - "Type"
+            properties:
+              Value:
+                $ref: "#/components/schemas/Value"
+              Type:
+                $ref: "#/components/schemas/OBExternalStatementValueType1Code"
+      additionalProperties: false
+    OBStatement2Basic:
+      type: "object"
+      description: "Provides further details on a statement resource."
+      required:
+        - "AccountId"
+        - "Type"
+        - "StartDateTime"
+        - "EndDateTime"
+        - "CreationDateTime"
+      properties:
+        AccountId:
+          $ref: "#/components/schemas/AccountId"
+        StatementId:
+          $ref: "#/components/schemas/StatementId"
+        StatementReference:
+          $ref: "#/components/schemas/StatementReference"
+        Type:
+          $ref: "#/components/schemas/OBExternalStatementType1Code"
+        StartDateTime:
+          $ref: "#/components/schemas/StartDateTime"
+        EndDateTime:
+          $ref: "#/components/schemas/EndDateTime"
+        CreationDateTime:
+          $ref: "#/components/schemas/CreationDateTime"
+        StatementDescription:
+          type: "array"
+          items:
+            description: "Other descriptions that may be available for the statement resource."
+            type: "string"
+            minLength: 1
+            maxLength: 500
+        StatementBenefit:
+          type: "array"
+          items:
+            type: "object"
+            description: "Set of elements used to provide details of a benefit or reward amount for the statement resource."
+            required:
+              - "Type"
+              - "Amount"
+            properties:
+              Type:
+                $ref: "#/components/schemas/OBExternalStatementBenefitType1Code"
+              Amount:
+                $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount_5"
+        StatementFee:
+          type: "array"
+          items:
+            type: "object"
+            description: "Set of elements used to provide details of a fee for the statement resource."
+            required:
+              - "CreditDebitIndicator"
+              - "Type"
+              - "Amount"
+            properties:
+              Description:
+                $ref: "#/components/schemas/Description_1"
+              CreditDebitIndicator:
+                $ref: "#/components/schemas/OBCreditDebitCode_0"
+              Type:
+                $ref: "#/components/schemas/OBExternalStatementFeeType1Code"
+              Rate:
+                $ref: "#/components/schemas/OBRate1_0"
+              RateType:
+                $ref: "#/components/schemas/OBExternalStatementFeeRateType1Code"
+              Frequency:
+                $ref: "#/components/schemas/OBExternalStatementFeeFrequency1Code"
+              Amount:
+                $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount_6"
+        StatementInterest:
+          type: "array"
+          items:
+            type: "object"
+            description: "Set of elements used to provide details of a generic interest amount related to the statement resource."
+            required:
+              - "CreditDebitIndicator"
+              - "Type"
+              - "Amount"
+            properties:
+              Description:
+                $ref: "#/components/schemas/Description_2"
+              CreditDebitIndicator:
+                $ref: "#/components/schemas/OBCreditDebitCode_0"
+              Type:
+                $ref: "#/components/schemas/OBExternalStatementInterestType1Code"
+              Rate:
+                $ref: "#/components/schemas/OBRate1_1"
+              RateType:
+                $ref: "#/components/schemas/OBExternalStatementInterestRateType1Code"
+              Frequency:
+                $ref: "#/components/schemas/OBExternalStatementInterestFrequency1Code"
+              Amount:
+                $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount_7"
+        StatementDateTime:
+          type: "array"
+          items:
+            type: "object"
+            description: "Set of elements used to provide details of a generic date time for the statement resource."
+            required:
+              - "DateTime"
+              - "Type"
+            properties:
+              DateTime:
+                $ref: "#/components/schemas/DateTime"
+              Type:
+                $ref: "#/components/schemas/OBExternalStatementDateTimeType1Code"
+        StatementRate:
+          type: "array"
+          items:
+            type: "object"
+            description: "Set of elements used to provide details of a generic rate related to the statement resource."
+            required:
+              - "Rate"
+              - "Type"
+            properties:
+              Rate:
+                $ref: "#/components/schemas/Rate"
+              Type:
+                $ref: "#/components/schemas/OBExternalStatementRateType1Code"
+        StatementValue:
+          type: "array"
+          items:
+            type: "object"
+            description: "Set of elements used to provide details of a generic number value related to the statement resource."
+            required:
+              - "Value"
+              - "Type"
+            properties:
+              Value:
+                $ref: "#/components/schemas/Value"
+              Type:
+                $ref: "#/components/schemas/OBExternalStatementValueType1Code"
+      additionalProperties: false
+    OBStatement2Detail:
+      type: "object"
+      description: "Provides further details on a statement resource."
+      required:
+        - "AccountId"
+        - "Type"
+        - "StartDateTime"
+        - "EndDateTime"
+        - "CreationDateTime"
+      properties:
+        AccountId:
+          $ref: "#/components/schemas/AccountId"
+        StatementId:
+          $ref: "#/components/schemas/StatementId"
+        StatementReference:
+          $ref: "#/components/schemas/StatementReference"
+        Type:
+          $ref: "#/components/schemas/OBExternalStatementType1Code"
+        StartDateTime:
+          $ref: "#/components/schemas/StartDateTime"
+        EndDateTime:
+          $ref: "#/components/schemas/EndDateTime"
+        CreationDateTime:
+          $ref: "#/components/schemas/CreationDateTime"
+        StatementDescription:
+          type: "array"
+          items:
+            description: "Other descriptions that may be available for the statement resource."
+            type: "string"
+            minLength: 1
+            maxLength: 500
+        StatementBenefit:
+          type: "array"
+          items:
+            type: "object"
+            description: "Set of elements used to provide details of a benefit or reward amount for the statement resource."
+            required:
+              - "Type"
+              - "Amount"
+            properties:
+              Type:
+                $ref: "#/components/schemas/OBExternalStatementBenefitType1Code"
+              Amount:
+                $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount_5"
+        StatementFee:
+          type: "array"
+          items:
+            type: "object"
+            description: "Set of elements used to provide details of a fee for the statement resource."
+            required:
+              - "CreditDebitIndicator"
+              - "Type"
+              - "Amount"
+            properties:
+              Description:
+                $ref: "#/components/schemas/Description_1"
+              CreditDebitIndicator:
+                $ref: "#/components/schemas/OBCreditDebitCode_0"
+              Type:
+                $ref: "#/components/schemas/OBExternalStatementFeeType1Code"
+              Rate:
+                $ref: "#/components/schemas/OBRate1_0"
+              RateType:
+                $ref: "#/components/schemas/OBExternalStatementFeeRateType1Code"
+              Frequency:
+                $ref: "#/components/schemas/OBExternalStatementFeeFrequency1Code"
+              Amount:
+                $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount_6"
+        StatementInterest:
+          type: "array"
+          items:
+            type: "object"
+            description: "Set of elements used to provide details of a generic interest amount related to the statement resource."
+            required:
+              - "CreditDebitIndicator"
+              - "Type"
+              - "Amount"
+            properties:
+              Description:
+                $ref: "#/components/schemas/Description_2"
+              CreditDebitIndicator:
+                $ref: "#/components/schemas/OBCreditDebitCode_0"
+              Type:
+                $ref: "#/components/schemas/OBExternalStatementInterestType1Code"
+              Rate:
+                $ref: "#/components/schemas/OBRate1_1"
+              RateType:
+                $ref: "#/components/schemas/OBExternalStatementInterestRateType1Code"
+              Frequency:
+                $ref: "#/components/schemas/OBExternalStatementInterestFrequency1Code"
+              Amount:
+                $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount_7"
+        StatementAmount:
+          type: "array"
+          items:
+            type: "object"
+            description: "Set of elements used to provide details of a generic amount for the statement resource."
+            required:
+              - "CreditDebitIndicator"
+              - "Type"
+              - "Amount"
+            properties:
+              CreditDebitIndicator:
+                $ref: "#/components/schemas/OBCreditDebitCode_0"
+              Type:
+                $ref: "#/components/schemas/OBExternalStatementAmountType1Code"
+              Amount:
+                $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount_8"
+        StatementDateTime:
+          type: "array"
+          items:
+            type: "object"
+            description: "Set of elements used to provide details of a generic date time for the statement resource."
+            required:
+              - "DateTime"
+              - "Type"
+            properties:
+              DateTime:
+                $ref: "#/components/schemas/DateTime"
+              Type:
+                $ref: "#/components/schemas/OBExternalStatementDateTimeType1Code"
+        StatementRate:
+          type: "array"
+          items:
+            type: "object"
+            description: "Set of elements used to provide details of a generic rate related to the statement resource."
+            required:
+              - "Rate"
+              - "Type"
+            properties:
+              Rate:
+                $ref: "#/components/schemas/Rate"
+              Type:
+                $ref: "#/components/schemas/OBExternalStatementRateType1Code"
+        StatementValue:
+          type: "array"
+          items:
+            type: "object"
+            description: "Set of elements used to provide details of a generic number value related to the statement resource."
+            required:
+              - "Value"
+              - "Type"
+            properties:
+              Value:
+                $ref: "#/components/schemas/Value"
+              Type:
+                $ref: "#/components/schemas/OBExternalStatementValueType1Code"
+      additionalProperties: false
+    OBSupplementaryData1:
+      type: "object"
+      properties: { }
+      additionalProperties: true
+      description: "Additional information that can not be captured in the structured fields and/or any other specific block."
+    OBTransaction6:
+      type: "object"
+      description: "Provides further details on an entry in the report."
+      required:
+        - "AccountId"
+        - "CreditDebitIndicator"
+        - "Status"
+        - "BookingDateTime"
+        - "Amount"
+      properties:
+        AccountId:
+          $ref: "#/components/schemas/AccountId"
+        TransactionId:
+          $ref: "#/components/schemas/TransactionId"
+        TransactionReference:
+          $ref: "#/components/schemas/TransactionReference"
+        StatementReference:
+          type: "array"
+          items:
+            $ref: "#/components/schemas/StatementReference"
+        CreditDebitIndicator:
+          $ref: "#/components/schemas/OBCreditDebitCode_1"
+        Status:
+          $ref: "#/components/schemas/OBEntryStatus1Code"
+        TransactionMutability:
+          $ref: "#/components/schemas/OBTransactionMutability1Code"
+        BookingDateTime:
+          $ref: "#/components/schemas/BookingDateTime"
+        ValueDateTime:
+          $ref: "#/components/schemas/ValueDateTime"
+        TransactionInformation:
+          $ref: "#/components/schemas/TransactionInformation"
+        AddressLine:
+          $ref: "#/components/schemas/AddressLine"
+        Amount:
+          $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount_9"
+        ChargeAmount:
+          $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount_10"
+        CurrencyExchange:
+          $ref: "#/components/schemas/OBCurrencyExchange5"
+        BankTransactionCode:
+          $ref: "#/components/schemas/OBBankTransactionCodeStructure1"
+        ProprietaryBankTransactionCode:
+          $ref: "#/components/schemas/ProprietaryBankTransactionCodeStructure1"
+        Balance:
+          $ref: "#/components/schemas/OBTransactionCashBalance"
+        MerchantDetails:
+          $ref: "#/components/schemas/OBMerchantDetails1"
+        CreditorAgent:
+          $ref: "#/components/schemas/OBBranchAndFinancialInstitutionIdentification6_1"
+        CreditorAccount:
+          $ref: "#/components/schemas/OBCashAccount6_0"
+        DebtorAgent:
+          $ref: "#/components/schemas/OBBranchAndFinancialInstitutionIdentification6_2"
+        DebtorAccount:
+          $ref: "#/components/schemas/OBCashAccount6_1"
+        CardInstrument:
+          $ref: "#/components/schemas/OBTransactionCardInstrument1"
+        SupplementaryData:
+          $ref: "#/components/schemas/OBSupplementaryData1"
+      additionalProperties: false
+    OBTransaction6Basic:
+      type: "object"
+      description: "Provides further details on an entry in the report."
+      required:
+        - "AccountId"
+        - "CreditDebitIndicator"
+        - "Status"
+        - "BookingDateTime"
+        - "Amount"
+      properties:
+        AccountId:
+          $ref: "#/components/schemas/AccountId"
+        TransactionId:
+          $ref: "#/components/schemas/TransactionId"
+        TransactionReference:
+          $ref: "#/components/schemas/TransactionReference"
+        StatementReference:
+          type: "array"
+          items:
+            $ref: "#/components/schemas/StatementReference"
+        CreditDebitIndicator:
+          $ref: "#/components/schemas/OBCreditDebitCode_1"
+        Status:
+          $ref: "#/components/schemas/OBEntryStatus1Code"
+        TransactionMutability:
+          $ref: "#/components/schemas/OBTransactionMutability1Code"
+        BookingDateTime:
+          $ref: "#/components/schemas/BookingDateTime"
+        ValueDateTime:
+          $ref: "#/components/schemas/ValueDateTime"
+        AddressLine:
+          $ref: "#/components/schemas/AddressLine"
+        Amount:
+          $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount_9"
+        ChargeAmount:
+          $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount_10"
+        CurrencyExchange:
+          $ref: "#/components/schemas/OBCurrencyExchange5"
+        BankTransactionCode:
+          $ref: "#/components/schemas/OBBankTransactionCodeStructure1"
+        ProprietaryBankTransactionCode:
+          $ref: "#/components/schemas/ProprietaryBankTransactionCodeStructure1"
+        CardInstrument:
+          $ref: "#/components/schemas/OBTransactionCardInstrument1"
+        SupplementaryData:
+          $ref: "#/components/schemas/OBSupplementaryData1"
+      additionalProperties: false
+    OBTransaction6Detail:
+      type: "object"
+      description: "Provides further details on an entry in the report."
+      required:
+        - "AccountId"
+        - "CreditDebitIndicator"
+        - "Status"
+        - "BookingDateTime"
+        - "Amount"
+      properties:
+        AccountId:
+          $ref: "#/components/schemas/AccountId"
+        TransactionId:
+          $ref: "#/components/schemas/TransactionId"
+        TransactionReference:
+          $ref: "#/components/schemas/TransactionReference"
+        StatementReference:
+          type: "array"
+          items:
+            $ref: "#/components/schemas/StatementReference"
+        CreditDebitIndicator:
+          $ref: "#/components/schemas/OBCreditDebitCode_1"
+        Status:
+          $ref: "#/components/schemas/OBEntryStatus1Code"
+        TransactionMutability:
+          $ref: "#/components/schemas/OBTransactionMutability1Code"
+        BookingDateTime:
+          $ref: "#/components/schemas/BookingDateTime"
+        ValueDateTime:
+          $ref: "#/components/schemas/ValueDateTime"
+        TransactionInformation:
+          $ref: "#/components/schemas/TransactionInformation"
+        AddressLine:
+          $ref: "#/components/schemas/AddressLine"
+        Amount:
+          $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount_9"
+        ChargeAmount:
+          $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount_10"
+        CurrencyExchange:
+          $ref: "#/components/schemas/OBCurrencyExchange5"
+        BankTransactionCode:
+          $ref: "#/components/schemas/OBBankTransactionCodeStructure1"
+        ProprietaryBankTransactionCode:
+          $ref: "#/components/schemas/ProprietaryBankTransactionCodeStructure1"
+        Balance:
+          $ref: "#/components/schemas/OBTransactionCashBalance"
+        MerchantDetails:
+          $ref: "#/components/schemas/OBMerchantDetails1"
+        CreditorAgent:
+          $ref: "#/components/schemas/OBBranchAndFinancialInstitutionIdentification6_1"
+        CreditorAccount:
+          $ref: "#/components/schemas/OBCashAccount6_0"
+        DebtorAgent:
+          $ref: "#/components/schemas/OBBranchAndFinancialInstitutionIdentification6_2"
+        DebtorAccount:
+          $ref: "#/components/schemas/OBCashAccount6_1"
+        CardInstrument:
+          $ref: "#/components/schemas/OBTransactionCardInstrument1"
+        SupplementaryData:
+          $ref: "#/components/schemas/OBSupplementaryData1"
+      additionalProperties: false
+    OBTransactionCardInstrument1:
+      type: "object"
+      required:
+        - "CardSchemeName"
+      description: "Set of elements to describe the card instrument used in the transaction."
+      properties:
+        CardSchemeName:
+          description: "Name of the card scheme."
+          type: "string"
+          enum:
+            - "AmericanExpress"
+            - "Diners"
+            - "Discover"
+            - "MasterCard"
+            - "VISA"
+        AuthorisationType:
+          description: "The card authorisation type."
+          type: "string"
+          enum:
+            - "ConsumerDevice"
+            - "Contactless"
+            - "None"
+            - "PIN"
+        Name:
+          description: "Name of the cardholder using the card instrument."
+          type: "string"
+          minLength: 1
+          maxLength: 70
+        Identification:
+          description: "Identification assigned by an institution to identify the card instrument used in the transaction. This identification is known by the account owner, and may be masked."
+          type: "string"
+          minLength: 1
+          maxLength: 34
+      additionalProperties: false
+    OBTransactionCashBalance:
+      type: "object"
+      required:
+        - "CreditDebitIndicator"
+        - "Type"
+        - "Amount"
+      description: "Set of elements used to define the balance as a numerical representation of the net increases and decreases in an account after a transaction entry is applied to the account."
+      properties:
+        CreditDebitIndicator:
+          $ref: "#/components/schemas/OBCreditDebitCode_2"
+        Type:
+          $ref: "#/components/schemas/OBBalanceType1Code"
+        Amount:
+          type: "object"
+          required:
+            - "Amount"
+            - "Currency"
+          description: "Amount of money of the cash balance after a transaction entry is applied to the account.."
+          properties:
+            Amount:
+              $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+            Currency:
+              $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode_1"
+      additionalProperties: false
+    OB_Amount1_0:
+      description: "Cap amount charged for a fee/charge"
+      type: "string"
+      pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+    OB_Amount1_1:
+      description: "Every additional tranche of an overdraft balance to which an overdraft fee is applied"
+      type: "string"
+      pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+    OB_Amount1_2:
+      description: "Amount charged for an overdraft fee/charge (where it is charged in terms of an amount rather than a rate)"
+      type: "string"
+      pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+    OB_Amount1_3:
+      description: "Fee Amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)"
+      type: "string"
+      pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+    OB_Amount1_4:
+      description: "Cap amount charged for a fee/charge (where it is charged in terms of an amount rather than a rate)"
+      type: "string"
+      pattern: "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
+    OB_CodeMnemonic:
+      description: "The four letter Mnemonic used within an XML file to identify a code"
+      type: "string"
+      pattern: "^\\\\w{0,4}$"
+    OB_FeeCategory1Code:
+      description: "Categorisation of fees and charges into standard categories."
+      type: "string"
+      enum:
+        - "FCOT"
+        - "FCRE"
+        - "FCSV"
+    OB_FeeFrequency1Code_0:
+      description: "Frequency at which the overdraft charge is applied to the account"
+      type: "string"
+      enum:
+        - "FEAC"
+        - "FEAO"
+        - "FECP"
+        - "FEDA"
+        - "FEHO"
+        - "FEI"
+        - "FEMO"
+        - "FEOA"
+        - "FEOT"
+        - "FEPC"
+        - "FEPH"
+        - "FEPO"
+        - "FEPS"
+        - "FEPT"
+        - "FEPTA"
+        - "FEPTP"
+        - "FEQU"
+        - "FESM"
+        - "FEST"
+        - "FEWE"
+        - "FEYE"
+    OB_FeeFrequency1Code_1:
+      description: "How often is the overdraft fee/charge calculated for the account."
+      type: "string"
+      enum:
+        - "FEAC"
+        - "FEAO"
+        - "FECP"
+        - "FEDA"
+        - "FEHO"
+        - "FEI"
+        - "FEMO"
+        - "FEOA"
+        - "FEOT"
+        - "FEPC"
+        - "FEPH"
+        - "FEPO"
+        - "FEPS"
+        - "FEPT"
+        - "FEPTA"
+        - "FEPTP"
+        - "FEQU"
+        - "FESM"
+        - "FEST"
+        - "FEWE"
+        - "FEYE"
+    OB_FeeFrequency1Code_2:
+      description: "How frequently the fee/charge is applied to the account"
+      type: "string"
+      enum:
+        - "FEAC"
+        - "FEAO"
+        - "FECP"
+        - "FEDA"
+        - "FEHO"
+        - "FEI"
+        - "FEMO"
+        - "FEOA"
+        - "FEOT"
+        - "FEPC"
+        - "FEPH"
+        - "FEPO"
+        - "FEPS"
+        - "FEPT"
+        - "FEPTA"
+        - "FEPTP"
+        - "FEQU"
+        - "FESM"
+        - "FEST"
+        - "FEWE"
+        - "FEYE"
+    OB_FeeFrequency1Code_3:
+      description: "How frequently the fee/charge is calculated"
+      type: "string"
+      enum:
+        - "FEAC"
+        - "FEAO"
+        - "FECP"
+        - "FEDA"
+        - "FEHO"
+        - "FEI"
+        - "FEMO"
+        - "FEOA"
+        - "FEOT"
+        - "FEPC"
+        - "FEPH"
+        - "FEPO"
+        - "FEPS"
+        - "FEPT"
+        - "FEPTA"
+        - "FEPTP"
+        - "FEQU"
+        - "FESM"
+        - "FEST"
+        - "FEWE"
+        - "FEYE"
+    OB_FeeFrequency1Code_4:
+      description: "Period e.g. day, week, month etc. for which the fee/charge is capped"
+      type: "string"
+      enum:
+        - "FEAC"
+        - "FEAO"
+        - "FECP"
+        - "FEDA"
+        - "FEHO"
+        - "FEI"
+        - "FEMO"
+        - "FEOA"
+        - "FEOT"
+        - "FEPC"
+        - "FEPH"
+        - "FEPO"
+        - "FEPS"
+        - "FEPT"
+        - "FEPTA"
+        - "FEPTP"
+        - "FEQU"
+        - "FESM"
+        - "FEST"
+        - "FEWE"
+        - "FEYE"
+    OB_FeeType1Code:
+      description: "Fee/Charge Type"
+      type: "string"
+      enum:
+        - "FEPF"
+        - "FTOT"
+        - "FYAF"
+        - "FYAM"
+        - "FYAQ"
+        - "FYCP"
+        - "FYDB"
+        - "FYMI"
+        - "FYXX"
+    OB_InterestCalculationMethod1Code:
+      description: "Methods of calculating interest"
+      type: "string"
+      enum:
+        - "ITCO"
+        - "ITOT"
+        - "ITSI"
+    OB_InterestFixedVariableType1Code:
+      description: "Type of interest rate, Fixed or Variable"
+      type: "string"
+      enum:
+        - "INFI"
+        - "INVA"
+    OB_InterestRateType1Code_0:
+      description: "Rate type for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)"
+      type: "string"
+      enum:
+        - "INBB"
+        - "INFR"
+        - "INGR"
+        - "INLR"
+        - "INNE"
+        - "INOT"
+    OB_InterestRateType1Code_1:
+      description: "Rate type for Fee/Charge (where it is charged in terms of a rate rather than an amount)"
+      type: "string"
+      enum:
+        - "INBB"
+        - "INFR"
+        - "INGR"
+        - "INLR"
+        - "INNE"
+        - "INOT"
+    OB_MinMaxType1Code:
+      description: "Min Max type"
+      type: "string"
+      enum:
+        - "FMMN"
+        - "FMMX"
+    OB_OtherCodeType1_0:
+      type: "object"
+      required:
+        - "Name"
+        - "Description"
+      properties:
+        Code:
+          $ref: "#/components/schemas/OB_CodeMnemonic"
+        Name:
+          $ref: "#/components/schemas/Name_4"
+        Description:
+          $ref: "#/components/schemas/Description_3"
+      additionalProperties: false
+    OB_OtherCodeType1_1:
+      type: "object"
+      required:
+        - "Name"
+        - "Description"
+      description: "Other application frequencies that are not available in the standard code list"
+      properties:
+        Code:
+          $ref: "#/components/schemas/OB_CodeMnemonic"
+        Name:
+          $ref: "#/components/schemas/Name_4"
+        Description:
+          $ref: "#/components/schemas/Description_3"
+      additionalProperties: false
+    OB_OtherCodeType1_2:
+      type: "object"
+      required:
+        - "Name"
+        - "Description"
+      description: "Other calculation frequency which is not available in the standard code set."
+      properties:
+        Code:
+          $ref: "#/components/schemas/OB_CodeMnemonic"
+        Name:
+          $ref: "#/components/schemas/Name_4"
+        Description:
+          $ref: "#/components/schemas/Description_3"
+      additionalProperties: false
+    OB_OtherCodeType1_3:
+      type: "object"
+      required:
+        - "Name"
+        - "Description"
+      description: "Other Fee type which is not available in the standard code set"
+      properties:
+        Code:
+          $ref: "#/components/schemas/OB_CodeMnemonic"
+        Name:
+          $ref: "#/components/schemas/Name_4"
+        Description:
+          $ref: "#/components/schemas/Description_3"
+      additionalProperties: false
+    OB_OtherCodeType1_4:
+      type: "object"
+      required:
+        - "Name"
+        - "Description"
+      description: "Other fee rate type code which is not available in the standard code set"
+      properties:
+        Code:
+          $ref: "#/components/schemas/OB_CodeMnemonic"
+        Name:
+          $ref: "#/components/schemas/Name_4"
+        Description:
+          $ref: "#/components/schemas/Description_3"
+      additionalProperties: false
+    OB_OtherCodeType1_5:
+      type: "object"
+      required:
+        - "Name"
+        - "Description"
+      description: "Other fee rate type which is not in the standard rate type list"
+      properties:
+        Code:
+          $ref: "#/components/schemas/OB_CodeMnemonic"
+        Name:
+          $ref: "#/components/schemas/Name_4"
+        Description:
+          $ref: "#/components/schemas/Description_3"
+      additionalProperties: false
+    OB_OtherCodeType1_6:
+      type: "object"
+      required:
+        - "Name"
+        - "Description"
+      description: "Other application frequencies not covered in the standard code list"
+      properties:
+        Code:
+          $ref: "#/components/schemas/OB_CodeMnemonic"
+        Name:
+          $ref: "#/components/schemas/Name_4"
+        Description:
+          $ref: "#/components/schemas/Description_3"
+      additionalProperties: false
+    OB_OtherCodeType1_7:
+      type: "object"
+      required:
+        - "Name"
+        - "Description"
+      description: "Other calculation frequency which is not available in standard code set."
+      properties:
+        Code:
+          $ref: "#/components/schemas/OB_CodeMnemonic"
+        Name:
+          $ref: "#/components/schemas/Name_4"
+        Description:
+          $ref: "#/components/schemas/Description_3"
+      additionalProperties: false
+    OB_OtherCodeType1_8:
+      type: "object"
+      required:
+        - "Name"
+        - "Description"
+      description: "Other fee rate type which is not available in the standard code set"
+      properties:
+        Code:
+          $ref: "#/components/schemas/OB_CodeMnemonic"
+        Name:
+          $ref: "#/components/schemas/Name_4"
+        Description:
+          $ref: "#/components/schemas/Description_3"
+      additionalProperties: false
+    OB_OtherFeeChargeDetailType:
+      type: "object"
+      required:
+        - "FeeCategory"
+        - "Name"
+        - "Description"
+      description: "Other Fee/charge type which is not available in the standard code set"
+      properties:
+        Code:
+          $ref: "#/components/schemas/OB_CodeMnemonic"
+        FeeCategory:
+          $ref: "#/components/schemas/OB_FeeCategory1Code"
+        Name:
+          $ref: "#/components/schemas/Name_4"
+        Description:
+          $ref: "#/components/schemas/Description_3"
+      additionalProperties: false
+    OB_OverdraftFeeType1Code:
+      description: "Overdraft fee type"
+      type: "string"
+      enum:
+        - "FBAO"
+        - "FBAR"
+        - "FBEB"
+        - "FBIT"
+        - "FBOR"
+        - "FBOS"
+        - "FBSC"
+        - "FBTO"
+        - "FBUB"
+        - "FBUT"
+        - "FTOT"
+        - "FTUT"
+    OB_Period1Code:
+      description: "Period e.g. day, week, month etc. for which the fee/charge is capped"
+      type: "string"
+      enum:
+        - "PACT"
+        - "PDAY"
+        - "PHYR"
+        - "PMTH"
+        - "PQTR"
+        - "PWEK"
+        - "PYER"
+    OB_Rate1_0:
+      description: "Rate charged for overdraft fee/charge (where it is charged in terms of a rate rather than an amount)"
+      type: "string"
+      pattern: "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$"
+    OB_Rate1_1:
+      description: "Rate charged for Fee/Charge (where it is charged in terms of a rate rather than an amount)"
+      type: "string"
+      pattern: "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$"
+    OpeningDate:
+      description: "Date on which the account and related basic services are effectively operational for the account owner.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+      type: "string"
+      format: "date-time"
+    PartyId:
+      description: "A unique and immutable identifier used to identify the customer resource. This identifier has no meaning to the account owner."
+      type: "string"
+      minLength: 1
+      maxLength: 40
+    PartyNumber:
+      description: "Number assigned by an agent to identify its customer."
+      type: "string"
+      minLength: 1
+      maxLength: 35
+    PhoneNumber_0:
+      description: "Collection of information that identifies a phone number, as defined by telecom services."
+      type: "string"
+      pattern: "\\+[0-9]{1,3}-[0-9()+\\-]{1,30}"
+    PhoneNumber_1:
+      description: "Collection of information that identifies a mobile phone number, as defined by telecom services."
+      type: "string"
+      pattern: "\\+[0-9]{1,3}-[0-9()+\\-]{1,30}"
+    PostCode:
+      description: "Identifier consisting of a group of letters and/or numbers that is added to a postal address to assist the sorting of mail."
+      type: "string"
+      minLength: 1
+      maxLength: 16
+    PreviousPaymentDateTime:
+      description: "Date of most recent direct debit collection.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+      type: "string"
+      format: "date-time"
+    ProprietaryBankTransactionCodeStructure1:
+      type: "object"
+      required:
+        - "Code"
+      description: "Set of elements to fully identify a proprietary bank transaction code."
+      properties:
+        Code:
+          description: "Proprietary bank transaction code to identify the underlying transaction."
+          type: "string"
+          minLength: 1
+          maxLength: 35
+        Issuer:
+          description: "Identification of the issuer of the proprietary bank transaction code."
+          type: "string"
+          minLength: 1
+          maxLength: 35
+      additionalProperties: false
+    Rate:
+      description: "Rate associated with the statement rate type."
+      type: "string"
+      pattern: "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$"
+    Reference:
+      description: "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction.\nUsage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money.\nIf the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+      type: "string"
+      minLength: 1
+      maxLength: 35
+    OBBeneficiaryType1Code:
+      description: "Specifies the Beneficiary Type."
+      type: "string"
+      enum:
+        - "Trusted"
+        - "Ordinary"
+    ScheduledPaymentDateTime:
+      description: "The date on which the scheduled payment will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+      type: "string"
+      format: "date-time"
+    ScheduledPaymentId:
+      description: "A unique and immutable identifier used to identify the scheduled payment resource. This identifier has no meaning to the account owner."
+      type: "string"
+      minLength: 1
+      maxLength: 40
+    SecondaryIdentification:
+      description: "This is secondary identification of the account, as assigned by the account servicing institution. \nThis can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+      type: "string"
+      minLength: 1
+      maxLength: 34
+    StandingOrderId:
+      description: "A unique and immutable identifier used to identify the standing order resource. This identifier has no meaning to the account owner."
+      type: "string"
+      minLength: 1
+      maxLength: 40
+    StartDateTime:
+      description: "Date and time at which the statement period starts.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+      type: "string"
+      format: "date-time"
+    StatementId:
+      description: "Unique identifier for the statement resource within an servicing institution. This identifier is both unique and immutable."
+      type: "string"
+      minLength: 1
+      maxLength: 40
+    StatementReference:
+      description: "Unique reference for the statement. This reference may be optionally populated if available."
+      type: "string"
+      minLength: 1
+      maxLength: 35
+    StatusUpdateDateTime:
+      description: "Date and time at which the resource status was updated.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+      type: "string"
+      format: "date-time"
+    StreetName:
+      description: "Name of a street or thoroughfare."
+      type: "string"
+      minLength: 1
+      maxLength: 70
+    TownName:
+      description: "Name of a built-up area, with defined boundaries, and a local government."
+      type: "string"
+      minLength: 1
+      maxLength: 35
+    TransactionId:
+      description: "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable."
+      type: "string"
+      minLength: 1
+      maxLength: 210
+    TransactionInformation:
+      description: "Further details of the transaction. \nThis is the transaction narrative, which is unstructured text."
+      type: "string"
+      minLength: 1
+      maxLength: 500
+    TransactionReference:
+      description: "Unique reference for the transaction. This reference is optionally populated, and may as an example be the FPID in the Faster Payments context."
+      type: "string"
+      minLength: 1
+      maxLength: 210
+    Value:
+      description: "Value associated with the statement value type."
+      type: "string"
+      minLength: 1
+      maxLength: 40
+    ValueDateTime:
+      description: "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry.\nUsage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date.\nFor transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+      type: "string"
+      format: "date-time"
+    Model:
+      type: "object"
+      properties:
+        id:
+          type: "integer"
+          format: "int64"
+

--- a/src/main/resources/specification/confirmation-funds-openapi.yaml
+++ b/src/main/resources/specification/confirmation-funds-openapi.yaml
@@ -1,0 +1,711 @@
+openapi: "3.0.0"
+info:
+  title: "Confirmation of Funds API Specification"
+  description: "Swagger for Confirmation of Funds API Specification"
+  termsOfService: "https://www.openbanking.org.uk/terms"
+  contact:
+    name: "Service Desk"
+    email: "ServiceDesk@openbanking.org.uk"
+  license:
+    name: "open-licence"
+    url: "https://www.openbanking.org.uk/open-licence"
+  version: "3.1.8"
+paths:
+  /funds-confirmation-consents:
+    post:
+      tags:
+        - "Funds Confirmations"
+      summary: "Create Funds Confirmation Consent"
+      operationId: "CreateFundsConfirmationConsents"
+      parameters:
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OBFundsConfirmationConsent1"
+        description: "Default"
+        required: true
+      responses:
+        201:
+          $ref: "#/components/responses/201FundsConfirmationConsentsCreated"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        415:
+          $ref: "#/components/responses/415Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - TPPOAuth2Security:
+            - "fundsconfirmations"
+  /funds-confirmation-consents/{ConsentId}:
+    get:
+      tags:
+        - "Funds Confirmations"
+      summary: "Get Funds Confirmation Consent"
+      operationId: "GetFundsConfirmationConsentsConsentId"
+      parameters:
+        - $ref: "#/components/parameters/ConsentId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200FundsConfirmationConsentsConsentIdRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - TPPOAuth2Security:
+            - "fundsconfirmations"
+    delete:
+      tags:
+        - "Funds Confirmations"
+      summary: "Delete Funds Confirmation Consent"
+      operationId: "DeleteFundsConfirmationConsentsConsentId"
+      parameters:
+        - $ref: "#/components/parameters/ConsentId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        204:
+          $ref: "#/components/responses/204FundsConfirmationConsentsConsentIdDeleted"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - TPPOAuth2Security:
+            - "fundsconfirmations"
+  /funds-confirmations:
+    post:
+      tags:
+        - "Funds Confirmations"
+      summary: "Create Funds Confirmation"
+      operationId: "CreateFundsConfirmations"
+      parameters:
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OBFundsConfirmation1"
+        description: "Default"
+        required: true
+      responses:
+        201:
+          $ref: "#/components/responses/201FundsConfirmationsCreated"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        415:
+          $ref: "#/components/responses/415Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - PSUOAuth2Security:
+            - "fundsconfirmations"
+servers:
+  - url: "/open-banking/v3.1/cbpii"
+components:
+  parameters:
+    ConsentId:
+      name: "ConsentId"
+      in: "path"
+      description: "ConsentId"
+      required: true
+      schema:
+        type: "string"
+    Authorization:
+      in: "header"
+      name: "Authorization"
+      required: true
+      description: "An Authorisation Token as per https://tools.ietf.org/html/rfc6750"
+      schema:
+        type: "string"
+    x-customer-user-agent:
+      in: "header"
+      name: "x-customer-user-agent"
+      description: "Indicates the user-agent that the PSU is using."
+      required: false
+      schema:
+        type: "string"
+    x-fapi-customer-ip-address:
+      in: "header"
+      name: "x-fapi-customer-ip-address"
+      required: false
+      description: "The PSU's IP address if the PSU is currently logged in with the TPP."
+      schema:
+        type: "string"
+    x-fapi-auth-date:
+      in: "header"
+      name: "x-fapi-auth-date"
+      required: false
+      description: "The time when the PSU last logged in with the TPP. \nAll dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below: \nSun, 10 Sep 2017 19:43:31 UTC"
+      schema:
+        type: "string"
+        pattern: "^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), \\d{2} (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \\d{4} \\d{2}:\\d{2}:\\d{2} (GMT|UTC)$"
+    x-fapi-interaction-id:
+      in: "header"
+      name: "x-fapi-interaction-id"
+      required: false
+      description: "An RFC4122 UID used as a correlation id."
+      schema:
+        type: "string"
+    x-idempotency-key:
+      name: "x-idempotency-key"
+      in: "header"
+      description: "Every request will be processed only once per x-idempotency-key.  The\nIdempotency Key will be valid for 24 hours.\n"
+      required: true
+      schema:
+        type: "string"
+        maxLength: 40
+        pattern: "^(?!\\s)(.*)(\\S)$"
+    x-jws-signature:
+      in: "header"
+      name: "x-jws-signature"
+      required: true
+      description: "A detached JWS signature of the body of the payload."
+      schema:
+        type: "string"
+  responses:
+    201FundsConfirmationConsentsCreated:
+      description: "Funds Confirmation Consent Created"
+      headers:
+        x-fapi-interaction-id:
+          required: true
+          description: "An RFC4122 UID used as a correlation id."
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBFundsConfirmationConsentResponse1"
+    200FundsConfirmationConsentsConsentIdRead:
+      description: "Funds Confirmation Consent Read"
+      headers:
+        x-fapi-interaction-id:
+          required: true
+          description: "An RFC4122 UID used as a correlation id."
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBFundsConfirmationConsentResponse1"
+    204FundsConfirmationConsentsConsentIdDeleted:
+      description: "Funds Confirmation Consent Deleted"
+      headers:
+        x-fapi-interaction-id:
+          required: true
+          description: "An RFC4122 UID used as a correlation id."
+          schema:
+            type: "string"
+    201FundsConfirmationsCreated:
+      description: "Funds Confirmation Created"
+      headers:
+        x-fapi-interaction-id:
+          required: true
+          description: "An RFC4122 UID used as a correlation id."
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBFundsConfirmationResponse1"
+    400Error:
+      description: "Bad request"
+      headers:
+        x-fapi-interaction-id:
+          required: true
+          description: "An RFC4122 UID used as a correlation id."
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBErrorResponse1"
+    401Error:
+      description: "Unauthorized"
+      headers:
+        x-fapi-interaction-id:
+          required: true
+          description: "An RFC4122 UID used as a correlation id."
+          schema:
+            type: "string"
+    403Error:
+      description: "Forbidden"
+      headers:
+        x-fapi-interaction-id:
+          required: true
+          description: "An RFC4122 UID used as a correlation id."
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBErrorResponse1"
+    404Error:
+      description: "Not found"
+      headers:
+        x-fapi-interaction-id:
+          required: true
+          description: "An RFC4122 UID used as a correlation id."
+          schema:
+            type: "string"
+    405Error:
+      description: "Method Not Allowed"
+      headers:
+        x-fapi-interaction-id:
+          required: true
+          description: "An RFC4122 UID used as a correlation id."
+          schema:
+            type: "string"
+    406Error:
+      description: "Not Acceptable"
+      headers:
+        x-fapi-interaction-id:
+          required: true
+          description: "An RFC4122 UID used as a correlation id."
+          schema:
+            type: "string"
+    415Error:
+      description: "Unsupported Media Type"
+      headers:
+        x-fapi-interaction-id:
+          required: true
+          description: "An RFC4122 UID used as a correlation id."
+          schema:
+            type: "string"
+    429Error:
+      description: "Too Many Requests"
+      headers:
+        Retry-After:
+          description: "Number in seconds to wait"
+          schema:
+            type: "integer"
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          schema:
+            type: "string"
+    500Error:
+      description: "Internal Server Error"
+      headers:
+        x-fapi-interaction-id:
+          required: true
+          description: "An RFC4122 UID used as a correlation id."
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBErrorResponse1"
+  securitySchemes:
+    TPPOAuth2Security:
+      type: "oauth2"
+      description: "TPP client credential authorisation flow with the ASPSP"
+      flows:
+        clientCredentials:
+          tokenUrl: "https://authserver.example/token"
+          scopes:
+            fundsconfirmations: "Funds confirmation entitlement"
+    PSUOAuth2Security:
+      type: "oauth2"
+      description: "OAuth flow, it is required when the PSU needs to perform SCA with the ASPSP when a TPP wants to access an ASPSP resource owned by the PSU"
+      flows:
+        authorizationCode:
+          authorizationUrl: "https://authserver.example/authorization"
+          tokenUrl: "https://authserver.example/token"
+          scopes:
+            fundsconfirmations: "Funds confirmation entitlement"
+  schemas:
+    ISODateTime:
+      description: "All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+      type: "string"
+      format: "date-time"
+    Links:
+      type: "object"
+      description: "Links relevant to the payload"
+      properties:
+        Self:
+          type: "string"
+          format: "uri"
+        First:
+          type: "string"
+          format: "uri"
+        Prev:
+          type: "string"
+          format: "uri"
+        Next:
+          type: "string"
+          format: "uri"
+        Last:
+          type: "string"
+          format: "uri"
+      additionalProperties: false
+      required:
+        - "Self"
+    Meta:
+      title: "MetaData"
+      type: "object"
+      description: "Meta Data relevant to the payload"
+      properties:
+        TotalPages:
+          type: "integer"
+          format: "int32"
+        FirstAvailableDateTime:
+          $ref: "#/components/schemas/ISODateTime"
+        LastAvailableDateTime:
+          $ref: "#/components/schemas/ISODateTime"
+      additionalProperties: false
+    OBError1:
+      type: "object"
+      properties:
+        ErrorCode:
+          description: "Low level textual error code, e.g., UK.OBIE.Field.Missing"
+          type: "string"
+          x-namespaced-enum:
+            - "UK.OBIE.Field.Expected"
+            - "UK.OBIE.Field.Invalid"
+            - "UK.OBIE.Field.InvalidDate"
+            - "UK.OBIE.Field.Missing"
+            - "UK.OBIE.Field.Unexpected"
+            - "UK.OBIE.Header.Invalid"
+            - "UK.OBIE.Header.Missing"
+            - "UK.OBIE.Reauthenticate"
+            - "UK.OBIE.Resource.ConsentMismatch"
+            - "UK.OBIE.Resource.InvalidConsentStatus"
+            - "UK.OBIE.Resource.InvalidFormat"
+            - "UK.OBIE.Resource.NotFound"
+            - "UK.OBIE.Rules.AfterCutOffDateTime"
+            - "UK.OBIE.Rules.DuplicateReference"
+            - "UK.OBIE.Signature.Invalid"
+            - "UK.OBIE.Signature.InvalidClaim"
+            - "UK.OBIE.Signature.Malformed"
+            - "UK.OBIE.Signature.Missing"
+            - "UK.OBIE.Signature.MissingClaim"
+            - "UK.OBIE.Signature.Unexpected"
+            - "UK.OBIE.UnexpectedError"
+            - "UK.OBIE.Unsupported.AccountIdentifier"
+            - "UK.OBIE.Unsupported.AccountSecondaryIdentifier"
+            - "UK.OBIE.Unsupported.Currency"
+            - "UK.OBIE.Unsupported.Frequency"
+            - "UK.OBIE.Unsupported.LocalInstrument"
+            - "UK.OBIE.Unsupported.Scheme"
+        Message:
+          description: "A description of the error that occurred. e.g., 'A mandatory field isn't supplied' or 'RequestedExecutionDateTime must be in future'\nOBIE doesn't standardise this field"
+          type: "string"
+          minLength: 1
+          maxLength: 500
+        Path:
+          description: "Recommended but optional reference to the JSON Path of the field with error, e.g., Data.Initiation.InstructedAmount.Currency"
+          type: "string"
+          minLength: 1
+          maxLength: 500
+        Url:
+          description: "URL to help remediate the problem, or provide more information, or to API Reference, or help etc"
+          type: "string"
+      required:
+        - "ErrorCode"
+        - "Message"
+      additionalProperties: false
+      minProperties: 1
+    OBErrorResponse1:
+      description: "An array of detail error codes, and messages, and URLs to documentation to help remediation."
+      type: "object"
+      properties:
+        Code:
+          description: "High level textual error code, to help categorize the errors."
+          type: "string"
+          minLength: 1
+          maxLength: 40
+        Id:
+          description: "A unique reference for the error instance, for audit purposes, in case of unknown/unclassified errors."
+          type: "string"
+          minLength: 1
+          maxLength: 40
+        Message:
+          description: "Brief Error message, e.g., 'There is something wrong with the request parameters provided'"
+          type: "string"
+          minLength: 1
+          maxLength: 500
+        Errors:
+          items:
+            $ref: "#/components/schemas/OBError1"
+          type: "array"
+          minItems: 1
+      required:
+        - "Code"
+        - "Message"
+        - "Errors"
+      additionalProperties: false
+    OBFundsConfirmation1:
+      type: "object"
+      required:
+        - "Data"
+      properties:
+        Data:
+          type: "object"
+          required:
+            - "ConsentId"
+            - "Reference"
+            - "InstructedAmount"
+          properties:
+            ConsentId:
+              description: "Unique identification as assigned by the ASPSP to uniquely identify the funds confirmation consent resource."
+              type: "string"
+              minLength: 1
+              maxLength: 128
+            Reference:
+              description: "Unique reference, as assigned by the CBPII, to unambiguously refer to the request related to the payment transaction."
+              type: "string"
+              minLength: 1
+              maxLength: 35
+            InstructedAmount:
+              type: "object"
+              required:
+                - "Amount"
+                - "Currency"
+              description: "Amount of money to be confirmed as available funds in the debtor account. Contains an Amount and a Currency."
+              properties:
+                Amount:
+                  description: "A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217."
+                  type: "string"
+                  pattern: "^\\d{1,13}$|^\\d{1,13}\\.\\d{1,5}$"
+                Currency:
+                  description: "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\"."
+                  type: "string"
+                  pattern: "^[A-Z]{3,3}$"
+      additionalProperties: false
+    OBFundsConfirmationConsent1:
+      type: "object"
+      required:
+        - "Data"
+      properties:
+        Data:
+          type: "object"
+          required:
+            - "DebtorAccount"
+          properties:
+            ExpirationDateTime:
+              description: "Specified date and time the funds confirmation authorisation will expire.\n If this is not populated, the authorisation will be open ended.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            DebtorAccount:
+              type: "object"
+              required:
+                - "SchemeName"
+                - "Identification"
+              description: "Unambiguous identification of the account of the debtor to which a confirmation of funds consent will be applied."
+              properties:
+                SchemeName:
+                  description: "Name of the identification scheme, in a coded form as published in an external list."
+                  type: "string"
+                  x-namespaced-enum:
+                    - "UK.OBIE.BBAN"
+                    - "UK.OBIE.IBAN"
+                    - "UK.OBIE.PAN"
+                    - "UK.OBIE.Paym"
+                    - "UK.OBIE.SortCodeAccountNumber"
+                Identification:
+                  description: "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 256
+                Name:
+                  description: "Name of the account, as assigned by the account servicing institution.\nUsage: The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 350
+                SecondaryIdentification:
+                  description: "This is secondary identification of the account, as assigned by the account servicing institution. \nThis can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 34
+      additionalProperties: false
+    OBFundsConfirmationConsentResponse1:
+      type: "object"
+      required:
+        - "Data"
+      properties:
+        Data:
+          type: "object"
+          required:
+            - "ConsentId"
+            - "CreationDateTime"
+            - "Status"
+            - "StatusUpdateDateTime"
+            - "DebtorAccount"
+          properties:
+            ConsentId:
+              description: "Unique identification as assigned to identify the funds confirmation consent resource."
+              type: "string"
+              minLength: 1
+              maxLength: 128
+            CreationDateTime:
+              description: "Date and time at which the resource was created.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            Status:
+              description: "Specifies the status of consent resource in code form."
+              type: "string"
+              enum:
+                - "Authorised"
+                - "AwaitingAuthorisation"
+                - "Rejected"
+                - "Revoked"
+            StatusUpdateDateTime:
+              description: "Date and time at which the resource status was updated.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            ExpirationDateTime:
+              description: "Specified date and time the funds confirmation authorisation will expire.\nIf this is not populated, the authorisation will be open ended.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            DebtorAccount:
+              type: "object"
+              required:
+                - "SchemeName"
+                - "Identification"
+              description: "Unambiguous identification of the account of the debtor to which a confirmation of funds consent will be applied."
+              properties:
+                SchemeName:
+                  description: "Name of the identification scheme, in a coded form as published in an external list."
+                  type: "string"
+                  x-namespaced-enum:
+                    - "UK.OBIE.BBAN"
+                    - "UK.OBIE.IBAN"
+                    - "UK.OBIE.PAN"
+                    - "UK.OBIE.Paym"
+                    - "UK.OBIE.SortCodeAccountNumber"
+                Identification:
+                  description: "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 256
+                Name:
+                  description: "Name of the account, as assigned by the account servicing institution.\nUsage: The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 350
+                SecondaryIdentification:
+                  description: "This is secondary identification of the account, as assigned by the account servicing institution. \nThis can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 34
+        Links:
+          $ref: "#/components/schemas/Links"
+        Meta:
+          $ref: "#/components/schemas/Meta"
+      additionalProperties: false
+    OBFundsConfirmationResponse1:
+      type: "object"
+      required:
+        - "Data"
+      properties:
+        Data:
+          type: "object"
+          required:
+            - "FundsConfirmationId"
+            - "ConsentId"
+            - "CreationDateTime"
+            - "FundsAvailable"
+            - "Reference"
+            - "InstructedAmount"
+          properties:
+            FundsConfirmationId:
+              description: "Unique identification as assigned by the ASPSP to uniquely identify the funds confirmation resource."
+              type: "string"
+              minLength: 1
+              maxLength: 40
+            ConsentId:
+              description: "Unique identification as assigned by the ASPSP to uniquely identify the funds confirmation consent resource."
+              type: "string"
+              minLength: 1
+              maxLength: 128
+            CreationDateTime:
+              description: "Date and time at which the resource was created.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            FundsAvailable:
+              description: "Flag to indicate the result of a confirmation of funds check."
+              type: "boolean"
+            Reference:
+              description: "Unique reference, as assigned by the CBPII, to unambiguously refer to the request related to the payment transaction."
+              type: "string"
+              minLength: 1
+              maxLength: 35
+            InstructedAmount:
+              type: "object"
+              required:
+                - "Amount"
+                - "Currency"
+              description: "Amount of money to be confirmed as available funds in the debtor account. Contains an Amount and a Currency."
+              properties:
+                Amount:
+                  description: "A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217."
+                  type: "string"
+                  pattern: "^\\d{1,13}$|^\\d{1,13}\\.\\d{1,5}$"
+                Currency:
+                  description: "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\"."
+                  type: "string"
+                  pattern: "^[A-Z]{3,3}$"
+        Links:
+          $ref: "#/components/schemas/Links"
+        Meta:
+          $ref: "#/components/schemas/Meta"
+      additionalProperties: false
+

--- a/src/main/resources/specification/event-notifications-openapi.yaml
+++ b/src/main/resources/specification/event-notifications-openapi.yaml
@@ -1,0 +1,178 @@
+openapi: "3.0.0"
+info:
+  title: "Event Notification API Specification - TPP Endpoints"
+  description: "Swagger for Event Notification API Specification - TPP Endpoints"
+  termsOfService: "https://www.openbanking.org.uk/terms"
+  contact:
+    name: "Service Desk"
+    email: "ServiceDesk@openbanking.org.uk"
+  license:
+    name: "open-licence"
+    url: "https://www.openbanking.org.uk/open-licence"
+  version: "3.1.8"
+paths:
+  /event-notifications:
+    post:
+      summary: "Send an event notification"
+      operationId: "CreateEventNotification"
+      tags:
+        - "Event Notification"
+      parameters:
+        - $ref: "#/components/parameters/x-fapi-financial-id-Param"
+        - $ref: "#/components/parameters/x-fapi-interaction-id-Param"
+      requestBody:
+        content:
+          application/jwt:
+            schema:
+              type: "string"
+              format: "base64"
+        description: "Create an Callback URI"
+        required: true
+      responses:
+        202:
+          description: "Accepted"
+servers:
+  - url: "/open-banking/v3.1"
+components:
+  parameters:
+    x-fapi-financial-id-Param:
+      in: "header"
+      name: "x-fapi-financial-id"
+      required: true
+      description: "The unique id of the ASPSP to which the request is issued. The unique id will be issued by OB."
+      schema:
+        type: "string"
+    x-fapi-interaction-id-Param:
+      in: "header"
+      name: "x-fapi-interaction-id"
+      required: false
+      description: "An RFC4122 UID used as a correlation id."
+      schema:
+        type: "string"
+  securitySchemes:
+    TPPOAuth2Security:
+      type: "oauth2"
+      description: "TPP client credential authorisation flow with the ASPSP"
+      flows:
+        clientCredentials:
+          tokenUrl: "https://authserver.example/token"
+          scopes:
+            accounts: "Ability to read Accounts information"
+            fundsconfirmations: "Ability to confirm funds"
+            payments: "Generic payment scope"
+  schemas:
+    OBEvent1:
+      description: "Events."
+      type: "object"
+      properties:
+        urn:uk:org:openbanking:events:resource-update:
+          $ref: "#/components/schemas/OBEventResourceUpdate1"
+      required:
+        - "urn:uk:org:openbanking:events:resource-update"
+      additionalProperties: false
+    OBEventLink1:
+      description: "Resource links to other available versions of the resource."
+      type: "object"
+      properties:
+        version:
+          description: "Resource version."
+          type: "string"
+          minLength: 1
+          maxLength: 10
+        link:
+          description: "Resource link."
+          type: "string"
+      required:
+        - "version"
+        - "link"
+      additionalProperties: false
+      minProperties: 1
+    OBEventNotification1:
+      description: "The resource-update event."
+      type: "object"
+      properties:
+        iss:
+          description: "Issuer."
+          type: "string"
+        iat:
+          description: "Issued At. "
+          type: "integer"
+          format: "int32"
+          minimum: 0
+        jti:
+          description: "JWT ID."
+          type: "string"
+          minLength: 1
+          maxLength: 128
+        aud:
+          description: "Audience."
+          type: "string"
+          minLength: 1
+          maxLength: 128
+        sub:
+          description: "Subject"
+          type: "string"
+          format: "uri"
+        txn:
+          description: "Transaction Identifier."
+          type: "string"
+          minLength: 1
+          maxLength: 128
+        toe:
+          description: "Time of Event."
+          type: "integer"
+          format: "int32"
+          minimum: 0
+        events:
+          $ref: "#/components/schemas/OBEvent1"
+      required:
+        - "iss"
+        - "iat"
+        - "jti"
+        - "aud"
+        - "sub"
+        - "txn"
+        - "toe"
+        - "events"
+      additionalProperties: false
+    OBEventResourceUpdate1:
+      description: "Resource-Update Event."
+      type: "object"
+      properties:
+        subject:
+          $ref: "#/components/schemas/OBEventSubject1"
+      required:
+        - "subject"
+      additionalProperties: false
+    OBEventSubject1:
+      description: "The resource-update event."
+      type: "object"
+      properties:
+        subject_type:
+          description: "Subject type for the updated resource. "
+          type: "string"
+          minLength: 1
+          maxLength: 128
+        http://openbanking.org.uk/rid:
+          description: "Resource Id for the updated resource."
+          type: "string"
+          minLength: 1
+          maxLength: 128
+        http://openbanking.org.uk/rty:
+          description: "Resource Type for the updated resource."
+          type: "string"
+          minLength: 1
+          maxLength: 128
+        http://openbanking.org.uk/rlk:
+          items:
+            $ref: "#/components/schemas/OBEventLink1"
+          type: "array"
+          description: "Resource links to other available versions of the resource."
+          minItems: 1
+      required:
+        - "subject_type"
+        - "http://openbanking.org.uk/rid"
+        - "http://openbanking.org.uk/rty"
+        - "http://openbanking.org.uk/rlk"
+      additionalProperties: false
+

--- a/src/main/resources/specification/events-openapi.yaml
+++ b/src/main/resources/specification/events-openapi.yaml
@@ -1,0 +1,765 @@
+openapi: "3.0.0"
+info:
+  title: "Events API Specification - ASPSP Endpoints"
+  description: "OpenAPI for Events (Subscription & Aggregated Polling) API Specification - ASPSP Endpoints"
+  termsOfService: "https://www.openbanking.org.uk/terms"
+  contact:
+    name: "Service Desk"
+    email: "ServiceDesk@openbanking.org.uk"
+  license:
+    name: "open-licence"
+    url: "https://www.openbanking.org.uk/open-licence"
+  version: "3.1.8"
+paths:
+  /event-subscriptions:
+    post:
+      tags:
+        - "Event Subscriptions"
+      summary: "Create Event Subscription"
+      operationId: "CreateEventSubscriptions"
+      parameters:
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-jws-signature"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      requestBody:
+        content:
+          application/json; charset=utf-8:
+            schema:
+              $ref: "#/components/schemas/OBEventSubscription1"
+          application/jose+jwe:
+            schema:
+              $ref: "#/components/schemas/OBEventSubscription1"
+        description: "Default"
+        required: true
+      responses:
+        201:
+          $ref: "#/components/responses/201EventSubscriptionsCreated"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        409:
+          $ref: "#/components/responses/409Error"
+        415:
+          $ref: "#/components/responses/415Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - TPPOAuth2Security:
+            - "accounts"
+            - "payments"
+            - "fundsconfirmations"
+    get:
+      tags:
+        - "Event Subscriptions"
+      summary: "Get Event Subscription"
+      operationId: "GetEventSubscriptions"
+      parameters:
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200EventSubscriptionsRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - TPPOAuth2Security:
+            - "accounts"
+            - "payments"
+            - "fundsconfirmations"
+  /event-subscriptions/{EventSubscriptionId}:
+    put:
+      tags:
+        - "Event Subscriptions"
+      summary: "Change Event Subscription"
+      operationId: "ChangeEventSubscriptionsEventSubscriptionId"
+      parameters:
+        - $ref: "#/components/parameters/EventSubscriptionId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-jws-signature"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      requestBody:
+        content:
+          application/json; charset=utf-8:
+            schema:
+              $ref: "#/components/schemas/OBEventSubscriptionResponse1"
+          application/jose+jwe:
+            schema:
+              $ref: "#/components/schemas/OBEventSubscriptionResponse1"
+        description: "Default"
+        required: true
+      responses:
+        200:
+          $ref: "#/components/responses/200EventSubscriptionsEventSubscriptionIdChanged"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        415:
+          $ref: "#/components/responses/415Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - TPPOAuth2Security:
+            - "accounts"
+            - "payments"
+            - "fundsconfirmations"
+    delete:
+      tags:
+        - "Event Subscriptions"
+      summary: "Delete Event Subscription"
+      operationId: "DeleteEventSubscriptionsEventSubscriptionId"
+      parameters:
+        - $ref: "#/components/parameters/EventSubscriptionId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        204:
+          $ref: "#/components/responses/204EventSubscriptionsEventSubscriptionIdDeleted"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - TPPOAuth2Security:
+            - "accounts"
+            - "payments"
+            - "fundsconfirmations"
+  /events:
+    post:
+      tags:
+        - "Events"
+      summary: "Create Events"
+      operationId: "CreateEvents"
+      parameters:
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      requestBody:
+        content:
+          application/json; charset=utf-8:
+            schema:
+              $ref: "#/components/schemas/OBEventPolling1"
+          application/jose+jwe:
+            schema:
+              $ref: "#/components/schemas/OBEventPolling1"
+        description: "Default"
+        required: true
+      responses:
+        200:
+          $ref: "#/components/responses/200EventsRead"
+        201:
+          $ref: "#/components/responses/201EventsCreated"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        415:
+          $ref: "/responses/415Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - TPPOAuth2Security:
+            - "accounts"
+            - "fundsconfirmations"
+servers:
+  - url: "/open-banking/v3.1"
+components:
+  parameters:
+    EventSubscriptionId:
+      name: "EventSubscriptionId"
+      in: "path"
+      description: "EventSubscriptionId"
+      required: true
+      schema:
+        type: "string"
+    Authorization:
+      in: "header"
+      name: "Authorization"
+      required: true
+      description: "An Authorisation Token as per https://tools.ietf.org/html/rfc6750"
+      schema:
+        type: "string"
+    x-customer-user-agent:
+      in: "header"
+      name: "x-customer-user-agent"
+      description: "Indicates the user-agent that the PSU is using."
+      required: false
+      schema:
+        type: "string"
+    x-fapi-customer-ip-address:
+      in: "header"
+      name: "x-fapi-customer-ip-address"
+      required: false
+      description: "The PSU's IP address if the PSU is currently logged in with the TPP."
+      schema:
+        type: "string"
+    x-fapi-auth-date:
+      in: "header"
+      name: "x-fapi-auth-date"
+      required: false
+      description: "The time when the PSU last logged in with the TPP. \nAll dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below: \nSun, 10 Sep 2017 19:43:31 UTC"
+      schema:
+        type: "string"
+        pattern: "^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), \\d{2} (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \\d{4} \\d{2}:\\d{2}:\\d{2} (GMT|UTC)$"
+    x-fapi-interaction-id:
+      in: "header"
+      name: "x-fapi-interaction-id"
+      required: false
+      description: "An RFC4122 UID used as a correlation id."
+      schema:
+        type: "string"
+    x-idempotency-key:
+      name: "x-idempotency-key"
+      in: "header"
+      description: "Every request will be processed only once per x-idempotency-key.  The\nIdempotency Key will be valid for 24 hours.\n"
+      required: true
+      schema:
+        type: "string"
+        maxLength: 40
+        pattern: "^(?!\\s)(.*)(\\S)$"
+    x-jws-signature:
+      in: "header"
+      name: "x-jws-signature"
+      required: true
+      description: "A detached JWS signature of the body of the payload."
+      schema:
+        type: "string"
+  responses:
+    201EventSubscriptionsCreated:
+      description: "Event Subscription Created"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBEventSubscriptionResponse1"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBEventSubscriptionResponse1"
+    200EventSubscriptionsRead:
+      description: "Event Subscription Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBEventSubscriptionsResponse1"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBEventSubscriptionsResponse1"
+    200EventSubscriptionsEventSubscriptionIdChanged:
+      description: "Event Subscription Changed"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBEventSubscriptionResponse1"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBEventSubscriptionResponse1"
+    204EventSubscriptionsEventSubscriptionIdDeleted:
+      description: "Event Subscription Deleted"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          schema:
+            type: "string"
+    201EventsCreated:
+      description: "Events Created"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBEventPollingResponse1"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBEventPollingResponse1"
+    200EventsRead:
+      description: "Read awaiting events"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBEventPollingResponse1"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBEventPollingResponse1"
+    400Error:
+      description: "Bad request"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBErrorResponse1"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBErrorResponse1"
+    401Error:
+      description: "Unauthorized"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          schema:
+            type: "string"
+    403Error:
+      description: "Forbidden"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBErrorResponse1"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBErrorResponse1"
+    404Error:
+      description: "Not found"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          schema:
+            type: "string"
+    405Error:
+      description: "Method Not Allowed"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          schema:
+            type: "string"
+    406Error:
+      description: "Not Acceptable"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          schema:
+            type: "string"
+    409Error:
+      description: "Conflict"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          schema:
+            type: "string"
+    415Error:
+      description: "Unsupported Media Type"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          schema:
+            type: "string"
+    429Error:
+      description: "Too Many Requests"
+      headers:
+        Retry-After:
+          description: "Number in seconds to wait"
+          schema:
+            type: "integer"
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          schema:
+            type: "string"
+    500Error:
+      description: "Internal Server Error"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBErrorResponse1"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBErrorResponse1"
+  securitySchemes:
+    TPPOAuth2Security:
+      type: "oauth2"
+      description: "TPP client credential authorisation flow with the ASPSP"
+      flows:
+        clientCredentials:
+          tokenUrl: "https://authserver.example/token"
+          scopes:
+            accounts: "Ability to receive events associated with Accounts information"
+            fundsconfirmations: "Ability to receive events associated with confirmation of funds"
+            payments: "Ability to receieve events associated with payments"
+  schemas:
+    ISODateTime:
+      description: "All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+      type: "string"
+      format: "date-time"
+    Links:
+      type: "object"
+      description: "Links relevant to the payload"
+      properties:
+        Self:
+          type: "string"
+          format: "uri"
+        First:
+          type: "string"
+          format: "uri"
+        Prev:
+          type: "string"
+          format: "uri"
+        Next:
+          type: "string"
+          format: "uri"
+        Last:
+          type: "string"
+          format: "uri"
+      additionalProperties: false
+      required:
+        - "Self"
+    Meta:
+      title: "MetaData"
+      type: "object"
+      description: "Meta Data relevant to the payload"
+      properties:
+        TotalPages:
+          type: "integer"
+          format: "int32"
+        FirstAvailableDateTime:
+          $ref: "#/components/schemas/ISODateTime"
+        LastAvailableDateTime:
+          $ref: "#/components/schemas/ISODateTime"
+      additionalProperties: false
+    OBError1:
+      type: "object"
+      properties:
+        ErrorCode:
+          description: "Low level textual error code, e.g., UK.OBIE.Field.Missing"
+          type: "string"
+          x-namespaced-enum:
+            - "UK.OBIE.Field.Expected"
+            - "UK.OBIE.Field.Invalid"
+            - "UK.OBIE.Field.InvalidDate"
+            - "UK.OBIE.Field.Missing"
+            - "UK.OBIE.Field.Unexpected"
+            - "UK.OBIE.Header.Invalid"
+            - "UK.OBIE.Header.Missing"
+            - "UK.OBIE.Reauthenticate"
+            - "UK.OBIE.Resource.ConsentMismatch"
+            - "UK.OBIE.Resource.InvalidConsentStatus"
+            - "UK.OBIE.Resource.InvalidFormat"
+            - "UK.OBIE.Resource.NotFound"
+            - "UK.OBIE.Rules.AfterCutOffDateTime"
+            - "UK.OBIE.Rules.DuplicateReference"
+            - "UK.OBIE.Signature.Invalid"
+            - "UK.OBIE.Signature.InvalidClaim"
+            - "UK.OBIE.Signature.Malformed"
+            - "UK.OBIE.Signature.Missing"
+            - "UK.OBIE.Signature.MissingClaim"
+            - "UK.OBIE.Signature.Unexpected"
+            - "UK.OBIE.UnexpectedError"
+            - "UK.OBIE.Unsupported.AccountIdentifier"
+            - "UK.OBIE.Unsupported.AccountSecondaryIdentifier"
+            - "UK.OBIE.Unsupported.Currency"
+            - "UK.OBIE.Unsupported.Frequency"
+            - "UK.OBIE.Unsupported.LocalInstrument"
+            - "UK.OBIE.Unsupported.Scheme"
+        Message:
+          description: "A description of the error that occurred. e.g., 'A mandatory field isn't supplied' or 'RequestedExecutionDateTime must be in future'\nOBIE doesn't standardise this field"
+          type: "string"
+          minLength: 1
+          maxLength: 500
+        Path:
+          description: "Recommended but optional reference to the JSON Path of the field with error, e.g., Data.Initiation.InstructedAmount.Currency"
+          type: "string"
+          minLength: 1
+          maxLength: 500
+        Url:
+          description: "URL to help remediate the problem, or provide more information, or to API Reference, or help etc"
+          type: "string"
+      required:
+        - "ErrorCode"
+        - "Message"
+      additionalProperties: false
+      minProperties: 1
+    OBErrorResponse1:
+      description: "An array of detail error codes, and messages, and URLs to documentation to help remediation."
+      type: "object"
+      properties:
+        Code:
+          description: "High level textual error code, to help categorize the errors."
+          type: "string"
+          minLength: 1
+          maxLength: 40
+        Id:
+          description: "A unique reference for the error instance, for audit purposes, in case of unknown/unclassified errors."
+          type: "string"
+          minLength: 1
+          maxLength: 40
+        Message:
+          description: "Brief Error message, e.g., 'There is something wrong with the request parameters provided'"
+          type: "string"
+          minLength: 1
+          maxLength: 500
+        Errors:
+          items:
+            $ref: "#/components/schemas/OBError1"
+          type: "array"
+          minItems: 1
+      required:
+        - "Code"
+        - "Message"
+        - "Errors"
+      additionalProperties: false
+    OBEventSubscription1:
+      type: "object"
+      required:
+        - "Data"
+      properties:
+        Data:
+          type: "object"
+          required:
+            - "Version"
+          properties:
+            CallbackUrl:
+              description: "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to."
+              type: "string"
+              format: "uri"
+            Version:
+              $ref: "#/components/schemas/Version"
+            EventTypes:
+              type: "array"
+              items:
+                description: "Array of event types the subscription applies to."
+                type: "string"
+      additionalProperties: false
+    OBEventSubscriptionResponse1:
+      type: "object"
+      required:
+        - "Data"
+      properties:
+        Data:
+          type: "object"
+          required:
+            - "EventSubscriptionId"
+            - "Version"
+          properties:
+            EventSubscriptionId:
+              description: "Unique identification as assigned by the ASPSP to uniquely identify the callback URL resource."
+              type: "string"
+              minLength: 1
+              maxLength: 40
+            CallbackUrl:
+              description: "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to."
+              type: "string"
+              format: "uri"
+            Version:
+              $ref: "#/components/schemas/Version"
+            EventTypes:
+              type: "array"
+              items:
+                description: "Array of event types the subscription applies to."
+                type: "string"
+        Links:
+          $ref: "#/components/schemas/Links"
+        Meta:
+          $ref: "#/components/schemas/Meta"
+      additionalProperties: false
+    OBEventSubscriptionsResponse1:
+      type: "object"
+      required:
+        - "Data"
+      properties:
+        Data:
+          type: "object"
+          properties:
+            EventSubscription:
+              type: "array"
+              items:
+                type: "object"
+                required:
+                  - "EventSubscriptionId"
+                  - "Version"
+                properties:
+                  EventSubscriptionId:
+                    description: "Unique identification as assigned by the ASPSP to uniquely identify the callback url resource."
+                    type: "string"
+                    minLength: 1
+                    maxLength: 40
+                  CallbackUrl:
+                    description: "Callback URL for a TPP hosted service. Will be used by ASPSPs, in conjunction with the resource name, to construct a URL to send event notifications to."
+                    type: "string"
+                    format: "uri"
+                  Version:
+                    $ref: "#/components/schemas/Version"
+                  EventTypes:
+                    type: "array"
+                    items:
+                      description: "Array of event types the subscription applies to."
+                      type: "string"
+        Links:
+          $ref: "#/components/schemas/Links"
+        Meta:
+          $ref: "#/components/schemas/Meta"
+      additionalProperties: false
+    Version:
+      description: "Version for the event notification."
+      type: "string"
+      minLength: 1
+      maxLength: 10
+    OBEventPolling1:
+      type: "object"
+      properties:
+        maxEvents:
+          description: "Maximum number of events to be returned. A value of zero indicates the ASPSP should not return events even if available"
+          type: "integer"
+        returnImmediately:
+          description: "Indicates whether an ASPSP should return a response immediately or provide a long poll"
+          type: "boolean"
+        ack:
+          type: "array"
+          items:
+            description: "An array of jti values indicating event notifications positively acknowledged by the TPP"
+            type: "string"
+            minLength: 1
+            maxLength: 128
+        setErrs:
+          type: "object"
+          description: "An object that encapsulates all negative acknowledgements transmitted by the TPP"
+          properties: { }
+          additionalProperties:
+            type: "object"
+            required:
+              - "err"
+              - "description"
+            properties:
+              err:
+                description: "A value from the IANA \"Security Event Token Delivery Error Codes\" registry that identifies the error as defined here \nhttps://tools.ietf.org/id/draft-ietf-secevent-http-push-03.html#error_codes"
+                type: "string"
+                minLength: 1
+                maxLength: 40
+              description:
+                description: "A human-readable string that provides additional diagnostic information"
+                type: "string"
+                minLength: 1
+                maxLength: 256
+      additionalProperties: false
+    OBEventPollingResponse1:
+      type: "object"
+      required:
+        - "moreAvailable"
+        - "sets"
+      properties:
+        moreAvailable:
+          description: "A JSON boolean value that indicates if more unacknowledged event notifications are available to be returned."
+          type: "boolean"
+        sets:
+          type: "object"
+          description: "A JSON object that contains zero or more nested JSON attributes. If there are no outstanding event notifications to be transmitted, the JSON object SHALL be empty."
+          properties: { }
+          additionalProperties:
+            description: "An object named with the jti of the event notification to be delivered. The value is the event notification, expressed as a string.\nThe payload of the event should be defined in the OBEventNotification2 format."
+            type: "string"
+      additionalProperties: false
+

--- a/src/main/resources/specification/payment-initiation-openapi.yaml
+++ b/src/main/resources/specification/payment-initiation-openapi.yaml
@@ -1,0 +1,8978 @@
+openapi: "3.0.0"
+info:
+  title: "Payment Initiation API"
+  description: "Swagger for Payment Initiation API Specification"
+  termsOfService: "https://www.openbanking.org.uk/terms"
+  contact:
+    name: "Service Desk"
+    email: "ServiceDesk@openbanking.org.uk"
+  license:
+    name: "open-licence"
+    url: "https://www.openbanking.org.uk/open-licence"
+  version: "3.1.8"
+paths:
+  /domestic-payment-consents:
+    post:
+      tags:
+        - "Domestic Payments"
+      summary: "Create Domestic Payment Consents"
+      operationId: "CreateDomesticPaymentConsents"
+      parameters:
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-idempotency-key"
+        - $ref: "#/components/parameters/x-jws-signature"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      requestBody:
+        content:
+          application/json; charset=utf-8:
+            schema:
+              $ref: "#/components/schemas/OBWriteDomesticConsent4"
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OBWriteDomesticConsent4"
+          application/jose+jwe:
+            schema:
+              $ref: "#/components/schemas/OBWriteDomesticConsent4"
+        description: "Default"
+        required: true
+      responses:
+        201:
+          $ref: "#/components/responses/201DomesticPaymentConsentsCreated"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        415:
+          $ref: "#/components/responses/415Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - TPPOAuth2Security:
+            - "payments"
+  /domestic-payment-consents/{ConsentId}:
+    get:
+      tags:
+        - "Domestic Payments"
+      summary: "Get Domestic Payment Consents"
+      operationId: "GetDomesticPaymentConsentsConsentId"
+      parameters:
+        - $ref: "#/components/parameters/ConsentId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200DomesticPaymentConsentsConsentIdRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - TPPOAuth2Security:
+            - "payments"
+  /domestic-payment-consents/{ConsentId}/funds-confirmation:
+    get:
+      tags:
+        - "Domestic Payments"
+      summary: "Get Domestic Payment Consents Funds Confirmation"
+      operationId: "GetDomesticPaymentConsentsConsentIdFundsConfirmation"
+      parameters:
+        - $ref: "#/components/parameters/ConsentId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200DomesticPaymentConsentsConsentIdFundsConfirmationRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - PSUOAuth2Security:
+            - "payments"
+  /domestic-payments:
+    post:
+      tags:
+        - "Domestic Payments"
+      summary: "Create Domestic Payments"
+      operationId: "CreateDomesticPayments"
+      parameters:
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-idempotency-key"
+        - $ref: "#/components/parameters/x-jws-signature"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      requestBody:
+        content:
+          application/json; charset=utf-8:
+            schema:
+              $ref: "#/components/schemas/OBWriteDomestic2"
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OBWriteDomestic2"
+          application/jose+jwe:
+            schema:
+              $ref: "#/components/schemas/OBWriteDomestic2"
+        description: "Default"
+        required: true
+      responses:
+        201:
+          $ref: "#/components/responses/201DomesticPaymentsCreated"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        415:
+          $ref: "#/components/responses/415Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - PSUOAuth2Security:
+            - "payments"
+  /domestic-payments/{DomesticPaymentId}:
+    get:
+      tags:
+        - "Domestic Payments"
+      summary: "Get Domestic Payments"
+      operationId: "GetDomesticPaymentsDomesticPaymentId"
+      parameters:
+        - $ref: "#/components/parameters/DomesticPaymentId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200DomesticPaymentsDomesticPaymentIdRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - TPPOAuth2Security:
+            - "payments"
+  /domestic-payments/{DomesticPaymentId}/payment-details:
+    get:
+      tags:
+        - "Payment Details"
+      summary: "Get Payment Details"
+      operationId: "GetDomesticPaymentsDomesticPaymentIdPaymentDetails"
+      parameters:
+        - $ref: "#/components/parameters/DomesticPaymentId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200DomesticPaymentsDomesticPaymentIdPaymentDetailsRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - TPPOAuth2Security:
+            - "payments"
+  /domestic-scheduled-payment-consents:
+    post:
+      tags:
+        - "Domestic Scheduled Payments"
+      summary: "Create Domestic Scheduled Payment Consents"
+      operationId: "CreateDomesticScheduledPaymentConsents"
+      parameters:
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-idempotency-key"
+        - $ref: "#/components/parameters/x-jws-signature"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      requestBody:
+        content:
+          application/json; charset=utf-8:
+            schema:
+              $ref: "#/components/schemas/OBWriteDomesticScheduledConsent4"
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OBWriteDomesticScheduledConsent4"
+          application/jose+jwe:
+            schema:
+              $ref: "#/components/schemas/OBWriteDomesticScheduledConsent4"
+        description: "Default"
+        required: true
+      responses:
+        201:
+          $ref: "#/components/responses/201DomesticScheduledPaymentConsentsCreated"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        415:
+          $ref: "#/components/responses/415Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - TPPOAuth2Security:
+            - "payments"
+  /domestic-scheduled-payment-consents/{ConsentId}:
+    get:
+      tags:
+        - "Domestic Scheduled Payments"
+      summary: "Get Domestic Scheduled Payment Consents"
+      operationId: "GetDomesticScheduledPaymentConsentsConsentId"
+      parameters:
+        - $ref: "#/components/parameters/ConsentId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200DomesticScheduledPaymentConsentsConsentIdRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - TPPOAuth2Security:
+            - "payments"
+  /domestic-scheduled-payments:
+    post:
+      tags:
+        - "Domestic Scheduled Payments"
+      summary: "Create Domestic Scheduled Payments"
+      operationId: "CreateDomesticScheduledPayments"
+      parameters:
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-idempotency-key"
+        - $ref: "#/components/parameters/x-jws-signature"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      requestBody:
+        content:
+          application/json; charset=utf-8:
+            schema:
+              $ref: "#/components/schemas/OBWriteDomesticScheduled2"
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OBWriteDomesticScheduled2"
+          application/jose+jwe:
+            schema:
+              $ref: "#/components/schemas/OBWriteDomesticScheduled2"
+        description: "Default"
+        required: true
+      responses:
+        201:
+          $ref: "#/components/responses/201DomesticScheduledPaymentsCreated"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        415:
+          $ref: "#/components/responses/415Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - PSUOAuth2Security:
+            - "payments"
+  /domestic-scheduled-payments/{DomesticScheduledPaymentId}:
+    get:
+      tags:
+        - "Domestic Scheduled Payments"
+      summary: "Get Domestic Scheduled Payments"
+      operationId: "GetDomesticScheduledPaymentsDomesticScheduledPaymentId"
+      parameters:
+        - $ref: "#/components/parameters/DomesticScheduledPaymentId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200DomesticScheduledPaymentsDomesticScheduledPaymentIdRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - TPPOAuth2Security:
+            - "payments"
+  /domestic-scheduled-payments/{DomesticScheduledPaymentId}/payment-details:
+    get:
+      tags:
+        - "Payment Details"
+      summary: "Get Payment Details"
+      operationId: "GetDomesticScheduledPaymentsDomesticScheduledPaymentIdPaymentDetails"
+      parameters:
+        - $ref: "#/components/parameters/DomesticScheduledPaymentId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200DomesticScheduledPaymentsDomesticScheduledPaymentIdPaymentDetailsRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - TPPOAuth2Security:
+            - "payments"
+  /domestic-standing-order-consents:
+    post:
+      tags:
+        - "Domestic Standing Orders"
+      summary: "Create Domestic Standing Order Consents"
+      operationId: "CreateDomesticStandingOrderConsents"
+      parameters:
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-idempotency-key"
+        - $ref: "#/components/parameters/x-jws-signature"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      requestBody:
+        content:
+          application/json; charset=utf-8:
+            schema:
+              $ref: "#/components/schemas/OBWriteDomesticStandingOrderConsent5"
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OBWriteDomesticStandingOrderConsent5"
+          application/jose+jwe:
+            schema:
+              $ref: "#/components/schemas/OBWriteDomesticStandingOrderConsent5"
+        description: "Default"
+        required: true
+      responses:
+        201:
+          $ref: "#/components/responses/201DomesticStandingOrderConsentsCreated"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        415:
+          $ref: "#/components/responses/415Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - TPPOAuth2Security:
+            - "payments"
+  /domestic-standing-order-consents/{ConsentId}:
+    get:
+      tags:
+        - "Domestic Standing Orders"
+      summary: "Get Domestic Standing Order Consents"
+      operationId: "GetDomesticStandingOrderConsentsConsentId"
+      parameters:
+        - $ref: "#/components/parameters/ConsentId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200DomesticStandingOrderConsentsConsentIdRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - TPPOAuth2Security:
+            - "payments"
+  /domestic-standing-orders:
+    post:
+      tags:
+        - "Domestic Standing Orders"
+      summary: "Create Domestic Standing Orders"
+      operationId: "CreateDomesticStandingOrders"
+      parameters:
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-idempotency-key"
+        - $ref: "#/components/parameters/x-jws-signature"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      requestBody:
+        content:
+          application/json; charset=utf-8:
+            schema:
+              $ref: "#/components/schemas/OBWriteDomesticStandingOrder3"
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OBWriteDomesticStandingOrder3"
+          application/jose+jwe:
+            schema:
+              $ref: "#/components/schemas/OBWriteDomesticStandingOrder3"
+        description: "Default"
+        required: true
+      responses:
+        201:
+          $ref: "#/components/responses/201DomesticStandingOrdersCreated"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        415:
+          $ref: "#/components/responses/415Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - PSUOAuth2Security:
+            - "payments"
+  /domestic-standing-orders/{DomesticStandingOrderId}:
+    get:
+      tags:
+        - "Domestic Standing Orders"
+      summary: "Get Domestic Standing Orders"
+      operationId: "GetDomesticStandingOrdersDomesticStandingOrderId"
+      parameters:
+        - $ref: "#/components/parameters/DomesticStandingOrderId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200DomesticStandingOrdersDomesticStandingOrderIdRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - TPPOAuth2Security:
+            - "payments"
+  /domestic-standing-orders/{DomesticStandingOrderId}/payment-details:
+    get:
+      tags:
+        - "Payment Details"
+      summary: "Get Payment Details"
+      operationId: "GetDomesticStandingOrdersDomesticStandingOrderIdPaymentDetails"
+      parameters:
+        - $ref: "#/components/parameters/DomesticStandingOrderId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200DomesticStandingOrdersDomesticStandingOrderIdPaymentDetailsRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - TPPOAuth2Security:
+            - "payments"
+  /file-payment-consents:
+    post:
+      tags:
+        - "File Payments"
+      summary: "Create File Payment Consents"
+      operationId: "CreateFilePaymentConsents"
+      parameters:
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-idempotency-key"
+        - $ref: "#/components/parameters/x-jws-signature"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      requestBody:
+        content:
+          application/json; charset=utf-8:
+            schema:
+              $ref: "#/components/schemas/OBWriteFileConsent3"
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OBWriteFileConsent3"
+          application/jose+jwe:
+            schema:
+              $ref: "#/components/schemas/OBWriteFileConsent3"
+        description: "Default"
+        required: true
+      responses:
+        201:
+          $ref: "#/components/responses/201FilePaymentConsentsCreated"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        415:
+          $ref: "#/components/responses/415Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - TPPOAuth2Security:
+            - "payments"
+  /file-payment-consents/{ConsentId}:
+    get:
+      tags:
+        - "File Payments"
+      summary: "Get File Payment Consents"
+      operationId: "GetFilePaymentConsentsConsentId"
+      parameters:
+        - $ref: "#/components/parameters/ConsentId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200FilePaymentConsentsConsentIdRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - TPPOAuth2Security:
+            - "payments"
+  /file-payment-consents/{ConsentId}/file:
+    post:
+      tags:
+        - "File Payments"
+      summary: "Create File Payment Consents"
+      operationId: "CreateFilePaymentConsentsConsentIdFile"
+      parameters:
+        - $ref: "#/components/parameters/ConsentId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-idempotency-key"
+        - $ref: "#/components/parameters/x-jws-signature"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      requestBody:
+        content:
+          application/json; charset=utf-8:
+            schema:
+              $ref: "#/components/schemas/File"
+          application/json:
+            schema:
+              $ref: "#/components/schemas/File"
+          application/jose+jwe:
+            schema:
+              $ref: "#/components/schemas/File"
+        description: "Default"
+        required: true
+      responses:
+        200:
+          $ref: "#/components/responses/200FilePaymentConsentsConsentIdFileCreated"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        415:
+          $ref: "#/components/responses/415Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - TPPOAuth2Security:
+            - "payments"
+    get:
+      tags:
+        - "File Payments"
+      summary: "Get File Payment Consents"
+      operationId: "GetFilePaymentConsentsConsentIdFile"
+      parameters:
+        - $ref: "#/components/parameters/ConsentId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200FilePaymentConsentsConsentIdFileRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - TPPOAuth2Security:
+            - "payments"
+  /file-payments:
+    post:
+      tags:
+        - "File Payments"
+      summary: "Create File Payments"
+      operationId: "CreateFilePayments"
+      parameters:
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-idempotency-key"
+        - $ref: "#/components/parameters/x-jws-signature"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      requestBody:
+        content:
+          application/json; charset=utf-8:
+            schema:
+              $ref: "#/components/schemas/OBWriteFile2"
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OBWriteFile2"
+          application/jose+jwe:
+            schema:
+              $ref: "#/components/schemas/OBWriteFile2"
+        description: "Default"
+        required: true
+      responses:
+        201:
+          $ref: "#/components/responses/201FilePaymentsCreated"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        415:
+          $ref: "#/components/responses/415Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - PSUOAuth2Security:
+            - "payments"
+  /file-payments/{FilePaymentId}:
+    get:
+      tags:
+        - "File Payments"
+      summary: "Get File Payments"
+      operationId: "GetFilePaymentsFilePaymentId"
+      parameters:
+        - $ref: "#/components/parameters/FilePaymentId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200FilePaymentsFilePaymentIdRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - TPPOAuth2Security:
+            - "payments"
+  /file-payments/{FilePaymentId}/payment-details:
+    get:
+      tags:
+        - "Payment Details"
+      summary: "Get Payment Details"
+      operationId: "GetFilePaymentsFilePaymentIdPaymentDetails"
+      parameters:
+        - $ref: "#/components/parameters/FilePaymentId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200FilePaymentsFilePaymentIdPaymentDetailsRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - TPPOAuth2Security:
+            - "payments"
+  /file-payments/{FilePaymentId}/report-file:
+    get:
+      tags:
+        - "File Payments"
+      summary: "Get File Payments"
+      operationId: "GetFilePaymentsFilePaymentIdReportFile"
+      parameters:
+        - $ref: "#/components/parameters/FilePaymentId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200FilePaymentsFilePaymentIdReportFileRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - TPPOAuth2Security:
+            - "payments"
+  /international-payment-consents:
+    post:
+      tags:
+        - "International Payments"
+      summary: "Create International Payment Consents"
+      operationId: "CreateInternationalPaymentConsents"
+      parameters:
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-idempotency-key"
+        - $ref: "#/components/parameters/x-jws-signature"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      requestBody:
+        content:
+          application/json; charset=utf-8:
+            schema:
+              $ref: "#/components/schemas/OBWriteInternationalConsent5"
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OBWriteInternationalConsent5"
+          application/jose+jwe:
+            schema:
+              $ref: "#/components/schemas/OBWriteInternationalConsent5"
+        description: "Default"
+        required: true
+      responses:
+        201:
+          $ref: "#/components/responses/201InternationalPaymentConsentsCreated"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        415:
+          $ref: "#/components/responses/415Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - TPPOAuth2Security:
+            - "payments"
+  /international-payment-consents/{ConsentId}:
+    get:
+      tags:
+        - "International Payments"
+      summary: "Get International Payment Consents"
+      operationId: "GetInternationalPaymentConsentsConsentId"
+      parameters:
+        - $ref: "#/components/parameters/ConsentId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200InternationalPaymentConsentsConsentIdRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - TPPOAuth2Security:
+            - "payments"
+  /international-payment-consents/{ConsentId}/funds-confirmation:
+    get:
+      tags:
+        - "International Payments"
+      summary: "Get International Payment Consents Funds Confirmation"
+      operationId: "GetInternationalPaymentConsentsConsentIdFundsConfirmation"
+      parameters:
+        - $ref: "#/components/parameters/ConsentId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200InternationalPaymentConsentsConsentIdFundsConfirmationRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - PSUOAuth2Security:
+            - "payments"
+  /international-payments:
+    post:
+      tags:
+        - "International Payments"
+      summary: "Create International Payments"
+      operationId: "CreateInternationalPayments"
+      parameters:
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-idempotency-key"
+        - $ref: "#/components/parameters/x-jws-signature"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      requestBody:
+        content:
+          application/json; charset=utf-8:
+            schema:
+              $ref: "#/components/schemas/OBWriteInternational3"
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OBWriteInternational3"
+          application/jose+jwe:
+            schema:
+              $ref: "#/components/schemas/OBWriteInternational3"
+        description: "Default"
+        required: true
+      responses:
+        201:
+          $ref: "#/components/responses/201InternationalPaymentsCreated"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        415:
+          $ref: "#/components/responses/415Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - PSUOAuth2Security:
+            - "payments"
+  /international-payments/{InternationalPaymentId}:
+    get:
+      tags:
+        - "International Payments"
+      summary: "Get International Payments"
+      operationId: "GetInternationalPaymentsInternationalPaymentId"
+      parameters:
+        - $ref: "#/components/parameters/InternationalPaymentId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200InternationalPaymentsInternationalPaymentIdRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - TPPOAuth2Security:
+            - "payments"
+  /international-payments/{InternationalPaymentId}/payment-details:
+    get:
+      tags:
+        - "Payment Details"
+      summary: "Get Payment Details"
+      operationId: "GetInternationalPaymentsInternationalPaymentIdPaymentDetails"
+      parameters:
+        - $ref: "#/components/parameters/InternationalPaymentId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200InternationalPaymentsInternationalPaymentIdPaymentDetailsRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - TPPOAuth2Security:
+            - "payments"
+  /international-scheduled-payment-consents:
+    post:
+      tags:
+        - "International Scheduled Payments"
+      summary: "Create International Scheduled Payment Consents"
+      operationId: "CreateInternationalScheduledPaymentConsents"
+      parameters:
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-idempotency-key"
+        - $ref: "#/components/parameters/x-jws-signature"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      requestBody:
+        content:
+          application/json; charset=utf-8:
+            schema:
+              $ref: "#/components/schemas/OBWriteInternationalScheduledConsent5"
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OBWriteInternationalScheduledConsent5"
+          application/jose+jwe:
+            schema:
+              $ref: "#/components/schemas/OBWriteInternationalScheduledConsent5"
+        description: "Default"
+        required: true
+      responses:
+        201:
+          $ref: "#/components/responses/201InternationalScheduledPaymentConsentsCreated"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        415:
+          $ref: "#/components/responses/415Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - TPPOAuth2Security:
+            - "payments"
+  /international-scheduled-payment-consents/{ConsentId}:
+    get:
+      tags:
+        - "International Scheduled Payments"
+      summary: "Get International Scheduled Payment Consents"
+      operationId: "GetInternationalScheduledPaymentConsentsConsentId"
+      parameters:
+        - $ref: "#/components/parameters/ConsentId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200InternationalScheduledPaymentConsentsConsentIdRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - TPPOAuth2Security:
+            - "payments"
+  /international-scheduled-payment-consents/{ConsentId}/funds-confirmation:
+    get:
+      tags:
+        - "International Scheduled Payments"
+      summary: "Get International Scheduled Payment Consents Funds Confirmation"
+      operationId: "GetInternationalScheduledPaymentConsentsConsentIdFundsConfirmation"
+      parameters:
+        - $ref: "#/components/parameters/ConsentId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200InternationalScheduledPaymentConsentsConsentIdFundsConfirmationRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - PSUOAuth2Security:
+            - "payments"
+  /international-scheduled-payments:
+    post:
+      tags:
+        - "International Scheduled Payments"
+      summary: "Create International Scheduled Payments"
+      operationId: "CreateInternationalScheduledPayments"
+      parameters:
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-idempotency-key"
+        - $ref: "#/components/parameters/x-jws-signature"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      requestBody:
+        content:
+          application/json; charset=utf-8:
+            schema:
+              $ref: "#/components/schemas/OBWriteInternationalScheduled3"
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OBWriteInternationalScheduled3"
+          application/jose+jwe:
+            schema:
+              $ref: "#/components/schemas/OBWriteInternationalScheduled3"
+        description: "Default"
+        required: true
+      responses:
+        201:
+          $ref: "#/components/responses/201InternationalScheduledPaymentsCreated"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        415:
+          $ref: "#/components/responses/415Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - PSUOAuth2Security:
+            - "payments"
+  /international-scheduled-payments/{InternationalScheduledPaymentId}:
+    get:
+      tags:
+        - "International Scheduled Payments"
+      summary: "Get International Scheduled Payments"
+      operationId: "GetInternationalScheduledPaymentsInternationalScheduledPaymentId"
+      parameters:
+        - $ref: "#/components/parameters/InternationalScheduledPaymentId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200InternationalScheduledPaymentsInternationalScheduledPaymentIdRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - TPPOAuth2Security:
+            - "payments"
+  /international-scheduled-payments/{InternationalScheduledPaymentId}/payment-details:
+    get:
+      tags:
+        - "Payment Details"
+      summary: "Get Payment Details"
+      operationId: "GetInternationalScheduledPaymentsInternationalScheduledPaymentIdPaymentDetails"
+      parameters:
+        - $ref: "#/components/parameters/InternationalScheduledPaymentId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200InternationalScheduledPaymentsInternationalScheduledPaymentIdPaymentDetailsRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - TPPOAuth2Security:
+            - "payments"
+  /international-standing-order-consents:
+    post:
+      tags:
+        - "International Standing Orders"
+      summary: "Create International Standing Order Consents"
+      operationId: "CreateInternationalStandingOrderConsents"
+      parameters:
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-idempotency-key"
+        - $ref: "#/components/parameters/x-jws-signature"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      requestBody:
+        content:
+          application/json; charset=utf-8:
+            schema:
+              $ref: "#/components/schemas/OBWriteInternationalStandingOrderConsent6"
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OBWriteInternationalStandingOrderConsent6"
+          application/jose+jwe:
+            schema:
+              $ref: "#/components/schemas/OBWriteInternationalStandingOrderConsent6"
+        description: "Default"
+        required: true
+      responses:
+        201:
+          $ref: "#/components/responses/201InternationalStandingOrderConsentsCreated"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        415:
+          $ref: "#/components/responses/415Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - TPPOAuth2Security:
+            - "payments"
+  /international-standing-order-consents/{ConsentId}:
+    get:
+      tags:
+        - "International Standing Orders"
+      summary: "Get International Standing Order Consents"
+      operationId: "GetInternationalStandingOrderConsentsConsentId"
+      parameters:
+        - $ref: "#/components/parameters/ConsentId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200InternationalStandingOrderConsentsConsentIdRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - TPPOAuth2Security:
+            - "payments"
+  /international-standing-orders:
+    post:
+      tags:
+        - "International Standing Orders"
+      summary: "Create International Standing Orders"
+      operationId: "CreateInternationalStandingOrders"
+      parameters:
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-idempotency-key"
+        - $ref: "#/components/parameters/x-jws-signature"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      requestBody:
+        content:
+          application/json; charset=utf-8:
+            schema:
+              $ref: "#/components/schemas/OBWriteInternationalStandingOrder4"
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OBWriteInternationalStandingOrder4"
+          application/jose+jwe:
+            schema:
+              $ref: "#/components/schemas/OBWriteInternationalStandingOrder4"
+        description: "Default"
+        required: true
+      responses:
+        201:
+          $ref: "#/components/responses/201InternationalStandingOrdersCreated"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        415:
+          $ref: "#/components/responses/415Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - PSUOAuth2Security:
+            - "payments"
+  /international-standing-orders/{InternationalStandingOrderPaymentId}:
+    get:
+      tags:
+        - "International Standing Orders"
+      summary: "Get International Standing Orders"
+      operationId: "GetInternationalStandingOrdersInternationalStandingOrderPaymentId"
+      parameters:
+        - $ref: "#/components/parameters/InternationalStandingOrderPaymentId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200InternationalStandingOrdersInternationalStandingOrderPaymentIdRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - TPPOAuth2Security:
+            - "payments"
+  /international-standing-orders/{InternationalStandingOrderPaymentId}/payment-details:
+    get:
+      tags:
+        - "Payment Details"
+      summary: "Get Payment Details"
+      operationId: "GetInternationalStandingOrdersInternationalStandingOrderPaymentIdPaymentDetails"
+      parameters:
+        - $ref: "#/components/parameters/InternationalStandingOrderPaymentId"
+        - $ref: "#/components/parameters/x-fapi-auth-date"
+        - $ref: "#/components/parameters/x-fapi-customer-ip-address"
+        - $ref: "#/components/parameters/x-fapi-interaction-id"
+        - $ref: "#/components/parameters/Authorization"
+        - $ref: "#/components/parameters/x-customer-user-agent"
+      responses:
+        200:
+          $ref: "#/components/responses/200InternationalStandingOrdersInternationalStandingOrderPaymentIdPaymentDetailsRead"
+        400:
+          $ref: "#/components/responses/400Error"
+        401:
+          $ref: "#/components/responses/401Error"
+        403:
+          $ref: "#/components/responses/403Error"
+        404:
+          $ref: "#/components/responses/404Error"
+        405:
+          $ref: "#/components/responses/405Error"
+        406:
+          $ref: "#/components/responses/406Error"
+        429:
+          $ref: "#/components/responses/429Error"
+        500:
+          $ref: "#/components/responses/500Error"
+      security:
+        - TPPOAuth2Security:
+            - "payments"
+servers:
+  - url: "/open-banking/v3.1/pisp"
+components:
+  parameters:
+    ConsentId:
+      name: "ConsentId"
+      in: "path"
+      description: "ConsentId"
+      required: true
+      schema:
+        type: "string"
+    DomesticPaymentId:
+      name: "DomesticPaymentId"
+      in: "path"
+      description: "DomesticPaymentId"
+      required: true
+      schema:
+        type: "string"
+    DomesticScheduledPaymentId:
+      name: "DomesticScheduledPaymentId"
+      in: "path"
+      description: "DomesticScheduledPaymentId"
+      required: true
+      schema:
+        type: "string"
+    DomesticStandingOrderId:
+      name: "DomesticStandingOrderId"
+      in: "path"
+      description: "DomesticStandingOrderId"
+      required: true
+      schema:
+        type: "string"
+    FilePaymentId:
+      name: "FilePaymentId"
+      in: "path"
+      description: "FilePaymentId"
+      required: true
+      schema:
+        type: "string"
+    InternationalPaymentId:
+      name: "InternationalPaymentId"
+      in: "path"
+      description: "InternationalPaymentId"
+      required: true
+      schema:
+        type: "string"
+    InternationalScheduledPaymentId:
+      name: "InternationalScheduledPaymentId"
+      in: "path"
+      description: "InternationalScheduledPaymentId"
+      required: true
+      schema:
+        type: "string"
+    InternationalStandingOrderPaymentId:
+      name: "InternationalStandingOrderPaymentId"
+      in: "path"
+      description: "InternationalStandingOrderPaymentId"
+      required: true
+      schema:
+        type: "string"
+    Authorization:
+      in: "header"
+      name: "Authorization"
+      required: true
+      description: "An Authorisation Token as per https://tools.ietf.org/html/rfc6750"
+      schema:
+        type: "string"
+    x-customer-user-agent:
+      in: "header"
+      name: "x-customer-user-agent"
+      description: "Indicates the user-agent that the PSU is using."
+      required: false
+      schema:
+        type: "string"
+    x-fapi-customer-ip-address:
+      in: "header"
+      name: "x-fapi-customer-ip-address"
+      required: false
+      description: "The PSU's IP address if the PSU is currently logged in with the TPP."
+      schema:
+        type: "string"
+    x-fapi-auth-date:
+      in: "header"
+      name: "x-fapi-auth-date"
+      required: false
+      description: "The time when the PSU last logged in with the TPP. \nAll dates in the HTTP headers are represented as RFC 7231 Full Dates. An example is below: \nSun, 10 Sep 2017 19:43:31 UTC"
+      schema:
+        type: "string"
+        pattern: "^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), \\d{2} (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \\d{4} \\d{2}:\\d{2}:\\d{2} (GMT|UTC)$"
+    x-fapi-interaction-id:
+      in: "header"
+      name: "x-fapi-interaction-id"
+      required: false
+      description: "An RFC4122 UID used as a correlation id."
+      schema:
+        type: "string"
+    x-idempotency-key:
+      name: "x-idempotency-key"
+      in: "header"
+      description: "Every request will be processed only once per x-idempotency-key.  The\nIdempotency Key will be valid for 24 hours.\n"
+      required: true
+      schema:
+        type: "string"
+        maxLength: 40
+        pattern: "^(?!\\s)(.*)(\\S)$"
+    x-jws-signature:
+      in: "header"
+      name: "x-jws-signature"
+      required: true
+      description: "A detached JWS signature of the body of the payload."
+      schema:
+        type: "string"
+  responses:
+    201DomesticPaymentConsentsCreated:
+      description: "Domestic Payment Consents Created"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBWriteDomesticConsentResponse5"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBWriteDomesticConsentResponse5"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBWriteDomesticConsentResponse5"
+    200DomesticPaymentConsentsConsentIdRead:
+      description: "Domestic Payment Consents Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBWriteDomesticConsentResponse5"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBWriteDomesticConsentResponse5"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBWriteDomesticConsentResponse5"
+    200DomesticPaymentConsentsConsentIdFundsConfirmationRead:
+      description: "Domestic Payment Consents Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBWriteFundsConfirmationResponse1"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBWriteFundsConfirmationResponse1"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBWriteFundsConfirmationResponse1"
+    201DomesticPaymentsCreated:
+      description: "Domestic Payments Created"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBWriteDomesticResponse5"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBWriteDomesticResponse5"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBWriteDomesticResponse5"
+    200DomesticPaymentsDomesticPaymentIdRead:
+      description: "Domestic Payments Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBWriteDomesticResponse5"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBWriteDomesticResponse5"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBWriteDomesticResponse5"
+    200DomesticPaymentsDomesticPaymentIdPaymentDetailsRead:
+      description: "Payment Details Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBWritePaymentDetailsResponse1"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBWritePaymentDetailsResponse1"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBWritePaymentDetailsResponse1"
+    201DomesticScheduledPaymentConsentsCreated:
+      description: "Domestic Scheduled Payment Consents Created"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBWriteDomesticScheduledConsentResponse5"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBWriteDomesticScheduledConsentResponse5"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBWriteDomesticScheduledConsentResponse5"
+    200DomesticScheduledPaymentConsentsConsentIdRead:
+      description: "Domestic Scheduled Payment Consents Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBWriteDomesticScheduledConsentResponse5"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBWriteDomesticScheduledConsentResponse5"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBWriteDomesticScheduledConsentResponse5"
+    201DomesticScheduledPaymentsCreated:
+      description: "Domestic Scheduled Payments Created"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBWriteDomesticScheduledResponse5"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBWriteDomesticScheduledResponse5"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBWriteDomesticScheduledResponse5"
+    200DomesticScheduledPaymentsDomesticScheduledPaymentIdRead:
+      description: "Domestic Scheduled Payments Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBWriteDomesticScheduledResponse5"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBWriteDomesticScheduledResponse5"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBWriteDomesticScheduledResponse5"
+    200DomesticScheduledPaymentsDomesticScheduledPaymentIdPaymentDetailsRead:
+      description: "Payment Details Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBWritePaymentDetailsResponse1"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBWritePaymentDetailsResponse1"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBWritePaymentDetailsResponse1"
+    201DomesticStandingOrderConsentsCreated:
+      description: "Domestic Standing Order Consents Created"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBWriteDomesticStandingOrderConsentResponse6"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBWriteDomesticStandingOrderConsentResponse6"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBWriteDomesticStandingOrderConsentResponse6"
+    200DomesticStandingOrderConsentsConsentIdRead:
+      description: "Domestic Standing Order Consents Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBWriteDomesticStandingOrderConsentResponse6"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBWriteDomesticStandingOrderConsentResponse6"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBWriteDomesticStandingOrderConsentResponse6"
+    201DomesticStandingOrdersCreated:
+      description: "Domestic Standing Orders Created"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBWriteDomesticStandingOrderResponse6"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBWriteDomesticStandingOrderResponse6"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBWriteDomesticStandingOrderResponse6"
+    200DomesticStandingOrdersDomesticStandingOrderIdRead:
+      description: "Domestic Standing Orders Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBWriteDomesticStandingOrderResponse6"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBWriteDomesticStandingOrderResponse6"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBWriteDomesticStandingOrderResponse6"
+    200DomesticStandingOrdersDomesticStandingOrderIdPaymentDetailsRead:
+      description: "Payment Details Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBWritePaymentDetailsResponse1"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBWritePaymentDetailsResponse1"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBWritePaymentDetailsResponse1"
+    201FilePaymentConsentsCreated:
+      description: "File Payment Consents Created"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBWriteFileConsentResponse4"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBWriteFileConsentResponse4"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBWriteFileConsentResponse4"
+    200FilePaymentConsentsConsentIdFileCreated:
+      description: "File Payment Consents Created"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+    200FilePaymentConsentsConsentIdRead:
+      description: "File Payment Consents Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBWriteFileConsentResponse4"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBWriteFileConsentResponse4"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBWriteFileConsentResponse4"
+    200FilePaymentConsentsConsentIdFileRead:
+      description: "File Payment Consents Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/File"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/File"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/File"
+    201FilePaymentsCreated:
+      description: "File Payments Created"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBWriteFileResponse3"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBWriteFileResponse3"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBWriteFileResponse3"
+    200FilePaymentsFilePaymentIdRead:
+      description: "File Payments Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBWriteFileResponse3"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBWriteFileResponse3"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBWriteFileResponse3"
+    200FilePaymentsFilePaymentIdReportFileRead:
+      description: "File Payments Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/File"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/File"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/File"
+    200FilePaymentsFilePaymentIdPaymentDetailsRead:
+      description: "Payment Details Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBWritePaymentDetailsResponse1"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBWritePaymentDetailsResponse1"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBWritePaymentDetailsResponse1"
+    201InternationalPaymentConsentsCreated:
+      description: "International Payment Consents Created"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBWriteInternationalConsentResponse6"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBWriteInternationalConsentResponse6"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBWriteInternationalConsentResponse6"
+    200InternationalPaymentConsentsConsentIdRead:
+      description: "International Payment Consents Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBWriteInternationalConsentResponse6"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBWriteInternationalConsentResponse6"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBWriteInternationalConsentResponse6"
+    200InternationalPaymentConsentsConsentIdFundsConfirmationRead:
+      description: "International Payment Consents Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBWriteFundsConfirmationResponse1"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBWriteFundsConfirmationResponse1"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBWriteFundsConfirmationResponse1"
+    201InternationalPaymentsCreated:
+      description: "International Payments Created"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBWriteInternationalResponse5"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBWriteInternationalResponse5"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBWriteInternationalResponse5"
+    200InternationalPaymentsInternationalPaymentIdRead:
+      description: "International Payments Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBWriteInternationalResponse5"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBWriteInternationalResponse5"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBWriteInternationalResponse5"
+    200InternationalPaymentsInternationalPaymentIdPaymentDetailsRead:
+      description: "Payment Details Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBWritePaymentDetailsResponse1"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBWritePaymentDetailsResponse1"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBWritePaymentDetailsResponse1"
+    201InternationalScheduledPaymentConsentsCreated:
+      description: "International Scheduled Payment Consents Created"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBWriteInternationalScheduledConsentResponse6"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBWriteInternationalScheduledConsentResponse6"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBWriteInternationalScheduledConsentResponse6"
+    200InternationalScheduledPaymentConsentsConsentIdRead:
+      description: "International Scheduled Payment Consents Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBWriteInternationalScheduledConsentResponse6"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBWriteInternationalScheduledConsentResponse6"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBWriteInternationalScheduledConsentResponse6"
+    200InternationalScheduledPaymentConsentsConsentIdFundsConfirmationRead:
+      description: "International Scheduled Payment Consents Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBWriteFundsConfirmationResponse1"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBWriteFundsConfirmationResponse1"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBWriteFundsConfirmationResponse1"
+    201InternationalScheduledPaymentsCreated:
+      description: "International Scheduled Payments Created"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBWriteInternationalScheduledResponse6"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBWriteInternationalScheduledResponse6"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBWriteInternationalScheduledResponse6"
+    200InternationalScheduledPaymentsInternationalScheduledPaymentIdRead:
+      description: "International Scheduled Payments Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBWriteInternationalScheduledResponse6"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBWriteInternationalScheduledResponse6"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBWriteInternationalScheduledResponse6"
+    200InternationalScheduledPaymentsInternationalScheduledPaymentIdPaymentDetailsRead:
+      description: "Payment Details Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBWritePaymentDetailsResponse1"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBWritePaymentDetailsResponse1"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBWritePaymentDetailsResponse1"
+    201InternationalStandingOrderConsentsCreated:
+      description: "International Standing Order Consents Created"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBWriteInternationalStandingOrderConsentResponse7"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBWriteInternationalStandingOrderConsentResponse7"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBWriteInternationalStandingOrderConsentResponse7"
+    200InternationalStandingOrderConsentsConsentIdRead:
+      description: "International Standing Order Consents Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBWriteInternationalStandingOrderConsentResponse7"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBWriteInternationalStandingOrderConsentResponse7"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBWriteInternationalStandingOrderConsentResponse7"
+    201InternationalStandingOrdersCreated:
+      description: "International Standing Orders Created"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBWriteInternationalStandingOrderResponse7"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBWriteInternationalStandingOrderResponse7"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBWriteInternationalStandingOrderResponse7"
+    200InternationalStandingOrdersInternationalStandingOrderPaymentIdRead:
+      description: "International Standing Orders Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBWriteInternationalStandingOrderResponse7"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBWriteInternationalStandingOrderResponse7"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBWriteInternationalStandingOrderResponse7"
+    200InternationalStandingOrdersInternationalStandingOrderPaymentIdPaymentDetailsRead:
+      description: "Payment Details Read"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBWritePaymentDetailsResponse1"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBWritePaymentDetailsResponse1"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBWritePaymentDetailsResponse1"
+    400Error:
+      description: "Bad request"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBErrorResponse1"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBErrorResponse1"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBErrorResponse1"
+    401Error:
+      description: "Unauthorized"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+    403Error:
+      description: "Forbidden"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBErrorResponse1"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBErrorResponse1"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBErrorResponse1"
+    404Error:
+      description: "Not found"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+    405Error:
+      description: "Method Not Allowed"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+    406Error:
+      description: "Not Acceptable"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+    415Error:
+      description: "Unsupported Media Type"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+    429Error:
+      description: "Too Many Requests"
+      headers:
+        Retry-After:
+          description: "Number in seconds to wait"
+          schema:
+            type: "integer"
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+    500Error:
+      description: "Internal Server Error"
+      headers:
+        x-fapi-interaction-id:
+          description: "An RFC4122 UID used as a correlation id."
+          required: true
+          schema:
+            type: "string"
+        x-jws-signature:
+          description: "Header containing a detached JWS signature of the body of the payload.\n"
+          required: true
+          schema:
+            type: "string"
+      content:
+        application/json; charset=utf-8:
+          schema:
+            $ref: "#/components/schemas/OBErrorResponse1"
+        application/json:
+          schema:
+            $ref: "#/components/schemas/OBErrorResponse1"
+        application/jose+jwe:
+          schema:
+            $ref: "#/components/schemas/OBErrorResponse1"
+  securitySchemes:
+    TPPOAuth2Security:
+      type: "oauth2"
+      description: "TPP client credential authorisation flow with the ASPSP"
+      flows:
+        clientCredentials:
+          tokenUrl: "https://authserver.example/token"
+          scopes:
+            payments: "Generic payment scope"
+    PSUOAuth2Security:
+      type: "oauth2"
+      description: "OAuth flow, it is required when the PSU needs to perform SCA with the ASPSP when a TPP wants to access an ASPSP resource owned by the PSU"
+      flows:
+        authorizationCode:
+          authorizationUrl: "https://authserver.example/authorization"
+          tokenUrl: "https://authserver.example/token"
+          scopes:
+            payments: "Generic payment scope"
+  schemas:
+    ActiveOrHistoricCurrencyCode:
+      description: "A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 \"Codes for the representation of currencies and funds\"."
+      type: "string"
+      pattern: "^[A-Z]{3,3}$"
+    BuildingNumber:
+      description: "Number that identifies the position of a building on a street."
+      type: "string"
+      minLength: 1
+      maxLength: 16
+    CountryCode:
+      description: "Nation with its own government."
+      type: "string"
+      pattern: "^[A-Z]{2,2}$"
+    CountrySubDivision:
+      description: "Identifies a subdivision of a country such as state, region, county."
+      type: "string"
+      minLength: 1
+      maxLength: 35
+    Department:
+      description: "Identification of a division of a large organisation or building."
+      type: "string"
+      minLength: 1
+      maxLength: 70
+    File:
+      type: "object"
+      additionalProperties: false
+      properties: { }
+    ISODateTime:
+      description: "All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+      type: "string"
+      format: "date-time"
+    Identification_0:
+      description: "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+      type: "string"
+      minLength: 1
+      maxLength: 256
+    Identification_1:
+      description: "Unique and unambiguous identification of a financial institution or a branch of a financial institution."
+      type: "string"
+      minLength: 1
+      maxLength: 35
+    Links:
+      type: "object"
+      additionalProperties: false
+      description: "Links relevant to the payload"
+      properties:
+        Self:
+          type: "string"
+          format: "uri"
+        First:
+          type: "string"
+          format: "uri"
+        Prev:
+          type: "string"
+          format: "uri"
+        Next:
+          type: "string"
+          format: "uri"
+        Last:
+          type: "string"
+          format: "uri"
+      required:
+        - "Self"
+    Meta:
+      title: "MetaData"
+      type: "object"
+      additionalProperties: false
+      description: "Meta Data relevant to the payload"
+      properties:
+        TotalPages:
+          type: "integer"
+          format: "int32"
+        FirstAvailableDateTime:
+          $ref: "#/components/schemas/ISODateTime"
+        LastAvailableDateTime:
+          $ref: "#/components/schemas/ISODateTime"
+    Name:
+      description: "Name by which an agent is known and which is usually used to identify that agent."
+      type: "string"
+      minLength: 1
+      maxLength: 140
+    OBActiveCurrencyAndAmount_SimpleType:
+      description: "A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217."
+      type: "string"
+      pattern: "^\\d{1,13}$|^\\d{1,13}\\.\\d{1,5}$"
+    OBActiveOrHistoricCurrencyAndAmount:
+      type: "object"
+      additionalProperties: false
+      required:
+        - "Amount"
+        - "Currency"
+      description: "Amount of money associated with the charge type."
+      properties:
+        Amount:
+          $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+        Currency:
+          $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode"
+    OBAddressTypeCode:
+      description: "Identifies the nature of the postal address."
+      type: "string"
+      enum:
+        - "Business"
+        - "Correspondence"
+        - "DeliveryTo"
+        - "MailTo"
+        - "POBox"
+        - "Postal"
+        - "Residential"
+        - "Statement"
+    OBChargeBearerType1Code:
+      description: "Specifies which party/parties will bear the charges associated with the processing of the payment transaction."
+      type: "string"
+      enum:
+        - "BorneByCreditor"
+        - "BorneByDebtor"
+        - "FollowingServiceLevel"
+        - "Shared"
+    OBCashAccountCreditor3:
+      type: "object"
+      properties:
+        SchemeName:
+          $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+        Identification:
+          type: "string"
+          description: "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+          maxLength: 256
+        Name:
+          type: "string"
+          description: "Name of the account, as assigned by the account servicing institution.  Usage The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account."
+        SecondaryIdentification:
+          type: "string"
+          description: "Secondary identification of the account, as assigned by the account servicing institution. This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+          maxLength: 34
+      required:
+        - "SchemeName"
+        - "Identification"
+        - "Name"
+    OBCashAccountDebtor4:
+      type: "object"
+      description: "^ Only incuded in the response if `Data. ReadRefundAccount` is set to `Yes` in the consent."
+      properties:
+        SchemeName:
+          type: "string"
+          description: "^ Name of the identification scheme, in a coded form as published in an external list. | Namespaced Enumeration OBExternalAccountIdentification4Code"
+        Identification:
+          type: "string"
+          description: "^ Identification assigned by an institution to identify an account. This identification is known by the account owner. | Max256Text"
+        Name:
+          type: "string"
+          description: "^ Name of the account, as assigned by the account servicing institution.  Usage The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account."
+        SecondaryIdentification:
+          type: "string"
+          description: "^ This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination) | Max34Text"
+    OBError1:
+      type: "object"
+      additionalProperties: false
+      properties:
+        ErrorCode:
+          description: "Low level textual error code, e.g., UK.OBIE.Field.Missing"
+          type: "string"
+          x-namespaced-enum:
+            - "UK.OBIE.Field.Expected"
+            - "UK.OBIE.Field.Invalid"
+            - "UK.OBIE.Field.InvalidDate"
+            - "UK.OBIE.Field.Missing"
+            - "UK.OBIE.Field.Unexpected"
+            - "UK.OBIE.Header.Invalid"
+            - "UK.OBIE.Header.Missing"
+            - "UK.OBIE.Reauthenticate"
+            - "UK.OBIE.Resource.ConsentMismatch"
+            - "UK.OBIE.Resource.InvalidConsentStatus"
+            - "UK.OBIE.Resource.InvalidFormat"
+            - "UK.OBIE.Resource.NotFound"
+            - "UK.OBIE.Rules.AfterCutOffDateTime"
+            - "UK.OBIE.Rules.DuplicateReference"
+            - "UK.OBIE.Signature.Invalid"
+            - "UK.OBIE.Signature.InvalidClaim"
+            - "UK.OBIE.Signature.Malformed"
+            - "UK.OBIE.Signature.Missing"
+            - "UK.OBIE.Signature.MissingClaim"
+            - "UK.OBIE.Signature.Unexpected"
+            - "UK.OBIE.UnexpectedError"
+            - "UK.OBIE.Unsupported.AccountIdentifier"
+            - "UK.OBIE.Unsupported.AccountSecondaryIdentifier"
+            - "UK.OBIE.Unsupported.Currency"
+            - "UK.OBIE.Unsupported.Frequency"
+            - "UK.OBIE.Unsupported.LocalInstrument"
+            - "UK.OBIE.Unsupported.Scheme"
+        Message:
+          description: "A description of the error that occurred. e.g., 'A mandatory field isn't supplied' or 'RequestedExecutionDateTime must be in future'\nOBIE doesn't standardise this field"
+          type: "string"
+          minLength: 1
+          maxLength: 500
+        Path:
+          description: "Recommended but optional reference to the JSON Path of the field with error, e.g., Data.Initiation.InstructedAmount.Currency"
+          type: "string"
+          minLength: 1
+          maxLength: 500
+        Url:
+          description: "URL to help remediate the problem, or provide more information, or to API Reference, or help etc"
+          type: "string"
+      required:
+        - "ErrorCode"
+        - "Message"
+      minProperties: 1
+    OBErrorResponse1:
+      description: "An array of detail error codes, and messages, and URLs to documentation to help remediation."
+      type: "object"
+      additionalProperties: false
+      properties:
+        Code:
+          description: "High level textual error code, to help categorize the errors."
+          type: "string"
+          minLength: 1
+          maxLength: 40
+        Id:
+          description: "A unique reference for the error instance, for audit purposes, in case of unknown/unclassified errors."
+          type: "string"
+          minLength: 1
+          maxLength: 40
+        Message:
+          description: "Brief Error message, e.g., 'There is something wrong with the request parameters provided'"
+          type: "string"
+          minLength: 1
+          maxLength: 500
+        Errors:
+          items:
+            $ref: "#/components/schemas/OBError1"
+          type: "array"
+          minItems: 1
+      required:
+        - "Code"
+        - "Message"
+        - "Errors"
+    OBExternalAccountIdentification4Code:
+      description: "Name of the identification scheme, in a coded form as published in an external list."
+      type: "string"
+      x-namespaced-enum:
+        - "UK.OBIE.BBAN"
+        - "UK.OBIE.IBAN"
+        - "UK.OBIE.PAN"
+        - "UK.OBIE.Paym"
+        - "UK.OBIE.SortCodeAccountNumber"
+    OBExternalFinancialInstitutionIdentification4Code:
+      description: "Name of the identification scheme, in a coded form as published in an external list."
+      type: "string"
+      x-namespaced-enum:
+        - "UK.OBIE.BICFI"
+    OBExternalLocalInstrument1Code:
+      description: "User community specific instrument.\nUsage: This element is used to specify a local instrument, local clearing option and/or further qualify the service or service level."
+      type: "string"
+      x-namespaced-enum:
+        - "UK.OBIE.BACS"
+        - "UK.OBIE.BalanceTransfer"
+        - "UK.OBIE.CHAPS"
+        - "UK.OBIE.Euro1"
+        - "UK.OBIE.FPS"
+        - "UK.OBIE.Link"
+        - "UK.OBIE.MoneyTransfer"
+        - "UK.OBIE.Paym"
+        - "UK.OBIE.SEPACreditTransfer"
+        - "UK.OBIE.SEPAInstantCreditTransfer"
+        - "UK.OBIE.SWIFT"
+        - "UK.OBIE.Target2"
+    OBExternalPaymentChargeType1Code:
+      description: "Charge type, in a coded form."
+      type: "string"
+      x-namespaced-enum:
+        - "UK.OBIE.CHAPSOut"
+    OBPostalAddress6:
+      type: "object"
+      additionalProperties: false
+      description: "Information that locates and identifies a specific address, as defined by postal services."
+      properties:
+        AddressType:
+          $ref: "#/components/schemas/OBAddressTypeCode"
+        Department:
+          $ref: "#/components/schemas/Department"
+        SubDepartment:
+          $ref: "#/components/schemas/SubDepartment"
+        StreetName:
+          $ref: "#/components/schemas/StreetName"
+        BuildingNumber:
+          $ref: "#/components/schemas/BuildingNumber"
+        PostCode:
+          $ref: "#/components/schemas/PostCode"
+        TownName:
+          $ref: "#/components/schemas/TownName"
+        CountrySubDivision:
+          $ref: "#/components/schemas/CountrySubDivision"
+        Country:
+          $ref: "#/components/schemas/CountryCode"
+        AddressLine:
+          type: "array"
+          items:
+            description: "Information that locates and identifies a specific address, as defined by postal services, presented in free format text."
+            type: "string"
+            minLength: 1
+            maxLength: 70
+          minItems: 0
+          maxItems: 7
+    OBRisk1:
+      type: "object"
+      additionalProperties: false
+      description: "The Risk section is sent by the initiating party to the ASPSP. It is used to specify additional details for risk scoring for Payments."
+      properties:
+        PaymentContextCode:
+          description: "Specifies the payment context"
+          type: "string"
+          enum:
+            - "BillPayment"
+            - "EcommerceGoods"
+            - "EcommerceServices"
+            - "Other"
+            - "PartyToParty"
+        MerchantCategoryCode:
+          description: "Category code conform to ISO 18245, related to the type of services or goods the merchant provides for the transaction."
+          type: "string"
+          minLength: 3
+          maxLength: 4
+        MerchantCustomerIdentification:
+          description: "The unique customer identifier of the PSU with the merchant."
+          type: "string"
+          minLength: 1
+          maxLength: 70
+        DeliveryAddress:
+          type: "object"
+          additionalProperties: false
+          required:
+            - "TownName"
+            - "Country"
+          description: "Information that locates and identifies a specific address, as defined by postal services or in free format text."
+          properties:
+            AddressLine:
+              type: "array"
+              items:
+                description: "Information that locates and identifies a specific address, as defined by postal services, that is presented in free format text."
+                type: "string"
+                minLength: 1
+                maxLength: 70
+              minItems: 0
+              maxItems: 2
+            StreetName:
+              $ref: "#/components/schemas/StreetName"
+            BuildingNumber:
+              $ref: "#/components/schemas/BuildingNumber"
+            PostCode:
+              $ref: "#/components/schemas/PostCode"
+            TownName:
+              $ref: "#/components/schemas/TownName"
+            CountrySubDivision:
+              $ref: "#/components/schemas/CountrySubDivision"
+            Country:
+              description: "Nation with its own government, occupying a particular territory."
+              type: "string"
+              pattern: "^[A-Z]{2,2}$"
+    OBSCASupportData1:
+      type: "object"
+      properties:
+        RequestedSCAExemptionType:
+          type: "string"
+          description: "This field allows a PISP to request specific SCA Exemption for a Payment Initiation"
+          enum:
+            - "BillPayment"
+            - "ContactlessTravel"
+            - "EcommerceGoods"
+            - "EcommerceServices"
+            - "Kiosk"
+            - "Parking"
+            - "PartyToParty"
+        AppliedAuthenticationApproach:
+          type: "string"
+          maxLength: 40
+          description: "Specifies a character string with a maximum length of 40 characters.\nUsage: This field indicates whether the PSU was subject to SCA performed by the TPP"
+          enum:
+            - "CA"
+            - "SCA"
+        ReferencePaymentOrderId:
+          type: "string"
+          maxLength: 40
+          minLength: 1
+          description: "If the payment is recurring, then this field is populated with the transaction identifier of the previous payment occurrence so that the ASPSP can verify that the PISP, amount and the payee are the same as the previous occurrence. The value here refers to the payment id e.g. DomesticPaymentId  "
+      description: "Supporting Data provided by TPP, when requesting SCA Exemption."
+    OBSupplementaryData1:
+      type: "object"
+      properties: { }
+      additionalProperties: true
+      description: "Additional information that can not be captured in the structured fields and/or any other specific block."
+    OBWriteDomestic2:
+      type: "object"
+      additionalProperties: false
+      required:
+        - "Data"
+        - "Risk"
+      properties:
+        Data:
+          type: "object"
+          additionalProperties: false
+          required:
+            - "ConsentId"
+            - "Initiation"
+          properties:
+            ConsentId:
+              description: "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+              type: "string"
+              minLength: 1
+              maxLength: 128
+            Initiation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "InstructionIdentification"
+                - "EndToEndIdentification"
+                - "InstructedAmount"
+                - "CreditorAccount"
+              description: "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single domestic payment."
+              properties:
+                InstructionIdentification:
+                  description: "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction.\nUsage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                EndToEndIdentification:
+                  description: "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain.\nUsage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction.\nOB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                LocalInstrument:
+                  $ref: "#/components/schemas/OBExternalLocalInstrument1Code"
+                InstructedAmount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "Amount"
+                    - "Currency"
+                  description: "Amount of money to be moved between the debtor and creditor, before deduction of charges, expressed in the currency as ordered by the initiating party.\nUsage: This amount has to be transported unchanged through the transaction chain."
+                  properties:
+                    Amount:
+                      $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+                    Currency:
+                      $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode"
+                DebtorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                  description: "Unambiguous identification of the account of the debtor to which a debit entry will be made as a result of the transaction."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels.\nNote, the account name is not the product name or the nickname of the account."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                CreditorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                    - "Name"
+                  description: "Unambiguous identification of the account of the creditor to which a credit entry will be posted as a result of the payment transaction."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level.\nNote, the account name is not the product name or the nickname of the account.\nOB: ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                CreditorPostalAddress:
+                  $ref: "#/components/schemas/OBPostalAddress6"
+                RemittanceInformation:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Information supplied to enable the matching of an entry with the items that the transfer is intended to settle, such as commercial invoices in an accounts' receivable system."
+                  properties:
+                    Unstructured:
+                      description: "Information supplied to enable the matching/reconciliation of an entry with the items that the payment is intended to settle, such as commercial invoices in an accounts' receivable system, in an unstructured form."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 140
+                    Reference:
+                      description: "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction.\nUsage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money.\nIf the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.\nOB: The Faster Payments Scheme can only accept 18 characters for the ReferenceInformation field - which is where this ISO field will be mapped."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 35
+                SupplementaryData:
+                  $ref: "#/components/schemas/OBSupplementaryData1"
+        Risk:
+          $ref: "#/components/schemas/OBRisk1"
+    OBWriteDomesticConsent4:
+      type: "object"
+      additionalProperties: false
+      required:
+        - "Data"
+        - "Risk"
+      properties:
+        Data:
+          type: "object"
+          additionalProperties: false
+          required:
+            - "Initiation"
+          properties:
+            ReadRefundAccount:
+              description: "Specifies to share the refund account details with PISP"
+              type: "string"
+              enum:
+                - "No"
+                - "Yes"
+            Initiation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "InstructionIdentification"
+                - "EndToEndIdentification"
+                - "InstructedAmount"
+                - "CreditorAccount"
+              description: "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single domestic payment."
+              properties:
+                InstructionIdentification:
+                  description: "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction.\nUsage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                EndToEndIdentification:
+                  description: "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain.\nUsage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction.\nOB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                LocalInstrument:
+                  $ref: "#/components/schemas/OBExternalLocalInstrument1Code"
+                InstructedAmount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "Amount"
+                    - "Currency"
+                  description: "Amount of money to be moved between the debtor and creditor, before deduction of charges, expressed in the currency as ordered by the initiating party.\nUsage: This amount has to be transported unchanged through the transaction chain."
+                  properties:
+                    Amount:
+                      $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+                    Currency:
+                      $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode"
+                DebtorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                  description: "Unambiguous identification of the account of the debtor to which a debit entry will be made as a result of the transaction."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels.\nNote, the account name is not the product name or the nickname of the account."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                CreditorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                    - "Name"
+                  description: "Unambiguous identification of the account of the creditor to which a credit entry will be posted as a result of the payment transaction."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level.\nNote, the account name is not the product name or the nickname of the account.\nOB: ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                CreditorPostalAddress:
+                  $ref: "#/components/schemas/OBPostalAddress6"
+                RemittanceInformation:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Information supplied to enable the matching of an entry with the items that the transfer is intended to settle, such as commercial invoices in an accounts' receivable system."
+                  properties:
+                    Unstructured:
+                      description: "Information supplied to enable the matching/reconciliation of an entry with the items that the payment is intended to settle, such as commercial invoices in an accounts' receivable system, in an unstructured form."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 140
+                    Reference:
+                      description: "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction.\nUsage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money.\nIf the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.\nOB: The Faster Payments Scheme can only accept 18 characters for the ReferenceInformation field - which is where this ISO field will be mapped."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 35
+                SupplementaryData:
+                  $ref: "#/components/schemas/OBSupplementaryData1"
+            Authorisation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "AuthorisationType"
+              description: "The authorisation type request from the TPP."
+              properties:
+                AuthorisationType:
+                  description: "Type of authorisation flow requested."
+                  type: "string"
+                  enum:
+                    - "Any"
+                    - "Single"
+                CompletionDateTime:
+                  description: "Date and time at which the requested authorisation flow must be completed.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+            SCASupportData:
+              $ref: "#/components/schemas/OBSCASupportData1"
+        Risk:
+          $ref: "#/components/schemas/OBRisk1"
+    OBWriteDomesticConsentResponse5:
+      type: "object"
+      additionalProperties: false
+      required:
+        - "Data"
+        - "Risk"
+      properties:
+        Data:
+          type: "object"
+          additionalProperties: false
+          required:
+            - "ConsentId"
+            - "CreationDateTime"
+            - "Status"
+            - "StatusUpdateDateTime"
+            - "Initiation"
+          properties:
+            ConsentId:
+              description: "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+              type: "string"
+              minLength: 1
+              maxLength: 128
+            CreationDateTime:
+              description: "Date and time at which the resource was created.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            Status:
+              description: "Specifies the status of consent resource in code form."
+              type: "string"
+              enum:
+                - "Authorised"
+                - "AwaitingAuthorisation"
+                - "Consumed"
+                - "Rejected"
+            StatusUpdateDateTime:
+              description: "Date and time at which the resource status was updated.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            ReadRefundAccount:
+              description: "Specifies to share the refund account details with PISP"
+              type: "string"
+              enum:
+                - "No"
+                - "Yes"
+            CutOffDateTime:
+              description: "Specified cut-off date and time for the payment consent.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            ExpectedExecutionDateTime:
+              description: "Expected execution date and time for the payment resource.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            ExpectedSettlementDateTime:
+              description: "Expected settlement date and time for the payment resource.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            Charges:
+              type: "array"
+              items:
+                type: "object"
+                additionalProperties: false
+                description: "Set of elements used to provide details of a charge for the payment initiation."
+                required:
+                  - "ChargeBearer"
+                  - "Type"
+                  - "Amount"
+                properties:
+                  ChargeBearer:
+                    $ref: "#/components/schemas/OBChargeBearerType1Code"
+                  Type:
+                    $ref: "#/components/schemas/OBExternalPaymentChargeType1Code"
+                  Amount:
+                    $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount"
+            Initiation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "InstructionIdentification"
+                - "EndToEndIdentification"
+                - "InstructedAmount"
+                - "CreditorAccount"
+              description: "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single domestic payment."
+              properties:
+                InstructionIdentification:
+                  description: "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction.\nUsage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                EndToEndIdentification:
+                  description: "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain.\nUsage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction.\nOB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                LocalInstrument:
+                  $ref: "#/components/schemas/OBExternalLocalInstrument1Code"
+                InstructedAmount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "Amount"
+                    - "Currency"
+                  description: "Amount of money to be moved between the debtor and creditor, before deduction of charges, expressed in the currency as ordered by the initiating party.\nUsage: This amount has to be transported unchanged through the transaction chain."
+                  properties:
+                    Amount:
+                      $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+                    Currency:
+                      $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode"
+                DebtorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                  description: "Unambiguous identification of the account of the debtor to which a debit entry will be made as a result of the transaction."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels.\nNote, the account name is not the product name or the nickname of the account."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                CreditorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                    - "Name"
+                  description: "Unambiguous identification of the account of the creditor to which a credit entry will be posted as a result of the payment transaction."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level.\nNote, the account name is not the product name or the nickname of the account.\nOB: ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                CreditorPostalAddress:
+                  $ref: "#/components/schemas/OBPostalAddress6"
+                RemittanceInformation:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Information supplied to enable the matching of an entry with the items that the transfer is intended to settle, such as commercial invoices in an accounts' receivable system."
+                  properties:
+                    Unstructured:
+                      description: "Information supplied to enable the matching/reconciliation of an entry with the items that the payment is intended to settle, such as commercial invoices in an accounts' receivable system, in an unstructured form."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 140
+                    Reference:
+                      description: "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction.\nUsage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money.\nIf the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.\nOB: The Faster Payments Scheme can only accept 18 characters for the ReferenceInformation field - which is where this ISO field will be mapped."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 35
+                SupplementaryData:
+                  $ref: "#/components/schemas/OBSupplementaryData1"
+            Authorisation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "AuthorisationType"
+              description: "The authorisation type request from the TPP."
+              properties:
+                AuthorisationType:
+                  description: "Type of authorisation flow requested."
+                  type: "string"
+                  enum:
+                    - "Any"
+                    - "Single"
+                CompletionDateTime:
+                  description: "Date and time at which the requested authorisation flow must be completed.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+            SCASupportData:
+              $ref: "#/components/schemas/OBSCASupportData1"
+            Debtor:
+              $ref: "#/components/schemas/OBCashAccountDebtor4"
+        Risk:
+          $ref: "#/components/schemas/OBRisk1"
+        Links:
+          $ref: "#/components/schemas/Links"
+        Meta:
+          $ref: "#/components/schemas/Meta"
+    OBWriteDomesticResponse5:
+      type: "object"
+      additionalProperties: false
+      required:
+        - "Data"
+      properties:
+        Data:
+          type: "object"
+          additionalProperties: false
+          required:
+            - "DomesticPaymentId"
+            - "ConsentId"
+            - "CreationDateTime"
+            - "Status"
+            - "StatusUpdateDateTime"
+            - "Initiation"
+          properties:
+            DomesticPaymentId:
+              description: "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic payment resource."
+              type: "string"
+              minLength: 1
+              maxLength: 40
+            ConsentId:
+              description: "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+              type: "string"
+              minLength: 1
+              maxLength: 128
+            CreationDateTime:
+              description: "Date and time at which the message was created.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            Status:
+              description: "Specifies the status of the payment information group."
+              type: "string"
+              enum:
+                - "AcceptedCreditSettlementCompleted"
+                - "AcceptedSettlementCompleted"
+                - "AcceptedSettlementInProcess"
+                - "AcceptedWithoutPosting"
+                - "Pending"
+                - "Rejected"
+            StatusUpdateDateTime:
+              description: "Date and time at which the resource status was updated.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            ExpectedExecutionDateTime:
+              description: "Expected execution date and time for the payment resource.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            ExpectedSettlementDateTime:
+              description: "Expected settlement date and time for the payment resource.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            Refund:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "Account"
+              description: "Unambiguous identification of the refund account to which a refund will be made as a result of the transaction."
+              properties:
+                Account:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                    - "Name"
+                  description: "Provides the details to identify an account."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "Name of the account, as assigned by the account servicing institution.\nUsage: The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account.\nOB: ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+            Charges:
+              type: "array"
+              items:
+                type: "object"
+                additionalProperties: false
+                description: "Set of elements used to provide details of a charge for the payment initiation."
+                required:
+                  - "ChargeBearer"
+                  - "Type"
+                  - "Amount"
+                properties:
+                  ChargeBearer:
+                    $ref: "#/components/schemas/OBChargeBearerType1Code"
+                  Type:
+                    $ref: "#/components/schemas/OBExternalPaymentChargeType1Code"
+                  Amount:
+                    $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount"
+            Initiation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "InstructionIdentification"
+                - "EndToEndIdentification"
+                - "InstructedAmount"
+                - "CreditorAccount"
+              description: "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single domestic payment."
+              properties:
+                InstructionIdentification:
+                  description: "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction.\nUsage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                EndToEndIdentification:
+                  description: "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain.\nUsage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction.\nOB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                LocalInstrument:
+                  $ref: "#/components/schemas/OBExternalLocalInstrument1Code"
+                InstructedAmount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "Amount"
+                    - "Currency"
+                  description: "Amount of money to be moved between the debtor and creditor, before deduction of charges, expressed in the currency as ordered by the initiating party.\nUsage: This amount has to be transported unchanged through the transaction chain."
+                  properties:
+                    Amount:
+                      $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+                    Currency:
+                      $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode"
+                DebtorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                  description: "Unambiguous identification of the account of the debtor to which a debit entry will be made as a result of the transaction."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels.\nNote, the account name is not the product name or the nickname of the account."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                CreditorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                    - "Name"
+                  description: "Unambiguous identification of the account of the creditor to which a credit entry will be posted as a result of the payment transaction."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level.\nNote, the account name is not the product name or the nickname of the account.\nOB: ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                CreditorPostalAddress:
+                  $ref: "#/components/schemas/OBPostalAddress6"
+                RemittanceInformation:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Information supplied to enable the matching of an entry with the items that the transfer is intended to settle, such as commercial invoices in an accounts' receivable system."
+                  properties:
+                    Unstructured:
+                      description: "Information supplied to enable the matching/reconciliation of an entry with the items that the payment is intended to settle, such as commercial invoices in an accounts' receivable system, in an unstructured form."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 140
+                    Reference:
+                      description: "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction.\nUsage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money.\nIf the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.\nOB: The Faster Payments Scheme can only accept 18 characters for the ReferenceInformation field - which is where this ISO field will be mapped."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 35
+                SupplementaryData:
+                  $ref: "#/components/schemas/OBSupplementaryData1"
+            MultiAuthorisation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "Status"
+              description: "The multiple authorisation flow response from the ASPSP."
+              properties:
+                Status:
+                  description: "Specifies the status of the authorisation flow in code form."
+                  type: "string"
+                  enum:
+                    - "Authorised"
+                    - "AwaitingFurtherAuthorisation"
+                    - "Rejected"
+                NumberRequired:
+                  description: "Number of authorisations required for payment order (total required at the start of the multi authorisation journey)."
+                  type: "integer"
+                NumberReceived:
+                  description: "Number of authorisations received."
+                  type: "integer"
+                LastUpdateDateTime:
+                  description: "Last date and time at the authorisation flow was updated.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+                ExpirationDateTime:
+                  description: "Date and time at which the requested authorisation flow must be completed.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+            Debtor:
+              $ref: "#/components/schemas/OBCashAccountDebtor4"
+        Links:
+          $ref: "#/components/schemas/Links"
+        Meta:
+          $ref: "#/components/schemas/Meta"
+    OBWriteDomesticScheduled2:
+      type: "object"
+      additionalProperties: false
+      required:
+        - "Data"
+        - "Risk"
+      properties:
+        Data:
+          type: "object"
+          additionalProperties: false
+          required:
+            - "ConsentId"
+            - "Initiation"
+          properties:
+            ConsentId:
+              description: "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+              type: "string"
+              minLength: 1
+              maxLength: 128
+            Initiation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "InstructionIdentification"
+                - "RequestedExecutionDateTime"
+                - "InstructedAmount"
+                - "CreditorAccount"
+              description: "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled domestic payment."
+              properties:
+                InstructionIdentification:
+                  description: "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction.\nUsage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                EndToEndIdentification:
+                  description: "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain.\nUsage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction.\nOB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                LocalInstrument:
+                  $ref: "#/components/schemas/OBExternalLocalInstrument1Code"
+                RequestedExecutionDateTime:
+                  description: "Date at which the initiating party requests the clearing agent to process the payment. \nUsage: This is the date on which the debtor's account is to be debited.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+                InstructedAmount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "Amount"
+                    - "Currency"
+                  description: "Amount of money to be moved between the debtor and creditor, before deduction of charges, expressed in the currency as ordered by the initiating party.\nUsage: This amount has to be transported unchanged through the transaction chain."
+                  properties:
+                    Amount:
+                      $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+                    Currency:
+                      $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode"
+                DebtorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                  description: "Unambiguous identification of the account of the debtor to which a debit entry will be made as a result of the transaction."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels.\nNote, the account name is not the product name or the nickname of the account."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                CreditorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                    - "Name"
+                  description: "Unambiguous identification of the account of the creditor to which a credit entry will be posted as a result of the payment transaction."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level.\nNote, the account name is not the product name or the nickname of the account.\nOB: ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                CreditorPostalAddress:
+                  $ref: "#/components/schemas/OBPostalAddress6"
+                RemittanceInformation:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Information supplied to enable the matching of an entry with the items that the transfer is intended to settle, such as commercial invoices in an accounts' receivable system."
+                  properties:
+                    Unstructured:
+                      description: "Information supplied to enable the matching/reconciliation of an entry with the items that the payment is intended to settle, such as commercial invoices in an accounts' receivable system, in an unstructured form."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 140
+                    Reference:
+                      description: "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction.\nUsage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money.\nIf the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.\nOB: The Faster Payments Scheme can only accept 18 characters for the ReferenceInformation field - which is where this ISO field will be mapped."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 35
+                SupplementaryData:
+                  $ref: "#/components/schemas/OBSupplementaryData1"
+        Risk:
+          $ref: "#/components/schemas/OBRisk1"
+    OBWriteDomesticScheduledConsent4:
+      type: "object"
+      additionalProperties: false
+      required:
+        - "Data"
+        - "Risk"
+      properties:
+        Data:
+          type: "object"
+          additionalProperties: false
+          required:
+            - "Permission"
+            - "Initiation"
+          properties:
+            Permission:
+              description: "Specifies the Open Banking service request types."
+              type: "string"
+              enum:
+                - "Create"
+            ReadRefundAccount:
+              description: "Specifies to share the refund account details with PISP"
+              type: "string"
+              enum:
+                - "No"
+                - "Yes"
+            Initiation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "InstructionIdentification"
+                - "RequestedExecutionDateTime"
+                - "InstructedAmount"
+                - "CreditorAccount"
+              description: "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled domestic payment."
+              properties:
+                InstructionIdentification:
+                  description: "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction.\nUsage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                EndToEndIdentification:
+                  description: "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain.\nUsage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction.\nOB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                LocalInstrument:
+                  $ref: "#/components/schemas/OBExternalLocalInstrument1Code"
+                RequestedExecutionDateTime:
+                  description: "Date at which the initiating party requests the clearing agent to process the payment. \nUsage: This is the date on which the debtor's account is to be debited.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+                InstructedAmount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "Amount"
+                    - "Currency"
+                  description: "Amount of money to be moved between the debtor and creditor, before deduction of charges, expressed in the currency as ordered by the initiating party.\nUsage: This amount has to be transported unchanged through the transaction chain."
+                  properties:
+                    Amount:
+                      $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+                    Currency:
+                      $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode"
+                DebtorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                  description: "Unambiguous identification of the account of the debtor to which a debit entry will be made as a result of the transaction."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels.\nNote, the account name is not the product name or the nickname of the account."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                CreditorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                    - "Name"
+                  description: "Unambiguous identification of the account of the creditor to which a credit entry will be posted as a result of the payment transaction."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level.\nNote, the account name is not the product name or the nickname of the account.\nOB: ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                CreditorPostalAddress:
+                  $ref: "#/components/schemas/OBPostalAddress6"
+                RemittanceInformation:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Information supplied to enable the matching of an entry with the items that the transfer is intended to settle, such as commercial invoices in an accounts' receivable system."
+                  properties:
+                    Unstructured:
+                      description: "Information supplied to enable the matching/reconciliation of an entry with the items that the payment is intended to settle, such as commercial invoices in an accounts' receivable system, in an unstructured form."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 140
+                    Reference:
+                      description: "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction.\nUsage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money.\nIf the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.\nOB: The Faster Payments Scheme can only accept 18 characters for the ReferenceInformation field - which is where this ISO field will be mapped."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 35
+                SupplementaryData:
+                  $ref: "#/components/schemas/OBSupplementaryData1"
+            Authorisation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "AuthorisationType"
+              description: "The authorisation type request from the TPP."
+              properties:
+                AuthorisationType:
+                  description: "Type of authorisation flow requested."
+                  type: "string"
+                  enum:
+                    - "Any"
+                    - "Single"
+                CompletionDateTime:
+                  description: "Date and time at which the requested authorisation flow must be completed.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+            SCASupportData:
+              $ref: "#/components/schemas/OBSCASupportData1"
+        Risk:
+          $ref: "#/components/schemas/OBRisk1"
+    OBWriteDomesticScheduledConsentResponse5:
+      type: "object"
+      additionalProperties: false
+      required:
+        - "Data"
+        - "Risk"
+      properties:
+        Data:
+          type: "object"
+          additionalProperties: false
+          required:
+            - "ConsentId"
+            - "CreationDateTime"
+            - "Status"
+            - "StatusUpdateDateTime"
+            - "Permission"
+            - "Initiation"
+          properties:
+            ConsentId:
+              description: "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+              type: "string"
+              minLength: 1
+              maxLength: 128
+            CreationDateTime:
+              description: "Date and time at which the resource was created.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            Status:
+              description: "Specifies the status of consent resource in code form."
+              type: "string"
+              enum:
+                - "Authorised"
+                - "AwaitingAuthorisation"
+                - "Consumed"
+                - "Rejected"
+            StatusUpdateDateTime:
+              description: "Date and time at which the consent resource status was updated.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            Permission:
+              description: "Specifies the Open Banking service request types."
+              type: "string"
+              enum:
+                - "Create"
+            ReadRefundAccount:
+              description: "Specifies to share the refund account details with PISP"
+              type: "string"
+              enum:
+                - "No"
+                - "Yes"
+            CutOffDateTime:
+              description: "Specified cut-off date and time for the payment consent.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            ExpectedExecutionDateTime:
+              description: "Expected execution date and time for the payment resource.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            ExpectedSettlementDateTime:
+              description: "Expected settlement date and time for the payment resource.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            Charges:
+              type: "array"
+              items:
+                type: "object"
+                additionalProperties: false
+                description: "Set of elements used to provide details of a charge for the payment initiation."
+                required:
+                  - "ChargeBearer"
+                  - "Type"
+                  - "Amount"
+                properties:
+                  ChargeBearer:
+                    $ref: "#/components/schemas/OBChargeBearerType1Code"
+                  Type:
+                    $ref: "#/components/schemas/OBExternalPaymentChargeType1Code"
+                  Amount:
+                    $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount"
+            Initiation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "InstructionIdentification"
+                - "RequestedExecutionDateTime"
+                - "InstructedAmount"
+                - "CreditorAccount"
+              description: "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled domestic payment."
+              properties:
+                InstructionIdentification:
+                  description: "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction.\nUsage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                EndToEndIdentification:
+                  description: "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain.\nUsage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction.\nOB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                LocalInstrument:
+                  $ref: "#/components/schemas/OBExternalLocalInstrument1Code"
+                RequestedExecutionDateTime:
+                  description: "Date at which the initiating party requests the clearing agent to process the payment. \nUsage: This is the date on which the debtor's account is to be debited.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+                InstructedAmount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "Amount"
+                    - "Currency"
+                  description: "Amount of money to be moved between the debtor and creditor, before deduction of charges, expressed in the currency as ordered by the initiating party.\nUsage: This amount has to be transported unchanged through the transaction chain."
+                  properties:
+                    Amount:
+                      $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+                    Currency:
+                      $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode"
+                DebtorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                  description: "Unambiguous identification of the account of the debtor to which a debit entry will be made as a result of the transaction."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels.\nNote, the account name is not the product name or the nickname of the account."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                CreditorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                    - "Name"
+                  description: "Unambiguous identification of the account of the creditor to which a credit entry will be posted as a result of the payment transaction."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level.\nNote, the account name is not the product name or the nickname of the account.\nOB: ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                CreditorPostalAddress:
+                  $ref: "#/components/schemas/OBPostalAddress6"
+                RemittanceInformation:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Information supplied to enable the matching of an entry with the items that the transfer is intended to settle, such as commercial invoices in an accounts' receivable system."
+                  properties:
+                    Unstructured:
+                      description: "Information supplied to enable the matching/reconciliation of an entry with the items that the payment is intended to settle, such as commercial invoices in an accounts' receivable system, in an unstructured form."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 140
+                    Reference:
+                      description: "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction.\nUsage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money.\nIf the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.\nOB: The Faster Payments Scheme can only accept 18 characters for the ReferenceInformation field - which is where this ISO field will be mapped."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 35
+                SupplementaryData:
+                  $ref: "#/components/schemas/OBSupplementaryData1"
+            Authorisation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "AuthorisationType"
+              description: "The authorisation type request from the TPP."
+              properties:
+                AuthorisationType:
+                  description: "Type of authorisation flow requested."
+                  type: "string"
+                  enum:
+                    - "Any"
+                    - "Single"
+                CompletionDateTime:
+                  description: "Date and time at which the requested authorisation flow must be completed.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+            SCASupportData:
+              $ref: "#/components/schemas/OBSCASupportData1"
+            Debtor:
+              $ref: "#/components/schemas/OBCashAccountDebtor4"
+        Risk:
+          $ref: "#/components/schemas/OBRisk1"
+        Links:
+          $ref: "#/components/schemas/Links"
+        Meta:
+          $ref: "#/components/schemas/Meta"
+    OBWriteDomesticScheduledResponse5:
+      type: "object"
+      additionalProperties: false
+      required:
+        - "Data"
+      properties:
+        Data:
+          type: "object"
+          additionalProperties: false
+          required:
+            - "DomesticScheduledPaymentId"
+            - "ConsentId"
+            - "CreationDateTime"
+            - "Status"
+            - "StatusUpdateDateTime"
+            - "Initiation"
+          properties:
+            DomesticScheduledPaymentId:
+              description: "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic schedule payment resource."
+              type: "string"
+              minLength: 1
+              maxLength: 40
+            ConsentId:
+              description: "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+              type: "string"
+              minLength: 1
+              maxLength: 128
+            CreationDateTime:
+              description: "Date and time at which the message was created.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            Status:
+              description: "Specifies the status of the payment order resource."
+              type: "string"
+              enum:
+                - "Cancelled"
+                - "InitiationCompleted"
+                - "InitiationFailed"
+                - "InitiationPending"
+            StatusUpdateDateTime:
+              description: "Date and time at which the resource status was updated.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            ExpectedExecutionDateTime:
+              description: "Expected execution date and time for the payment resource.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            ExpectedSettlementDateTime:
+              description: "Expected settlement date and time for the payment resource.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            Refund:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "Account"
+              description: "Unambiguous identification of the refund account to which a refund will be made as a result of the transaction."
+              properties:
+                Account:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                    - "Name"
+                  description: "Provides the details to identify an account."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "Name of the account, as assigned by the account servicing institution.\nUsage: The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account.\nOB: ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+            Charges:
+              type: "array"
+              items:
+                type: "object"
+                additionalProperties: false
+                description: "Set of elements used to provide details of a charge for the payment initiation."
+                required:
+                  - "ChargeBearer"
+                  - "Type"
+                  - "Amount"
+                properties:
+                  ChargeBearer:
+                    $ref: "#/components/schemas/OBChargeBearerType1Code"
+                  Type:
+                    $ref: "#/components/schemas/OBExternalPaymentChargeType1Code"
+                  Amount:
+                    $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount"
+            Initiation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "InstructionIdentification"
+                - "RequestedExecutionDateTime"
+                - "InstructedAmount"
+                - "CreditorAccount"
+              description: "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled domestic payment."
+              properties:
+                InstructionIdentification:
+                  description: "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction.\nUsage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                EndToEndIdentification:
+                  description: "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain.\nUsage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction.\nOB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                LocalInstrument:
+                  $ref: "#/components/schemas/OBExternalLocalInstrument1Code"
+                RequestedExecutionDateTime:
+                  description: "Date at which the initiating party requests the clearing agent to process the payment. \nUsage: This is the date on which the debtor's account is to be debited.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+                InstructedAmount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "Amount"
+                    - "Currency"
+                  description: "Amount of money to be moved between the debtor and creditor, before deduction of charges, expressed in the currency as ordered by the initiating party.\nUsage: This amount has to be transported unchanged through the transaction chain."
+                  properties:
+                    Amount:
+                      $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+                    Currency:
+                      $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode"
+                DebtorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                  description: "Unambiguous identification of the account of the debtor to which a debit entry will be made as a result of the transaction."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels.\nNote, the account name is not the product name or the nickname of the account."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                CreditorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                    - "Name"
+                  description: "Unambiguous identification of the account of the creditor to which a credit entry will be posted as a result of the payment transaction."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level.\nNote, the account name is not the product name or the nickname of the account.\nOB: ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                CreditorPostalAddress:
+                  $ref: "#/components/schemas/OBPostalAddress6"
+                RemittanceInformation:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Information supplied to enable the matching of an entry with the items that the transfer is intended to settle, such as commercial invoices in an accounts' receivable system."
+                  properties:
+                    Unstructured:
+                      description: "Information supplied to enable the matching/reconciliation of an entry with the items that the payment is intended to settle, such as commercial invoices in an accounts' receivable system, in an unstructured form."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 140
+                    Reference:
+                      description: "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction.\nUsage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money.\nIf the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.\nOB: The Faster Payments Scheme can only accept 18 characters for the ReferenceInformation field - which is where this ISO field will be mapped."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 35
+                SupplementaryData:
+                  $ref: "#/components/schemas/OBSupplementaryData1"
+            MultiAuthorisation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "Status"
+              description: "The multiple authorisation flow response from the ASPSP."
+              properties:
+                Status:
+                  description: "Specifies the status of the authorisation flow in code form."
+                  type: "string"
+                  enum:
+                    - "Authorised"
+                    - "AwaitingFurtherAuthorisation"
+                    - "Rejected"
+                NumberRequired:
+                  description: "Number of authorisations required for payment order (total required at the start of the multi authorisation journey)."
+                  type: "integer"
+                NumberReceived:
+                  description: "Number of authorisations received."
+                  type: "integer"
+                LastUpdateDateTime:
+                  description: "Last date and time at the authorisation flow was updated.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+                ExpirationDateTime:
+                  description: "Date and time at which the requested authorisation flow must be completed.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+            Debtor:
+              $ref: "#/components/schemas/OBCashAccountDebtor4"
+        Links:
+          $ref: "#/components/schemas/Links"
+        Meta:
+          $ref: "#/components/schemas/Meta"
+    OBWriteDomesticStandingOrder3:
+      type: "object"
+      additionalProperties: false
+      required:
+        - "Data"
+        - "Risk"
+      properties:
+        Data:
+          type: "object"
+          additionalProperties: false
+          required:
+            - "ConsentId"
+            - "Initiation"
+          properties:
+            ConsentId:
+              description: "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+              type: "string"
+              minLength: 1
+              maxLength: 128
+            Initiation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "Frequency"
+                - "FirstPaymentDateTime"
+                - "FirstPaymentAmount"
+                - "CreditorAccount"
+              description: "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a domestic standing order."
+              properties:
+                Frequency:
+                  description: "Individual Definitions:\nEvryDay - Every day\nEvryWorkgDay - Every working day\nIntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07)\nWkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07)\nIntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31)\nQtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED). \nENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December. \nSCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November.\nRECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December. \nIndividual Patterns:\nEvryDay (ScheduleCode)\nEvryWorkgDay (ScheduleCode)\nIntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek)\nWkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek)\nIntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth)\nQtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay\nThe regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here:\nEvryDay\nEvryWorkgDay\nIntrvlWkDay:0[1-9]:0[1-7]\nWkInMnthDay:0[1-5]:0[1-7]\nIntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01])\nQtrDay:(ENGLISH|SCOTTISH|RECEIVED)\nFull Regular Expression:\n^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+                  type: "string"
+                  pattern: "^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]))$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+                Reference:
+                  description: "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction.\nUsage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money.\nIf the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                NumberOfPayments:
+                  description: "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                FirstPaymentDateTime:
+                  description: "The date on which the first payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+                RecurringPaymentDateTime:
+                  description: "The date on which the first recurring payment for a Standing Order schedule will be made. \nUsage: This must be populated only if the first recurring date is different to the first payment date.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+                FinalPaymentDateTime:
+                  description: "The date on which the final payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+                FirstPaymentAmount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "Amount"
+                    - "Currency"
+                  description: "The amount of the first Standing Order"
+                  properties:
+                    Amount:
+                      $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+                    Currency:
+                      $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode"
+                RecurringPaymentAmount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "Amount"
+                    - "Currency"
+                  description: "The amount of the recurring Standing Order"
+                  properties:
+                    Amount:
+                      $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+                    Currency:
+                      $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode"
+                FinalPaymentAmount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "Amount"
+                    - "Currency"
+                  description: "The amount of the final Standing Order"
+                  properties:
+                    Amount:
+                      $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+                    Currency:
+                      $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode"
+                DebtorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                  description: "Provides the details to identify the debtor account."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels.\nNote, the account name is not the product name or the nickname of the account."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                CreditorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                    - "Name"
+                  description: "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level.\nNote, the account name is not the product name or the nickname of the account.\nOB: ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                SupplementaryData:
+                  $ref: "#/components/schemas/OBSupplementaryData1"
+        Risk:
+          $ref: "#/components/schemas/OBRisk1"
+    OBWriteDomesticStandingOrderConsent5:
+      type: "object"
+      additionalProperties: false
+      required:
+        - "Data"
+        - "Risk"
+      properties:
+        Data:
+          type: "object"
+          additionalProperties: false
+          required:
+            - "Permission"
+            - "Initiation"
+          properties:
+            Permission:
+              description: "Specifies the Open Banking service request types."
+              type: "string"
+              enum:
+                - "Create"
+            ReadRefundAccount:
+              description: "Specifies to share the refund account details with PISP"
+              type: "string"
+              enum:
+                - "No"
+                - "Yes"
+            Initiation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "Frequency"
+                - "FirstPaymentDateTime"
+                - "FirstPaymentAmount"
+                - "CreditorAccount"
+              description: "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a domestic standing order."
+              properties:
+                Frequency:
+                  description: "Individual Definitions:\nEvryDay - Every day\nEvryWorkgDay - Every working day\nIntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07)\nWkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07)\nIntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31)\nQtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED). \nENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December. \nSCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November.\nRECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December. \nIndividual Patterns:\nEvryDay (ScheduleCode)\nEvryWorkgDay (ScheduleCode)\nIntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek)\nWkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek)\nIntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth)\nQtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay\nThe regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here:\nEvryDay\nEvryWorkgDay\nIntrvlWkDay:0[1-9]:0[1-7]\nWkInMnthDay:0[1-5]:0[1-7]\nIntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01])\nQtrDay:(ENGLISH|SCOTTISH|RECEIVED)\nFull Regular Expression:\n^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+                  type: "string"
+                  pattern: "^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]))$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+                Reference:
+                  description: "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction.\nUsage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money.\nIf the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                NumberOfPayments:
+                  description: "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                FirstPaymentDateTime:
+                  description: "The date on which the first payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+                RecurringPaymentDateTime:
+                  description: "The date on which the first recurring payment for a Standing Order schedule will be made. \nUsage: This must be populated only if the first recurring date is different to the first payment date.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+                FinalPaymentDateTime:
+                  description: "The date on which the final payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+                FirstPaymentAmount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "Amount"
+                    - "Currency"
+                  description: "The amount of the first Standing Order"
+                  properties:
+                    Amount:
+                      $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+                    Currency:
+                      $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode"
+                RecurringPaymentAmount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "Amount"
+                    - "Currency"
+                  description: "The amount of the recurring Standing Order"
+                  properties:
+                    Amount:
+                      $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+                    Currency:
+                      $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode"
+                FinalPaymentAmount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "Amount"
+                    - "Currency"
+                  description: "The amount of the final Standing Order"
+                  properties:
+                    Amount:
+                      $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+                    Currency:
+                      $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode"
+                DebtorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                  description: "Provides the details to identify the debtor account."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels.\nNote, the account name is not the product name or the nickname of the account."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                CreditorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                    - "Name"
+                  description: "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level.\nNote, the account name is not the product name or the nickname of the account.\nOB: ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                SupplementaryData:
+                  $ref: "#/components/schemas/OBSupplementaryData1"
+            Authorisation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "AuthorisationType"
+              description: "The authorisation type request from the TPP."
+              properties:
+                AuthorisationType:
+                  description: "Type of authorisation flow requested."
+                  type: "string"
+                  enum:
+                    - "Any"
+                    - "Single"
+                CompletionDateTime:
+                  description: "Date and time at which the requested authorisation flow must be completed.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+            SCASupportData:
+              $ref: "#/components/schemas/OBSCASupportData1"
+        Risk:
+          $ref: "#/components/schemas/OBRisk1"
+    OBWriteDomesticStandingOrderConsentResponse6:
+      type: "object"
+      additionalProperties: false
+      required:
+        - "Data"
+        - "Risk"
+      properties:
+        Data:
+          type: "object"
+          additionalProperties: false
+          required:
+            - "ConsentId"
+            - "CreationDateTime"
+            - "Status"
+            - "StatusUpdateDateTime"
+            - "Permission"
+            - "Initiation"
+          properties:
+            ConsentId:
+              description: "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+              type: "string"
+              minLength: 1
+              maxLength: 128
+            CreationDateTime:
+              description: "Date and time at which the resource was created.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            Status:
+              description: "Specifies the status of consent resource in code form."
+              type: "string"
+              enum:
+                - "Authorised"
+                - "AwaitingAuthorisation"
+                - "Consumed"
+                - "Rejected"
+            StatusUpdateDateTime:
+              description: "Date and time at which the resource status was updated.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            Permission:
+              description: "Specifies the Open Banking service request types."
+              type: "string"
+              enum:
+                - "Create"
+            ReadRefundAccount:
+              description: "Specifies to share the refund account details with PISP"
+              type: "string"
+              enum:
+                - "No"
+                - "Yes"
+            CutOffDateTime:
+              description: "Specified cut-off date and time for the payment consent.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            Charges:
+              type: "array"
+              items:
+                type: "object"
+                additionalProperties: false
+                description: "Set of elements used to provide details of a charge for the payment initiation."
+                required:
+                  - "ChargeBearer"
+                  - "Type"
+                  - "Amount"
+                properties:
+                  ChargeBearer:
+                    $ref: "#/components/schemas/OBChargeBearerType1Code"
+                  Type:
+                    $ref: "#/components/schemas/OBExternalPaymentChargeType1Code"
+                  Amount:
+                    $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount"
+            Initiation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "Frequency"
+                - "FirstPaymentDateTime"
+                - "FirstPaymentAmount"
+                - "CreditorAccount"
+              description: "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a domestic standing order."
+              properties:
+                Frequency:
+                  description: "Individual Definitions:\nEvryDay - Every day\nEvryWorkgDay - Every working day\nIntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07)\nWkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07)\nIntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31)\nQtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED). \nENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December. \nSCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November.\nRECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December. \nIndividual Patterns:\nEvryDay (ScheduleCode)\nEvryWorkgDay (ScheduleCode)\nIntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek)\nWkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek)\nIntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth)\nQtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay\nThe regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here:\nEvryDay\nEvryWorkgDay\nIntrvlWkDay:0[1-9]:0[1-7]\nWkInMnthDay:0[1-5]:0[1-7]\nIntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01])\nQtrDay:(ENGLISH|SCOTTISH|RECEIVED)\nFull Regular Expression:\n^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+                  type: "string"
+                  pattern: "^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]))$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+                Reference:
+                  description: "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction.\nUsage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money.\nIf the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                NumberOfPayments:
+                  description: "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                FirstPaymentDateTime:
+                  description: "The date on which the first payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+                RecurringPaymentDateTime:
+                  description: "The date on which the first recurring payment for a Standing Order schedule will be made. \nUsage: This must be populated only if the first recurring date is different to the first payment date.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+                FinalPaymentDateTime:
+                  description: "The date on which the final payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+                FirstPaymentAmount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "Amount"
+                    - "Currency"
+                  description: "The amount of the first Standing Order"
+                  properties:
+                    Amount:
+                      $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+                    Currency:
+                      $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode"
+                RecurringPaymentAmount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "Amount"
+                    - "Currency"
+                  description: "The amount of the recurring Standing Order"
+                  properties:
+                    Amount:
+                      $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+                    Currency:
+                      $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode"
+                FinalPaymentAmount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "Amount"
+                    - "Currency"
+                  description: "The amount of the final Standing Order"
+                  properties:
+                    Amount:
+                      $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+                    Currency:
+                      $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode"
+                DebtorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                  description: "Unambiguous identification of the account of the debtor to which a debit entry will be made as a result of the transaction."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels.\nNote, the account name is not the product name or the nickname of the account."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                CreditorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                    - "Name"
+                  description: "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level.\nNote, the account name is not the product name or the nickname of the account.\nOB: ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                SupplementaryData:
+                  $ref: "#/components/schemas/OBSupplementaryData1"
+            Authorisation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "AuthorisationType"
+              description: "The authorisation type request from the TPP."
+              properties:
+                AuthorisationType:
+                  description: "Type of authorisation flow requested."
+                  type: "string"
+                  enum:
+                    - "Any"
+                    - "Single"
+                CompletionDateTime:
+                  description: "Date and time at which the requested authorisation flow must be completed.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+            SCASupportData:
+              $ref: "#/components/schemas/OBSCASupportData1"
+            Debtor:
+              $ref: "#/components/schemas/OBCashAccountDebtor4"
+        Risk:
+          $ref: "#/components/schemas/OBRisk1"
+        Links:
+          $ref: "#/components/schemas/Links"
+        Meta:
+          $ref: "#/components/schemas/Meta"
+    OBWriteDomesticStandingOrderResponse6:
+      type: "object"
+      additionalProperties: false
+      required:
+        - "Data"
+      properties:
+        Data:
+          type: "object"
+          additionalProperties: false
+          required:
+            - "DomesticStandingOrderId"
+            - "ConsentId"
+            - "CreationDateTime"
+            - "Status"
+            - "StatusUpdateDateTime"
+            - "Initiation"
+          properties:
+            DomesticStandingOrderId:
+              description: "OB: Unique identification as assigned by the ASPSP to uniquely identify the domestic standing order resource."
+              type: "string"
+              minLength: 1
+              maxLength: 40
+            ConsentId:
+              description: "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+              type: "string"
+              minLength: 1
+              maxLength: 128
+            CreationDateTime:
+              description: "Date and time at which the resource was created.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            Status:
+              description: "Specifies the status of the payment order resource."
+              type: "string"
+              enum:
+                - "Cancelled"
+                - "InitiationCompleted"
+                - "InitiationFailed"
+                - "InitiationPending"
+            StatusUpdateDateTime:
+              description: "Date and time at which the resource status was updated.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            Refund:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "Account"
+              description: "Unambiguous identification of the refund account to which a refund will be made as a result of the transaction."
+              properties:
+                Account:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                    - "Name"
+                  description: "Provides the details to identify an account."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "Name of the account, as assigned by the account servicing institution.\nUsage: The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account.\nOB: ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+            Charges:
+              type: "array"
+              items:
+                type: "object"
+                additionalProperties: false
+                description: "Set of elements used to provide details of a charge for the payment initiation."
+                required:
+                  - "ChargeBearer"
+                  - "Type"
+                  - "Amount"
+                properties:
+                  ChargeBearer:
+                    $ref: "#/components/schemas/OBChargeBearerType1Code"
+                  Type:
+                    $ref: "#/components/schemas/OBExternalPaymentChargeType1Code"
+                  Amount:
+                    $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount"
+            Initiation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "Frequency"
+                - "FirstPaymentDateTime"
+                - "FirstPaymentAmount"
+                - "CreditorAccount"
+              description: "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a domestic standing order."
+              properties:
+                Frequency:
+                  description: "Individual Definitions:\nEvryDay - Every day\nEvryWorkgDay - Every working day\nIntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07)\nWkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07)\nIntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31)\nQtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED). \nENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December. \nSCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November.\nRECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December. \nIndividual Patterns:\nEvryDay (ScheduleCode)\nEvryWorkgDay (ScheduleCode)\nIntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek)\nWkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek)\nIntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth)\nQtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay\nThe regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here:\nEvryDay\nEvryWorkgDay\nIntrvlWkDay:0[1-9]:0[1-7]\nWkInMnthDay:0[1-5]:0[1-7]\nIntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01])\nQtrDay:(ENGLISH|SCOTTISH|RECEIVED)\nFull Regular Expression:\n^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+                  type: "string"
+                  pattern: "^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]))$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+                Reference:
+                  description: "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction.\nUsage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money.\nIf the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                NumberOfPayments:
+                  description: "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                FirstPaymentDateTime:
+                  description: "The date on which the first payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+                RecurringPaymentDateTime:
+                  description: "The date on which the first recurring payment for a Standing Order schedule will be made. \nUsage: This must be populated only if the first recurring date is different to the first payment date.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+                FinalPaymentDateTime:
+                  description: "The date on which the final payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+                FirstPaymentAmount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "Amount"
+                    - "Currency"
+                  description: "The amount of the first Standing Order"
+                  properties:
+                    Amount:
+                      $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+                    Currency:
+                      $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode"
+                RecurringPaymentAmount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "Amount"
+                    - "Currency"
+                  description: "The amount of the recurring Standing Order"
+                  properties:
+                    Amount:
+                      $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+                    Currency:
+                      $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode"
+                FinalPaymentAmount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "Amount"
+                    - "Currency"
+                  description: "The amount of the final Standing Order"
+                  properties:
+                    Amount:
+                      $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+                    Currency:
+                      $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode"
+                DebtorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                  description: "Unambiguous identification of the account of the debtor to which a debit entry will be made as a result of the transaction."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels.\nNote, the account name is not the product name or the nickname of the account."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                CreditorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                    - "Name"
+                  description: "Identification assigned by an institution to identify an account. This identification is known by the account owner."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level.\nNote, the account name is not the product name or the nickname of the account.\nOB: ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                SupplementaryData:
+                  $ref: "#/components/schemas/OBSupplementaryData1"
+            MultiAuthorisation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "Status"
+              description: "The multiple authorisation flow response from the ASPSP."
+              properties:
+                Status:
+                  description: "Specifies the status of the authorisation flow in code form."
+                  type: "string"
+                  enum:
+                    - "Authorised"
+                    - "AwaitingFurtherAuthorisation"
+                    - "Rejected"
+                NumberRequired:
+                  description: "Number of authorisations required for payment order (total required at the start of the multi authorisation journey)."
+                  type: "integer"
+                NumberReceived:
+                  description: "Number of authorisations received."
+                  type: "integer"
+                LastUpdateDateTime:
+                  description: "Last date and time at the authorisation flow was updated.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+                ExpirationDateTime:
+                  description: "Date and time at which the requested authorisation flow must be completed.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+            Debtor:
+              $ref: "#/components/schemas/OBCashAccountDebtor4"
+        Links:
+          $ref: "#/components/schemas/Links"
+        Meta:
+          $ref: "#/components/schemas/Meta"
+    OBWriteFile2:
+      type: "object"
+      additionalProperties: false
+      required:
+        - "Data"
+      properties:
+        Data:
+          type: "object"
+          additionalProperties: false
+          required:
+            - "ConsentId"
+            - "Initiation"
+          properties:
+            ConsentId:
+              description: "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+              type: "string"
+              minLength: 1
+              maxLength: 128
+            Initiation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "FileType"
+                - "FileHash"
+              description: "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds using a payment file."
+              properties:
+                FileType:
+                  description: "Specifies the payment file type."
+                  type: "string"
+                  x-namespaced-enum:
+                    - "UK.OBIE.PaymentInitiation.3.1"
+                    - "UK.OBIE.pain.001.001.08"
+                FileHash:
+                  description: "A base64 encoding of a SHA256 hash of the file to be uploaded."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 44
+                FileReference:
+                  description: "Reference for the file."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 40
+                NumberOfTransactions:
+                  description: "Number of individual transactions contained in the payment information group."
+                  type: "string"
+                  pattern: "[0-9]{1,15}"
+                ControlSum:
+                  description: "Total of all individual amounts included in the group, irrespective of currencies."
+                  type: "number"
+                RequestedExecutionDateTime:
+                  description: "Date at which the initiating party requests the clearing agent to process the payment. \nUsage: This is the date on which the debtor's account is to be debited.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+                LocalInstrument:
+                  $ref: "#/components/schemas/OBExternalLocalInstrument1Code"
+                DebtorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                  description: "Unambiguous identification of the account of the debtor to which a debit entry will be made as a result of the transaction."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels.\nNote, the account name is not the product name or the nickname of the account."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                RemittanceInformation:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Information supplied to enable the matching of an entry with the items that the transfer is intended to settle, such as commercial invoices in an accounts' receivable system."
+                  properties:
+                    Unstructured:
+                      description: "Information supplied to enable the matching/reconciliation of an entry with the items that the payment is intended to settle, such as commercial invoices in an accounts' receivable system, in an unstructured form."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 140
+                    Reference:
+                      description: "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction.\nUsage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money.\nIf the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.\nOB: The Faster Payments Scheme can only accept 18 characters for the ReferenceInformation field - which is where this ISO field will be mapped."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 35
+                SupplementaryData:
+                  $ref: "#/components/schemas/OBSupplementaryData1"
+    OBWriteFileConsent3:
+      type: "object"
+      additionalProperties: false
+      required:
+        - "Data"
+      properties:
+        Data:
+          type: "object"
+          additionalProperties: false
+          required:
+            - "Initiation"
+          properties:
+            Initiation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "FileType"
+                - "FileHash"
+              description: "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds using a payment file."
+              properties:
+                FileType:
+                  description: "Specifies the payment file type."
+                  type: "string"
+                  x-namespaced-enum:
+                    - "UK.OBIE.PaymentInitiation.3.1"
+                    - "UK.OBIE.pain.001.001.08"
+                FileHash:
+                  description: "A base64 encoding of a SHA256 hash of the file to be uploaded."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 44
+                FileReference:
+                  description: "Reference for the file."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 40
+                NumberOfTransactions:
+                  description: "Number of individual transactions contained in the payment information group."
+                  type: "string"
+                  pattern: "[0-9]{1,15}"
+                ControlSum:
+                  description: "Total of all individual amounts included in the group, irrespective of currencies."
+                  type: "number"
+                RequestedExecutionDateTime:
+                  description: "Date at which the initiating party requests the clearing agent to process the payment. \nUsage: This is the date on which the debtor's account is to be debited.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+                LocalInstrument:
+                  $ref: "#/components/schemas/OBExternalLocalInstrument1Code"
+                DebtorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                  description: "Unambiguous identification of the account of the debtor to which a debit entry will be made as a result of the transaction."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels.\nNote, the account name is not the product name or the nickname of the account."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                RemittanceInformation:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Information supplied to enable the matching of an entry with the items that the transfer is intended to settle, such as commercial invoices in an accounts' receivable system."
+                  properties:
+                    Unstructured:
+                      description: "Information supplied to enable the matching/reconciliation of an entry with the items that the payment is intended to settle, such as commercial invoices in an accounts' receivable system, in an unstructured form."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 140
+                    Reference:
+                      description: "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction.\nUsage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money.\nIf the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.\nOB: The Faster Payments Scheme can only accept 18 characters for the ReferenceInformation field - which is where this ISO field will be mapped."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 35
+                SupplementaryData:
+                  $ref: "#/components/schemas/OBSupplementaryData1"
+            Authorisation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "AuthorisationType"
+              description: "The authorisation type request from the TPP."
+              properties:
+                AuthorisationType:
+                  description: "Type of authorisation flow requested."
+                  type: "string"
+                  enum:
+                    - "Any"
+                    - "Single"
+                CompletionDateTime:
+                  description: "Date and time at which the requested authorisation flow must be completed.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+            SCASupportData:
+              $ref: "#/components/schemas/OBSCASupportData1"
+    OBWriteFileConsentResponse4:
+      type: "object"
+      additionalProperties: false
+      required:
+        - "Data"
+      properties:
+        Data:
+          type: "object"
+          additionalProperties: false
+          required:
+            - "ConsentId"
+            - "CreationDateTime"
+            - "Status"
+            - "StatusUpdateDateTime"
+            - "Initiation"
+          properties:
+            ConsentId:
+              description: "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+              type: "string"
+              minLength: 1
+              maxLength: 128
+            CreationDateTime:
+              description: "Date and time at which the resource was created.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            Status:
+              description: "Specifies the status of consent resource in code form."
+              type: "string"
+              enum:
+                - "Authorised"
+                - "AwaitingAuthorisation"
+                - "AwaitingUpload"
+                - "Consumed"
+                - "Rejected"
+            StatusUpdateDateTime:
+              description: "Date and time at which the consent resource status was updated.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            CutOffDateTime:
+              description: "Specified cut-off date and time for the payment consent.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            Charges:
+              type: "array"
+              items:
+                type: "object"
+                additionalProperties: false
+                description: "Set of elements used to provide details of a charge for the payment initiation."
+                required:
+                  - "ChargeBearer"
+                  - "Type"
+                  - "Amount"
+                properties:
+                  ChargeBearer:
+                    $ref: "#/components/schemas/OBChargeBearerType1Code"
+                  Type:
+                    $ref: "#/components/schemas/OBExternalPaymentChargeType1Code"
+                  Amount:
+                    $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount"
+            Initiation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "FileType"
+                - "FileHash"
+              description: "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds using a payment file."
+              properties:
+                FileType:
+                  description: "Specifies the payment file type."
+                  type: "string"
+                  x-namespaced-enum:
+                    - "UK.OBIE.PaymentInitiation.3.1"
+                    - "UK.OBIE.pain.001.001.08"
+                FileHash:
+                  description: "A base64 encoding of a SHA256 hash of the file to be uploaded."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 44
+                FileReference:
+                  description: "Reference for the file."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 40
+                NumberOfTransactions:
+                  description: "Number of individual transactions contained in the payment information group."
+                  type: "string"
+                  pattern: "[0-9]{1,15}"
+                ControlSum:
+                  description: "Total of all individual amounts included in the group, irrespective of currencies."
+                  type: "number"
+                RequestedExecutionDateTime:
+                  description: "Date at which the initiating party requests the clearing agent to process the payment. \nUsage: This is the date on which the debtor's account is to be debited.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+                LocalInstrument:
+                  $ref: "#/components/schemas/OBExternalLocalInstrument1Code"
+                DebtorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                  description: "Unambiguous identification of the account of the debtor to which a debit entry will be made as a result of the transaction."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels.\nNote, the account name is not the product name or the nickname of the account."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                RemittanceInformation:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Information supplied to enable the matching of an entry with the items that the transfer is intended to settle, such as commercial invoices in an accounts' receivable system."
+                  properties:
+                    Unstructured:
+                      description: "Information supplied to enable the matching/reconciliation of an entry with the items that the payment is intended to settle, such as commercial invoices in an accounts' receivable system, in an unstructured form."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 140
+                    Reference:
+                      description: "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction.\nUsage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money.\nIf the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.\nOB: The Faster Payments Scheme can only accept 18 characters for the ReferenceInformation field - which is where this ISO field will be mapped."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 35
+                SupplementaryData:
+                  $ref: "#/components/schemas/OBSupplementaryData1"
+            Authorisation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "AuthorisationType"
+              description: "The authorisation type request from the TPP."
+              properties:
+                AuthorisationType:
+                  description: "Type of authorisation flow requested."
+                  type: "string"
+                  enum:
+                    - "Any"
+                    - "Single"
+                CompletionDateTime:
+                  description: "Date and time at which the requested authorisation flow must be completed.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+            SCASupportData:
+              $ref: "#/components/schemas/OBSCASupportData1"
+            Debtor:
+              $ref: "#/components/schemas/OBCashAccountDebtor4"
+        Links:
+          $ref: "#/components/schemas/Links"
+        Meta:
+          $ref: "#/components/schemas/Meta"
+    OBWriteFileResponse3:
+      type: "object"
+      additionalProperties: false
+      required:
+        - "Data"
+      properties:
+        Data:
+          type: "object"
+          additionalProperties: false
+          required:
+            - "FilePaymentId"
+            - "ConsentId"
+            - "CreationDateTime"
+            - "Status"
+            - "StatusUpdateDateTime"
+            - "Initiation"
+          properties:
+            FilePaymentId:
+              description: "OB: Unique identification as assigned by the ASPSP to uniquely identify the file payment resource."
+              type: "string"
+              minLength: 1
+              maxLength: 40
+            ConsentId:
+              description: "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+              type: "string"
+              minLength: 1
+              maxLength: 128
+            CreationDateTime:
+              description: "Date and time at which the message was created.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            Status:
+              description: "Specifies the status of the payment order resource."
+              type: "string"
+              enum:
+                - "InitiationCompleted"
+                - "InitiationFailed"
+                - "InitiationPending"
+            StatusUpdateDateTime:
+              description: "Date and time at which the resource status was updated.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            Charges:
+              type: "array"
+              items:
+                type: "object"
+                additionalProperties: false
+                description: "Set of elements used to provide details of a charge for the payment initiation."
+                required:
+                  - "ChargeBearer"
+                  - "Type"
+                  - "Amount"
+                properties:
+                  ChargeBearer:
+                    $ref: "#/components/schemas/OBChargeBearerType1Code"
+                  Type:
+                    $ref: "#/components/schemas/OBExternalPaymentChargeType1Code"
+                  Amount:
+                    $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount"
+            Initiation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "FileType"
+                - "FileHash"
+              description: "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds using a payment file."
+              properties:
+                FileType:
+                  description: "Specifies the payment file type."
+                  type: "string"
+                  x-namespaced-enum:
+                    - "UK.OBIE.PaymentInitiation.3.1"
+                    - "UK.OBIE.pain.001.001.08"
+                FileHash:
+                  description: "A base64 encoding of a SHA256 hash of the file to be uploaded."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 44
+                FileReference:
+                  description: "Reference for the file."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 40
+                NumberOfTransactions:
+                  description: "Number of individual transactions contained in the payment information group."
+                  type: "string"
+                  pattern: "[0-9]{1,15}"
+                ControlSum:
+                  description: "Total of all individual amounts included in the group, irrespective of currencies."
+                  type: "number"
+                RequestedExecutionDateTime:
+                  description: "Date at which the initiating party requests the clearing agent to process the payment. \nUsage: This is the date on which the debtor's account is to be debited.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+                LocalInstrument:
+                  $ref: "#/components/schemas/OBExternalLocalInstrument1Code"
+                DebtorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                  description: "Unambiguous identification of the account of the debtor to which a debit entry will be made as a result of the transaction."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels.\nNote, the account name is not the product name or the nickname of the account."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                RemittanceInformation:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Information supplied to enable the matching of an entry with the items that the transfer is intended to settle, such as commercial invoices in an accounts' receivable system."
+                  properties:
+                    Unstructured:
+                      description: "Information supplied to enable the matching/reconciliation of an entry with the items that the payment is intended to settle, such as commercial invoices in an accounts' receivable system, in an unstructured form."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 140
+                    Reference:
+                      description: "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction.\nUsage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money.\nIf the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.\nOB: The Faster Payments Scheme can only accept 18 characters for the ReferenceInformation field - which is where this ISO field will be mapped."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 35
+                SupplementaryData:
+                  $ref: "#/components/schemas/OBSupplementaryData1"
+            MultiAuthorisation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "Status"
+              description: "The multiple authorisation flow response from the ASPSP."
+              properties:
+                Status:
+                  description: "Specifies the status of the authorisation flow in code form."
+                  type: "string"
+                  enum:
+                    - "Authorised"
+                    - "AwaitingFurtherAuthorisation"
+                    - "Rejected"
+                NumberRequired:
+                  description: "Number of authorisations required for payment order (total required at the start of the multi authorisation journey)."
+                  type: "integer"
+                NumberReceived:
+                  description: "Number of authorisations received."
+                  type: "integer"
+                LastUpdateDateTime:
+                  description: "Last date and time at the authorisation flow was updated.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+                ExpirationDateTime:
+                  description: "Date and time at which the requested authorisation flow must be completed.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+            Debtor:
+              $ref: "#/components/schemas/OBCashAccountDebtor4"
+        Links:
+          $ref: "#/components/schemas/Links"
+        Meta:
+          $ref: "#/components/schemas/Meta"
+    OBWriteFundsConfirmationResponse1:
+      type: "object"
+      additionalProperties: false
+      required:
+        - "Data"
+      properties:
+        Data:
+          type: "object"
+          additionalProperties: false
+          properties:
+            FundsAvailableResult:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "FundsAvailableDateTime"
+                - "FundsAvailable"
+              description: "Result of a funds availability check."
+              properties:
+                FundsAvailableDateTime:
+                  description: "Date and time at which the funds availability check was generated.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+                FundsAvailable:
+                  description: "Flag to indicate the availability of funds given the Amount in the consent request."
+                  type: "boolean"
+            SupplementaryData:
+              $ref: "#/components/schemas/OBSupplementaryData1"
+        Links:
+          $ref: "#/components/schemas/Links"
+        Meta:
+          $ref: "#/components/schemas/Meta"
+    OBWriteInternational3:
+      type: "object"
+      additionalProperties: false
+      required:
+        - "Data"
+        - "Risk"
+      properties:
+        Data:
+          type: "object"
+          additionalProperties: false
+          required:
+            - "ConsentId"
+            - "Initiation"
+          properties:
+            ConsentId:
+              description: "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+              type: "string"
+              minLength: 1
+              maxLength: 128
+            Initiation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "InstructionIdentification"
+                - "EndToEndIdentification"
+                - "CurrencyOfTransfer"
+                - "InstructedAmount"
+                - "CreditorAccount"
+              description: "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single international payment."
+              properties:
+                InstructionIdentification:
+                  description: "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction.\nUsage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                EndToEndIdentification:
+                  description: "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain.\nUsage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction.\nOB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                LocalInstrument:
+                  $ref: "#/components/schemas/OBExternalLocalInstrument1Code"
+                InstructionPriority:
+                  description: "Indicator of the urgency or order of importance that the instructing party would like the instructed party to apply to the processing of the instruction."
+                  type: "string"
+                  enum:
+                    - "Normal"
+                    - "Urgent"
+                Purpose:
+                  description: "Specifies the external purpose code in the format of character string with a maximum length of 4 characters.\nThe list of valid codes is an external code list published separately.\nExternal code sets can be downloaded from www.iso20022.org."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 4
+                ExtendedPurpose:
+                  description: "Specifies the purpose of an international payment, when there is no corresponding 4 character code available in the ISO20022 list of Purpose Codes."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 140
+                ChargeBearer:
+                  $ref: "#/components/schemas/OBChargeBearerType1Code"
+                CurrencyOfTransfer:
+                  description: "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+                  type: "string"
+                  pattern: "^[A-Z]{3,3}$"
+                DestinationCountryCode:
+                  description: "Country in which Credit Account is domiciled. Code to identify a country, a dependency, or another area of particular geopolitical interest, on the basis of country names obtained from the United Nations (ISO 3166, Alpha-2 code)."
+                  type: "string"
+                  pattern: "[A-Z]{2,2}"
+                InstructedAmount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "Amount"
+                    - "Currency"
+                  description: "Amount of money to be moved between the debtor and creditor, before deduction of charges, expressed in the currency as ordered by the initiating party.\nUsage: This amount has to be transported unchanged through the transaction chain."
+                  properties:
+                    Amount:
+                      $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+                    Currency:
+                      $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode"
+                ExchangeRateInformation:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "UnitCurrency"
+                    - "RateType"
+                  description: "Provides details on the currency exchange rate and contract."
+                  properties:
+                    UnitCurrency:
+                      description: "Currency in which the rate of exchange is expressed in a currency exchange. In the example 1GBP = xxxCUR, the unit currency is GBP."
+                      type: "string"
+                      pattern: "^[A-Z]{3,3}$"
+                    ExchangeRate:
+                      description: "The factor used for conversion of an amount from one currency to another. This reflects the price at which one currency was bought with another currency."
+                      type: "number"
+                    RateType:
+                      description: "Specifies the type used to complete the currency exchange."
+                      type: "string"
+                      enum:
+                        - "Actual"
+                        - "Agreed"
+                        - "Indicative"
+                    ContractIdentification:
+                      description: "Unique and unambiguous reference to the foreign exchange contract agreed between the initiating party/creditor and the debtor agent."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 256
+                DebtorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                  description: "Unambiguous identification of the account of the debtor to which a debit entry will be made as a result of the transaction."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels.\nNote, the account name is not the product name or the nickname of the account."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                Creditor:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Party to which an amount of money is due."
+                  properties:
+                    Name:
+                      description: "Name by which a party is known and which is usually used to identify that party."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 140
+                    PostalAddress:
+                      $ref: "#/components/schemas/OBPostalAddress6"
+                CreditorAgent:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Financial institution servicing an account for the creditor."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalFinancialInstitutionIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_1"
+                    Name:
+                      $ref: "#/components/schemas/Name"
+                    PostalAddress:
+                      $ref: "#/components/schemas/OBPostalAddress6"
+                CreditorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                    - "Name"
+                  description: "Unambiguous identification of the account of the creditor to which a credit entry will be posted as a result of the payment transaction."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level.\nNote, the account name is not the product name or the nickname of the account.\nOB: ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                RemittanceInformation:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Information supplied to enable the matching of an entry with the items that the transfer is intended to settle, such as commercial invoices in an accounts' receivable system."
+                  properties:
+                    Unstructured:
+                      description: "Information supplied to enable the matching/reconciliation of an entry with the items that the payment is intended to settle, such as commercial invoices in an accounts' receivable system, in an unstructured form."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 140
+                    Reference:
+                      description: "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction.\nUsage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money.\nIf the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.\nOB: The Faster Payments Scheme can only accept 18 characters for the ReferenceInformation field - which is where this ISO field will be mapped."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 35
+                SupplementaryData:
+                  $ref: "#/components/schemas/OBSupplementaryData1"
+        Risk:
+          $ref: "#/components/schemas/OBRisk1"
+    OBWriteInternationalConsent5:
+      type: "object"
+      additionalProperties: false
+      required:
+        - "Data"
+        - "Risk"
+      properties:
+        Data:
+          type: "object"
+          additionalProperties: false
+          required:
+            - "Initiation"
+          properties:
+            ReadRefundAccount:
+              description: "Specifies to share the refund account details with PISP"
+              type: "string"
+              enum:
+                - "No"
+                - "Yes"
+            Initiation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "InstructionIdentification"
+                - "EndToEndIdentification"
+                - "CurrencyOfTransfer"
+                - "InstructedAmount"
+                - "CreditorAccount"
+              description: "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single international payment."
+              properties:
+                InstructionIdentification:
+                  description: "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction.\nUsage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                EndToEndIdentification:
+                  description: "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain.\nUsage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction.\nOB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                LocalInstrument:
+                  $ref: "#/components/schemas/OBExternalLocalInstrument1Code"
+                InstructionPriority:
+                  description: "Indicator of the urgency or order of importance that the instructing party would like the instructed party to apply to the processing of the instruction."
+                  type: "string"
+                  enum:
+                    - "Normal"
+                    - "Urgent"
+                Purpose:
+                  description: "Specifies the external purpose code in the format of character string with a maximum length of 4 characters.\nThe list of valid codes is an external code list published separately.\nExternal code sets can be downloaded from www.iso20022.org."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 4
+                ExtendedPurpose:
+                  description: "Specifies the purpose of an international payment, when there is no corresponding 4 character code available in the ISO20022 list of Purpose Codes."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 140
+                ChargeBearer:
+                  $ref: "#/components/schemas/OBChargeBearerType1Code"
+                CurrencyOfTransfer:
+                  description: "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+                  type: "string"
+                  pattern: "^[A-Z]{3,3}$"
+                DestinationCountryCode:
+                  description: "Country in which Credit Account is domiciled. Code to identify a country, a dependency, or another area of particular geopolitical interest, on the basis of country names obtained from the United Nations (ISO 3166, Alpha-2 code)."
+                  type: "string"
+                  pattern: "[A-Z]{2,2}"
+                InstructedAmount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "Amount"
+                    - "Currency"
+                  description: "Amount of money to be moved between the debtor and creditor, before deduction of charges, expressed in the currency as ordered by the initiating party.\nUsage: This amount has to be transported unchanged through the transaction chain."
+                  properties:
+                    Amount:
+                      $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+                    Currency:
+                      $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode"
+                ExchangeRateInformation:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "UnitCurrency"
+                    - "RateType"
+                  description: "Provides details on the currency exchange rate and contract."
+                  properties:
+                    UnitCurrency:
+                      description: "Currency in which the rate of exchange is expressed in a currency exchange. In the example 1GBP = xxxCUR, the unit currency is GBP."
+                      type: "string"
+                      pattern: "^[A-Z]{3,3}$"
+                    ExchangeRate:
+                      description: "The factor used for conversion of an amount from one currency to another. This reflects the price at which one currency was bought with another currency."
+                      type: "number"
+                    RateType:
+                      description: "Specifies the type used to complete the currency exchange."
+                      type: "string"
+                      enum:
+                        - "Actual"
+                        - "Agreed"
+                        - "Indicative"
+                    ContractIdentification:
+                      description: "Unique and unambiguous reference to the foreign exchange contract agreed between the initiating party/creditor and the debtor agent."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 256
+                DebtorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                  description: "Unambiguous identification of the account of the debtor to which a debit entry will be made as a result of the transaction."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels.\nNote, the account name is not the product name or the nickname of the account."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                Creditor:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Party to which an amount of money is due."
+                  properties:
+                    Name:
+                      description: "Name by which a party is known and which is usually used to identify that party."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 140
+                    PostalAddress:
+                      $ref: "#/components/schemas/OBPostalAddress6"
+                CreditorAgent:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Financial institution servicing an account for the creditor."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalFinancialInstitutionIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_1"
+                    Name:
+                      $ref: "#/components/schemas/Name"
+                    PostalAddress:
+                      $ref: "#/components/schemas/OBPostalAddress6"
+                CreditorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                    - "Name"
+                  description: "Unambiguous identification of the account of the creditor to which a credit entry will be posted as a result of the payment transaction."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level.\nNote, the account name is not the product name or the nickname of the account.\nOB: ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                RemittanceInformation:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Information supplied to enable the matching of an entry with the items that the transfer is intended to settle, such as commercial invoices in an accounts' receivable system."
+                  properties:
+                    Unstructured:
+                      description: "Information supplied to enable the matching/reconciliation of an entry with the items that the payment is intended to settle, such as commercial invoices in an accounts' receivable system, in an unstructured form."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 140
+                    Reference:
+                      description: "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction.\nUsage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money.\nIf the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.\nOB: The Faster Payments Scheme can only accept 18 characters for the ReferenceInformation field - which is where this ISO field will be mapped."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 35
+                SupplementaryData:
+                  $ref: "#/components/schemas/OBSupplementaryData1"
+            Authorisation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "AuthorisationType"
+              description: "The authorisation type request from the TPP."
+              properties:
+                AuthorisationType:
+                  description: "Type of authorisation flow requested."
+                  type: "string"
+                  enum:
+                    - "Any"
+                    - "Single"
+                CompletionDateTime:
+                  description: "Date and time at which the requested authorisation flow must be completed.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+            SCASupportData:
+              $ref: "#/components/schemas/OBSCASupportData1"
+        Risk:
+          $ref: "#/components/schemas/OBRisk1"
+    OBWriteInternationalConsentResponse6:
+      type: "object"
+      additionalProperties: false
+      required:
+        - "Data"
+        - "Risk"
+      properties:
+        Data:
+          type: "object"
+          additionalProperties: false
+          required:
+            - "ConsentId"
+            - "CreationDateTime"
+            - "Status"
+            - "StatusUpdateDateTime"
+            - "Initiation"
+          properties:
+            ConsentId:
+              description: "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+              type: "string"
+              minLength: 1
+              maxLength: 128
+            CreationDateTime:
+              description: "Date and time at which the resource was created.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            Status:
+              description: "Specifies the status of consent resource in code form."
+              type: "string"
+              enum:
+                - "Authorised"
+                - "AwaitingAuthorisation"
+                - "Consumed"
+                - "Rejected"
+            StatusUpdateDateTime:
+              description: "Date and time at which the resource status was updated.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            ReadRefundAccount:
+              description: "Specifies to share the refund account details with PISP"
+              type: "string"
+              enum:
+                - "No"
+                - "Yes"
+            CutOffDateTime:
+              description: "Specified cut-off date and time for the payment consent.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            ExpectedExecutionDateTime:
+              description: "Expected execution date and time for the payment resource.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            ExpectedSettlementDateTime:
+              description: "Expected settlement date and time for the payment resource.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            Charges:
+              type: "array"
+              items:
+                type: "object"
+                additionalProperties: false
+                description: "Set of elements used to provide details of a charge for the payment initiation."
+                required:
+                  - "ChargeBearer"
+                  - "Type"
+                  - "Amount"
+                properties:
+                  ChargeBearer:
+                    $ref: "#/components/schemas/OBChargeBearerType1Code"
+                  Type:
+                    $ref: "#/components/schemas/OBExternalPaymentChargeType1Code"
+                  Amount:
+                    $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount"
+            ExchangeRateInformation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "UnitCurrency"
+                - "ExchangeRate"
+                - "RateType"
+              description: "Further detailed information on the exchange rate that has been used in the payment transaction."
+              properties:
+                UnitCurrency:
+                  description: "Currency in which the rate of exchange is expressed in a currency exchange. In the example 1GBP = xxxCUR, the unit currency is GBP."
+                  type: "string"
+                  pattern: "^[A-Z]{3,3}$"
+                ExchangeRate:
+                  description: "The factor used for conversion of an amount from one currency to another. This reflects the price at which one currency was bought with another currency."
+                  type: "number"
+                RateType:
+                  description: "Specifies the type used to complete the currency exchange."
+                  type: "string"
+                  enum:
+                    - "Actual"
+                    - "Agreed"
+                    - "Indicative"
+                ContractIdentification:
+                  description: "Unique and unambiguous reference to the foreign exchange contract agreed between the initiating party/creditor and the debtor agent."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 256
+                ExpirationDateTime:
+                  description: "Specified date and time the exchange rate agreement will expire.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+            Initiation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "InstructionIdentification"
+                - "EndToEndIdentification"
+                - "CurrencyOfTransfer"
+                - "InstructedAmount"
+                - "CreditorAccount"
+              description: "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single international payment."
+              properties:
+                InstructionIdentification:
+                  description: "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction.\nUsage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                EndToEndIdentification:
+                  description: "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain.\nUsage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction.\nOB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                LocalInstrument:
+                  $ref: "#/components/schemas/OBExternalLocalInstrument1Code"
+                InstructionPriority:
+                  description: "Indicator of the urgency or order of importance that the instructing party would like the instructed party to apply to the processing of the instruction."
+                  type: "string"
+                  enum:
+                    - "Normal"
+                    - "Urgent"
+                Purpose:
+                  description: "Specifies the external purpose code in the format of character string with a maximum length of 4 characters.\nThe list of valid codes is an external code list published separately.\nExternal code sets can be downloaded from www.iso20022.org."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 4
+                ExtendedPurpose:
+                  description: "Specifies the purpose of an international payment, when there is no corresponding 4 character code available in the ISO20022 list of Purpose Codes."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 140
+                ChargeBearer:
+                  $ref: "#/components/schemas/OBChargeBearerType1Code"
+                CurrencyOfTransfer:
+                  description: "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+                  type: "string"
+                  pattern: "^[A-Z]{3,3}$"
+                DestinationCountryCode:
+                  description: "Country in which Credit Account is domiciled. Code to identify a country, a dependency, or another area of particular geopolitical interest, on the basis of country names obtained from the United Nations (ISO 3166, Alpha-2 code)."
+                  type: "string"
+                  pattern: "[A-Z]{2,2}"
+                InstructedAmount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "Amount"
+                    - "Currency"
+                  description: "Amount of money to be moved between the debtor and creditor, before deduction of charges, expressed in the currency as ordered by the initiating party.\nUsage: This amount has to be transported unchanged through the transaction chain."
+                  properties:
+                    Amount:
+                      $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+                    Currency:
+                      $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode"
+                ExchangeRateInformation:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "UnitCurrency"
+                    - "RateType"
+                  description: "Provides details on the currency exchange rate and contract."
+                  properties:
+                    UnitCurrency:
+                      description: "Currency in which the rate of exchange is expressed in a currency exchange. In the example 1GBP = xxxCUR, the unit currency is GBP."
+                      type: "string"
+                      pattern: "^[A-Z]{3,3}$"
+                    ExchangeRate:
+                      description: "The factor used for conversion of an amount from one currency to another. This reflects the price at which one currency was bought with another currency."
+                      type: "number"
+                    RateType:
+                      description: "Specifies the type used to complete the currency exchange."
+                      type: "string"
+                      enum:
+                        - "Actual"
+                        - "Agreed"
+                        - "Indicative"
+                    ContractIdentification:
+                      description: "Unique and unambiguous reference to the foreign exchange contract agreed between the initiating party/creditor and the debtor agent."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 256
+                DebtorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                  description: "Unambiguous identification of the account of the debtor to which a debit entry will be made as a result of the transaction."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels.\nNote, the account name is not the product name or the nickname of the account."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                Creditor:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Party to which an amount of money is due."
+                  properties:
+                    Name:
+                      description: "Name by which a party is known and which is usually used to identify that party."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 140
+                    PostalAddress:
+                      $ref: "#/components/schemas/OBPostalAddress6"
+                CreditorAgent:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Financial institution servicing an account for the creditor."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalFinancialInstitutionIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_1"
+                    Name:
+                      $ref: "#/components/schemas/Name"
+                    PostalAddress:
+                      $ref: "#/components/schemas/OBPostalAddress6"
+                CreditorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                    - "Name"
+                  description: "Unambiguous identification of the account of the creditor to which a credit entry will be posted as a result of the payment transaction."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level.\nNote, the account name is not the product name or the nickname of the account.\nOB: ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                RemittanceInformation:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Information supplied to enable the matching of an entry with the items that the transfer is intended to settle, such as commercial invoices in an accounts' receivable system."
+                  properties:
+                    Unstructured:
+                      description: "Information supplied to enable the matching/reconciliation of an entry with the items that the payment is intended to settle, such as commercial invoices in an accounts' receivable system, in an unstructured form."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 140
+                    Reference:
+                      description: "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction.\nUsage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money.\nIf the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.\nOB: The Faster Payments Scheme can only accept 18 characters for the ReferenceInformation field - which is where this ISO field will be mapped."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 35
+                SupplementaryData:
+                  $ref: "#/components/schemas/OBSupplementaryData1"
+            Authorisation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "AuthorisationType"
+              description: "The authorisation type request from the TPP."
+              properties:
+                AuthorisationType:
+                  description: "Type of authorisation flow requested."
+                  type: "string"
+                  enum:
+                    - "Any"
+                    - "Single"
+                CompletionDateTime:
+                  description: "Date and time at which the requested authorisation flow must be completed.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+            SCASupportData:
+              $ref: "#/components/schemas/OBSCASupportData1"
+            Debtor:
+              $ref: "#/components/schemas/OBCashAccountDebtor4"
+        Risk:
+          $ref: "#/components/schemas/OBRisk1"
+        Links:
+          $ref: "#/components/schemas/Links"
+        Meta:
+          $ref: "#/components/schemas/Meta"
+    OBWriteInternationalResponse5:
+      type: "object"
+      additionalProperties: false
+      required:
+        - "Data"
+      properties:
+        Data:
+          type: "object"
+          additionalProperties: false
+          required:
+            - "InternationalPaymentId"
+            - "ConsentId"
+            - "CreationDateTime"
+            - "Status"
+            - "StatusUpdateDateTime"
+            - "Initiation"
+          properties:
+            InternationalPaymentId:
+              description: "OB: Unique identification as assigned by the ASPSP to uniquely identify the international payment resource."
+              type: "string"
+              minLength: 1
+              maxLength: 40
+            ConsentId:
+              description: "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+              type: "string"
+              minLength: 1
+              maxLength: 128
+            CreationDateTime:
+              description: "Date and time at which the message was created.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            Status:
+              description: "Specifies the status of the payment information group."
+              type: "string"
+              enum:
+                - "AcceptedCreditSettlementCompleted"
+                - "AcceptedSettlementCompleted"
+                - "AcceptedSettlementInProcess"
+                - "AcceptedWithoutPosting"
+                - "Pending"
+                - "Rejected"
+            StatusUpdateDateTime:
+              description: "Date and time at which the resource status was updated.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            ExpectedExecutionDateTime:
+              description: "Expected execution date and time for the payment resource.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            ExpectedSettlementDateTime:
+              description: "Expected settlement date and time for the payment resource.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            Refund:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "Account"
+              properties:
+                Creditor:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Set of elements used to identify a person or an organisation."
+                  properties:
+                    Name:
+                      description: "Name by which a party is known and which is usually used to identify that party."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 140
+                    PostalAddress:
+                      $ref: "#/components/schemas/OBPostalAddress6"
+                Agent:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Set of elements used to uniquely and unambiguously identify a financial institution or a branch of a financial institution."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalFinancialInstitutionIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_1"
+                    Name:
+                      $ref: "#/components/schemas/Name"
+                    PostalAddress:
+                      $ref: "#/components/schemas/OBPostalAddress6"
+                Account:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                    - "Name"
+                  description: "Provides the details to identify an account."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "Name of the account, as assigned by the account servicing institution.\nUsage: The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account.\nOB: ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+            Charges:
+              type: "array"
+              items:
+                type: "object"
+                additionalProperties: false
+                description: "Set of elements used to provide details of a charge for the payment initiation."
+                required:
+                  - "ChargeBearer"
+                  - "Type"
+                  - "Amount"
+                properties:
+                  ChargeBearer:
+                    $ref: "#/components/schemas/OBChargeBearerType1Code"
+                  Type:
+                    $ref: "#/components/schemas/OBExternalPaymentChargeType1Code"
+                  Amount:
+                    $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount"
+            ExchangeRateInformation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "UnitCurrency"
+                - "ExchangeRate"
+                - "RateType"
+              description: "Further detailed information on the exchange rate that has been used in the payment transaction."
+              properties:
+                UnitCurrency:
+                  description: "Currency in which the rate of exchange is expressed in a currency exchange. In the example 1GBP = xxxCUR, the unit currency is GBP."
+                  type: "string"
+                  pattern: "^[A-Z]{3,3}$"
+                ExchangeRate:
+                  description: "The factor used for conversion of an amount from one currency to another. This reflects the price at which one currency was bought with another currency."
+                  type: "number"
+                RateType:
+                  description: "Specifies the type used to complete the currency exchange."
+                  type: "string"
+                  enum:
+                    - "Actual"
+                    - "Agreed"
+                    - "Indicative"
+                ContractIdentification:
+                  description: "Unique and unambiguous reference to the foreign exchange contract agreed between the initiating party/creditor and the debtor agent."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 256
+                ExpirationDateTime:
+                  description: "Specified date and time the exchange rate agreement will expire.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+            Initiation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "InstructionIdentification"
+                - "EndToEndIdentification"
+                - "CurrencyOfTransfer"
+                - "InstructedAmount"
+                - "CreditorAccount"
+              description: "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single international payment."
+              properties:
+                InstructionIdentification:
+                  description: "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction.\nUsage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                EndToEndIdentification:
+                  description: "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain.\nUsage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction.\nOB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                LocalInstrument:
+                  $ref: "#/components/schemas/OBExternalLocalInstrument1Code"
+                InstructionPriority:
+                  description: "Indicator of the urgency or order of importance that the instructing party would like the instructed party to apply to the processing of the instruction."
+                  type: "string"
+                  enum:
+                    - "Normal"
+                    - "Urgent"
+                Purpose:
+                  description: "Specifies the external purpose code in the format of character string with a maximum length of 4 characters.\nThe list of valid codes is an external code list published separately.\nExternal code sets can be downloaded from www.iso20022.org."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 4
+                ExtendedPurpose:
+                  description: "Specifies the purpose of an international payment, when there is no corresponding 4 character code available in the ISO20022 list of Purpose Codes."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 140
+                ChargeBearer:
+                  $ref: "#/components/schemas/OBChargeBearerType1Code"
+                CurrencyOfTransfer:
+                  description: "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+                  type: "string"
+                  pattern: "^[A-Z]{3,3}$"
+                DestinationCountryCode:
+                  description: "Country in which Credit Account is domiciled. Code to identify a country, a dependency, or another area of particular geopolitical interest, on the basis of country names obtained from the United Nations (ISO 3166, Alpha-2 code)."
+                  type: "string"
+                  pattern: "[A-Z]{2,2}"
+                InstructedAmount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "Amount"
+                    - "Currency"
+                  description: "Amount of money to be moved between the debtor and creditor, before deduction of charges, expressed in the currency as ordered by the initiating party.\nUsage: This amount has to be transported unchanged through the transaction chain."
+                  properties:
+                    Amount:
+                      $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+                    Currency:
+                      $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode"
+                ExchangeRateInformation:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "UnitCurrency"
+                    - "RateType"
+                  description: "Provides details on the currency exchange rate and contract."
+                  properties:
+                    UnitCurrency:
+                      description: "Currency in which the rate of exchange is expressed in a currency exchange. In the example 1GBP = xxxCUR, the unit currency is GBP."
+                      type: "string"
+                      pattern: "^[A-Z]{3,3}$"
+                    ExchangeRate:
+                      description: "The factor used for conversion of an amount from one currency to another. This reflects the price at which one currency was bought with another currency."
+                      type: "number"
+                    RateType:
+                      description: "Specifies the type used to complete the currency exchange."
+                      type: "string"
+                      enum:
+                        - "Actual"
+                        - "Agreed"
+                        - "Indicative"
+                    ContractIdentification:
+                      description: "Unique and unambiguous reference to the foreign exchange contract agreed between the initiating party/creditor and the debtor agent."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 256
+                DebtorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                  description: "Unambiguous identification of the account of the debtor to which a debit entry will be made as a result of the transaction."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels.\nNote, the account name is not the product name or the nickname of the account."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                Creditor:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Party to which an amount of money is due."
+                  properties:
+                    Name:
+                      description: "Name by which a party is known and which is usually used to identify that party."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 140
+                    PostalAddress:
+                      $ref: "#/components/schemas/OBPostalAddress6"
+                CreditorAgent:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Financial institution servicing an account for the creditor."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalFinancialInstitutionIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_1"
+                    Name:
+                      $ref: "#/components/schemas/Name"
+                    PostalAddress:
+                      $ref: "#/components/schemas/OBPostalAddress6"
+                CreditorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                    - "Name"
+                  description: "Unambiguous identification of the account of the creditor to which a credit entry will be posted as a result of the payment transaction."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level.\nNote, the account name is not the product name or the nickname of the account.\nOB: ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                RemittanceInformation:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Information supplied to enable the matching of an entry with the items that the transfer is intended to settle, such as commercial invoices in an accounts' receivable system."
+                  properties:
+                    Unstructured:
+                      description: "Information supplied to enable the matching/reconciliation of an entry with the items that the payment is intended to settle, such as commercial invoices in an accounts' receivable system, in an unstructured form."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 140
+                    Reference:
+                      description: "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction.\nUsage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money.\nIf the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.\nOB: The Faster Payments Scheme can only accept 18 characters for the ReferenceInformation field - which is where this ISO field will be mapped."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 35
+                SupplementaryData:
+                  $ref: "#/components/schemas/OBSupplementaryData1"
+            MultiAuthorisation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "Status"
+              description: "The multiple authorisation flow response from the ASPSP."
+              properties:
+                Status:
+                  description: "Specifies the status of the authorisation flow in code form."
+                  type: "string"
+                  enum:
+                    - "Authorised"
+                    - "AwaitingFurtherAuthorisation"
+                    - "Rejected"
+                NumberRequired:
+                  description: "Number of authorisations required for payment order (total required at the start of the multi authorisation journey)."
+                  type: "integer"
+                NumberReceived:
+                  description: "Number of authorisations received."
+                  type: "integer"
+                LastUpdateDateTime:
+                  description: "Last date and time at the authorisation flow was updated.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+                ExpirationDateTime:
+                  description: "Date and time at which the requested authorisation flow must be completed.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+            Debtor:
+              $ref: "#/components/schemas/OBCashAccountDebtor4"
+        Links:
+          $ref: "#/components/schemas/Links"
+        Meta:
+          $ref: "#/components/schemas/Meta"
+    OBWriteInternationalScheduled3:
+      type: "object"
+      additionalProperties: false
+      required:
+        - "Data"
+        - "Risk"
+      properties:
+        Data:
+          type: "object"
+          additionalProperties: false
+          required:
+            - "ConsentId"
+            - "Initiation"
+          properties:
+            ConsentId:
+              description: "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+              type: "string"
+              minLength: 1
+              maxLength: 128
+            Initiation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "InstructionIdentification"
+                - "RequestedExecutionDateTime"
+                - "CurrencyOfTransfer"
+                - "InstructedAmount"
+                - "CreditorAccount"
+              description: "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled international payment."
+              properties:
+                InstructionIdentification:
+                  description: "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction.\nUsage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                EndToEndIdentification:
+                  description: "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain.\nUsage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction.\nOB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                LocalInstrument:
+                  $ref: "#/components/schemas/OBExternalLocalInstrument1Code"
+                InstructionPriority:
+                  description: "Indicator of the urgency or order of importance that the instructing party would like the instructed party to apply to the processing of the instruction."
+                  type: "string"
+                  enum:
+                    - "Normal"
+                    - "Urgent"
+                Purpose:
+                  description: "Specifies the external purpose code in the format of character string with a maximum length of 4 characters.\nThe list of valid codes is an external code list published separately.\nExternal code sets can be downloaded from www.iso20022.org."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 4
+                ExtendedPurpose:
+                  description: "Specifies the purpose of an international payment, when there is no corresponding 4 character code available in the ISO20022 list of Purpose Codes."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 140
+                ChargeBearer:
+                  $ref: "#/components/schemas/OBChargeBearerType1Code"
+                RequestedExecutionDateTime:
+                  description: "Date at which the initiating party requests the clearing agent to process the payment. \nUsage: This is the date on which the debtor's account is to be debited.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+                CurrencyOfTransfer:
+                  description: "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+                  type: "string"
+                  pattern: "^[A-Z]{3,3}$"
+                DestinationCountryCode:
+                  description: "Country in which Credit Account is domiciled. Code to identify a country, a dependency, or another area of particular geopolitical interest, on the basis of country names obtained from the United Nations (ISO 3166, Alpha-2 code)."
+                  type: "string"
+                  pattern: "[A-Z]{2,2}"
+                InstructedAmount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "Amount"
+                    - "Currency"
+                  description: "Amount of money to be moved between the debtor and creditor, before deduction of charges, expressed in the currency as ordered by the initiating party.\nUsage: This amount has to be transported unchanged through the transaction chain."
+                  properties:
+                    Amount:
+                      $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+                    Currency:
+                      $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode"
+                ExchangeRateInformation:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "UnitCurrency"
+                    - "RateType"
+                  description: "Provides details on the currency exchange rate and contract."
+                  properties:
+                    UnitCurrency:
+                      description: "Currency in which the rate of exchange is expressed in a currency exchange. In the example 1GBP = xxxCUR, the unit currency is GBP."
+                      type: "string"
+                      pattern: "^[A-Z]{3,3}$"
+                    ExchangeRate:
+                      description: "The factor used for conversion of an amount from one currency to another. This reflects the price at which one currency was bought with another currency."
+                      type: "number"
+                    RateType:
+                      description: "Specifies the type used to complete the currency exchange."
+                      type: "string"
+                      enum:
+                        - "Actual"
+                        - "Agreed"
+                        - "Indicative"
+                    ContractIdentification:
+                      description: "Unique and unambiguous reference to the foreign exchange contract agreed between the initiating party/creditor and the debtor agent."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 256
+                DebtorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                  description: "Unambiguous identification of the account of the debtor to which a debit entry will be made as a result of the transaction."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels.\nNote, the account name is not the product name or the nickname of the account."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                Creditor:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Party to which an amount of money is due."
+                  properties:
+                    Name:
+                      description: "Name by which a party is known and which is usually used to identify that party."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 140
+                    PostalAddress:
+                      $ref: "#/components/schemas/OBPostalAddress6"
+                CreditorAgent:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Financial institution servicing an account for the creditor."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalFinancialInstitutionIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_1"
+                    Name:
+                      $ref: "#/components/schemas/Name"
+                    PostalAddress:
+                      $ref: "#/components/schemas/OBPostalAddress6"
+                CreditorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                    - "Name"
+                  description: "Unambiguous identification of the account of the creditor to which a credit entry will be posted as a result of the payment transaction."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level.\nNote, the account name is not the product name or the nickname of the account.\nOB: ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                RemittanceInformation:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Information supplied to enable the matching of an entry with the items that the transfer is intended to settle, such as commercial invoices in an accounts' receivable system."
+                  properties:
+                    Unstructured:
+                      description: "Information supplied to enable the matching/reconciliation of an entry with the items that the payment is intended to settle, such as commercial invoices in an accounts' receivable system, in an unstructured form."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 140
+                    Reference:
+                      description: "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction.\nUsage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money.\nIf the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.\nOB: The Faster Payments Scheme can only accept 18 characters for the ReferenceInformation field - which is where this ISO field will be mapped."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 35
+                SupplementaryData:
+                  $ref: "#/components/schemas/OBSupplementaryData1"
+        Risk:
+          $ref: "#/components/schemas/OBRisk1"
+    OBWriteInternationalScheduledConsent5:
+      type: "object"
+      additionalProperties: false
+      required:
+        - "Data"
+        - "Risk"
+      properties:
+        Data:
+          type: "object"
+          additionalProperties: false
+          required:
+            - "Permission"
+            - "Initiation"
+          properties:
+            Permission:
+              description: "Specifies the Open Banking service request types."
+              type: "string"
+              enum:
+                - "Create"
+            ReadRefundAccount:
+              description: "Specifies to share the refund account details with PISP"
+              type: "string"
+              enum:
+                - "No"
+                - "Yes"
+            Initiation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "InstructionIdentification"
+                - "RequestedExecutionDateTime"
+                - "CurrencyOfTransfer"
+                - "InstructedAmount"
+                - "CreditorAccount"
+              description: "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled international payment."
+              properties:
+                InstructionIdentification:
+                  description: "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction.\nUsage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                EndToEndIdentification:
+                  description: "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain.\nUsage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction.\nOB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                LocalInstrument:
+                  $ref: "#/components/schemas/OBExternalLocalInstrument1Code"
+                InstructionPriority:
+                  description: "Indicator of the urgency or order of importance that the instructing party would like the instructed party to apply to the processing of the instruction."
+                  type: "string"
+                  enum:
+                    - "Normal"
+                    - "Urgent"
+                Purpose:
+                  description: "Specifies the external purpose code in the format of character string with a maximum length of 4 characters.\nThe list of valid codes is an external code list published separately.\nExternal code sets can be downloaded from www.iso20022.org."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 4
+                ExtendedPurpose:
+                  description: "Specifies the purpose of an international payment, when there is no corresponding 4 character code available in the ISO20022 list of Purpose Codes."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 140
+                ChargeBearer:
+                  $ref: "#/components/schemas/OBChargeBearerType1Code"
+                RequestedExecutionDateTime:
+                  description: "Date at which the initiating party requests the clearing agent to process the payment. \nUsage: This is the date on which the debtor's account is to be debited.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+                CurrencyOfTransfer:
+                  description: "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+                  type: "string"
+                  pattern: "^[A-Z]{3,3}$"
+                DestinationCountryCode:
+                  description: "Country in which Credit Account is domiciled. Code to identify a country, a dependency, or another area of particular geopolitical interest, on the basis of country names obtained from the United Nations (ISO 3166, Alpha-2 code)."
+                  type: "string"
+                  pattern: "[A-Z]{2,2}"
+                InstructedAmount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "Amount"
+                    - "Currency"
+                  description: "Amount of money to be moved between the debtor and creditor, before deduction of charges, expressed in the currency as ordered by the initiating party.\nUsage: This amount has to be transported unchanged through the transaction chain."
+                  properties:
+                    Amount:
+                      $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+                    Currency:
+                      $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode"
+                ExchangeRateInformation:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "UnitCurrency"
+                    - "RateType"
+                  description: "Provides details on the currency exchange rate and contract."
+                  properties:
+                    UnitCurrency:
+                      description: "Currency in which the rate of exchange is expressed in a currency exchange. In the example 1GBP = xxxCUR, the unit currency is GBP."
+                      type: "string"
+                      pattern: "^[A-Z]{3,3}$"
+                    ExchangeRate:
+                      description: "The factor used for conversion of an amount from one currency to another. This reflects the price at which one currency was bought with another currency."
+                      type: "number"
+                    RateType:
+                      description: "Specifies the type used to complete the currency exchange."
+                      type: "string"
+                      enum:
+                        - "Actual"
+                        - "Agreed"
+                        - "Indicative"
+                    ContractIdentification:
+                      description: "Unique and unambiguous reference to the foreign exchange contract agreed between the initiating party/creditor and the debtor agent."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 256
+                DebtorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                  description: "Unambiguous identification of the account of the debtor to which a debit entry will be made as a result of the transaction."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels.\nNote, the account name is not the product name or the nickname of the account."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                Creditor:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Party to which an amount of money is due."
+                  properties:
+                    Name:
+                      description: "Name by which a party is known and which is usually used to identify that party."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 140
+                    PostalAddress:
+                      $ref: "#/components/schemas/OBPostalAddress6"
+                CreditorAgent:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Financial institution servicing an account for the creditor."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalFinancialInstitutionIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_1"
+                    Name:
+                      $ref: "#/components/schemas/Name"
+                    PostalAddress:
+                      $ref: "#/components/schemas/OBPostalAddress6"
+                CreditorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                    - "Name"
+                  description: "Unambiguous identification of the account of the creditor to which a credit entry will be posted as a result of the payment transaction."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level.\nNote, the account name is not the product name or the nickname of the account.\nOB: ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                RemittanceInformation:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Information supplied to enable the matching of an entry with the items that the transfer is intended to settle, such as commercial invoices in an accounts' receivable system."
+                  properties:
+                    Unstructured:
+                      description: "Information supplied to enable the matching/reconciliation of an entry with the items that the payment is intended to settle, such as commercial invoices in an accounts' receivable system, in an unstructured form."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 140
+                    Reference:
+                      description: "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction.\nUsage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money.\nIf the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.\nOB: The Faster Payments Scheme can only accept 18 characters for the ReferenceInformation field - which is where this ISO field will be mapped."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 35
+                SupplementaryData:
+                  $ref: "#/components/schemas/OBSupplementaryData1"
+            Authorisation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "AuthorisationType"
+              description: "The authorisation type request from the TPP."
+              properties:
+                AuthorisationType:
+                  description: "Type of authorisation flow requested."
+                  type: "string"
+                  enum:
+                    - "Any"
+                    - "Single"
+                CompletionDateTime:
+                  description: "Date and time at which the requested authorisation flow must be completed.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+            SCASupportData:
+              $ref: "#/components/schemas/OBSCASupportData1"
+        Risk:
+          $ref: "#/components/schemas/OBRisk1"
+    OBWriteInternationalScheduledConsentResponse6:
+      type: "object"
+      additionalProperties: false
+      required:
+        - "Data"
+        - "Risk"
+      properties:
+        Data:
+          type: "object"
+          additionalProperties: false
+          required:
+            - "ConsentId"
+            - "CreationDateTime"
+            - "Status"
+            - "StatusUpdateDateTime"
+            - "Permission"
+            - "Initiation"
+          properties:
+            ConsentId:
+              description: "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+              type: "string"
+              minLength: 1
+              maxLength: 128
+            CreationDateTime:
+              description: "Date and time at which the resource was created.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            Status:
+              description: "Specifies the status of consent resource in code form."
+              type: "string"
+              enum:
+                - "Authorised"
+                - "AwaitingAuthorisation"
+                - "Consumed"
+                - "Rejected"
+            StatusUpdateDateTime:
+              description: "Date and time at which the resource status was updated.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            Permission:
+              description: "Specifies the Open Banking service request types."
+              type: "string"
+              enum:
+                - "Create"
+            ReadRefundAccount:
+              description: "Specifies to share the refund account details with PISP"
+              type: "string"
+              enum:
+                - "No"
+                - "Yes"
+            CutOffDateTime:
+              description: "Specified cut-off date and time for the payment consent.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            ExpectedExecutionDateTime:
+              description: "Expected execution date and time for the payment resource.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            ExpectedSettlementDateTime:
+              description: "Expected settlement date and time for the payment resource.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            Charges:
+              type: "array"
+              items:
+                type: "object"
+                additionalProperties: false
+                description: "Set of elements used to provide details of a charge for the payment initiation."
+                required:
+                  - "ChargeBearer"
+                  - "Type"
+                  - "Amount"
+                properties:
+                  ChargeBearer:
+                    $ref: "#/components/schemas/OBChargeBearerType1Code"
+                  Type:
+                    $ref: "#/components/schemas/OBExternalPaymentChargeType1Code"
+                  Amount:
+                    $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount"
+            ExchangeRateInformation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "UnitCurrency"
+                - "ExchangeRate"
+                - "RateType"
+              description: "Further detailed information on the exchange rate that has been used in the payment transaction."
+              properties:
+                UnitCurrency:
+                  description: "Currency in which the rate of exchange is expressed in a currency exchange. In the example 1GBP = xxxCUR, the unit currency is GBP."
+                  type: "string"
+                  pattern: "^[A-Z]{3,3}$"
+                ExchangeRate:
+                  description: "The factor used for conversion of an amount from one currency to another. This reflects the price at which one currency was bought with another currency."
+                  type: "number"
+                RateType:
+                  description: "Specifies the type used to complete the currency exchange."
+                  type: "string"
+                  enum:
+                    - "Actual"
+                    - "Agreed"
+                    - "Indicative"
+                ContractIdentification:
+                  description: "Unique and unambiguous reference to the foreign exchange contract agreed between the initiating party/creditor and the debtor agent."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 256
+                ExpirationDateTime:
+                  description: "Specified date and time the exchange rate agreement will expire.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+            Initiation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "InstructionIdentification"
+                - "RequestedExecutionDateTime"
+                - "CurrencyOfTransfer"
+                - "InstructedAmount"
+                - "CreditorAccount"
+              description: "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled international payment."
+              properties:
+                InstructionIdentification:
+                  description: "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction.\nUsage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                EndToEndIdentification:
+                  description: "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain.\nUsage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction.\nOB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                LocalInstrument:
+                  $ref: "#/components/schemas/OBExternalLocalInstrument1Code"
+                InstructionPriority:
+                  description: "Indicator of the urgency or order of importance that the instructing party would like the instructed party to apply to the processing of the instruction."
+                  type: "string"
+                  enum:
+                    - "Normal"
+                    - "Urgent"
+                Purpose:
+                  description: "Specifies the external purpose code in the format of character string with a maximum length of 4 characters.\nThe list of valid codes is an external code list published separately.\nExternal code sets can be downloaded from www.iso20022.org."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 4
+                ExtendedPurpose:
+                  description: "Specifies the purpose of an international payment, when there is no corresponding 4 character code available in the ISO20022 list of Purpose Codes."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 140
+                ChargeBearer:
+                  $ref: "#/components/schemas/OBChargeBearerType1Code"
+                RequestedExecutionDateTime:
+                  description: "Date at which the initiating party requests the clearing agent to process the payment. \nUsage: This is the date on which the debtor's account is to be debited.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+                CurrencyOfTransfer:
+                  description: "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+                  type: "string"
+                  pattern: "^[A-Z]{3,3}$"
+                DestinationCountryCode:
+                  description: "Country in which Credit Account is domiciled. Code to identify a country, a dependency, or another area of particular geopolitical interest, on the basis of country names obtained from the United Nations (ISO 3166, Alpha-2 code)."
+                  type: "string"
+                  pattern: "[A-Z]{2,2}"
+                InstructedAmount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "Amount"
+                    - "Currency"
+                  description: "Amount of money to be moved between the debtor and creditor, before deduction of charges, expressed in the currency as ordered by the initiating party.\nUsage: This amount has to be transported unchanged through the transaction chain."
+                  properties:
+                    Amount:
+                      $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+                    Currency:
+                      $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode"
+                ExchangeRateInformation:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "UnitCurrency"
+                    - "RateType"
+                  description: "Provides details on the currency exchange rate and contract."
+                  properties:
+                    UnitCurrency:
+                      description: "Currency in which the rate of exchange is expressed in a currency exchange. In the example 1GBP = xxxCUR, the unit currency is GBP."
+                      type: "string"
+                      pattern: "^[A-Z]{3,3}$"
+                    ExchangeRate:
+                      description: "The factor used for conversion of an amount from one currency to another. This reflects the price at which one currency was bought with another currency."
+                      type: "number"
+                    RateType:
+                      description: "Specifies the type used to complete the currency exchange."
+                      type: "string"
+                      enum:
+                        - "Actual"
+                        - "Agreed"
+                        - "Indicative"
+                    ContractIdentification:
+                      description: "Unique and unambiguous reference to the foreign exchange contract agreed between the initiating party/creditor and the debtor agent."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 256
+                DebtorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                  description: "Unambiguous identification of the account of the debtor to which a debit entry will be made as a result of the transaction."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels.\nNote, the account name is not the product name or the nickname of the account."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                Creditor:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Party to which an amount of money is due."
+                  properties:
+                    Name:
+                      description: "Name by which a party is known and which is usually used to identify that party."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    PostalAddress:
+                      $ref: "#/components/schemas/OBPostalAddress6"
+                CreditorAgent:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Financial institution servicing an account for the creditor."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalFinancialInstitutionIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_1"
+                    Name:
+                      $ref: "#/components/schemas/Name"
+                    PostalAddress:
+                      $ref: "#/components/schemas/OBPostalAddress6"
+                CreditorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                    - "Name"
+                  description: "Unambiguous identification of the account of the creditor to which a credit entry will be posted as a result of the payment transaction."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level.\nNote, the account name is not the product name or the nickname of the account.\nOB: ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                RemittanceInformation:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Information supplied to enable the matching of an entry with the items that the transfer is intended to settle, such as commercial invoices in an accounts' receivable system."
+                  properties:
+                    Unstructured:
+                      description: "Information supplied to enable the matching/reconciliation of an entry with the items that the payment is intended to settle, such as commercial invoices in an accounts' receivable system, in an unstructured form."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 140
+                    Reference:
+                      description: "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction.\nUsage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money.\nIf the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.\nOB: The Faster Payments Scheme can only accept 18 characters for the ReferenceInformation field - which is where this ISO field will be mapped."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 35
+                SupplementaryData:
+                  $ref: "#/components/schemas/OBSupplementaryData1"
+            Authorisation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "AuthorisationType"
+              description: "The authorisation type request from the TPP."
+              properties:
+                AuthorisationType:
+                  description: "Type of authorisation flow requested."
+                  type: "string"
+                  enum:
+                    - "Any"
+                    - "Single"
+                CompletionDateTime:
+                  description: "Date and time at which the requested authorisation flow must be completed.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+            SCASupportData:
+              $ref: "#/components/schemas/OBSCASupportData1"
+            Debtor:
+              $ref: "#/components/schemas/OBCashAccountDebtor4"
+        Risk:
+          $ref: "#/components/schemas/OBRisk1"
+        Links:
+          $ref: "#/components/schemas/Links"
+        Meta:
+          $ref: "#/components/schemas/Meta"
+    OBWriteInternationalScheduledResponse6:
+      type: "object"
+      additionalProperties: false
+      required:
+        - "Data"
+      properties:
+        Data:
+          type: "object"
+          additionalProperties: false
+          required:
+            - "InternationalScheduledPaymentId"
+            - "ConsentId"
+            - "CreationDateTime"
+            - "Status"
+            - "StatusUpdateDateTime"
+            - "Initiation"
+          properties:
+            InternationalScheduledPaymentId:
+              description: "OB: Unique identification as assigned by the ASPSP to uniquely identify the international scheduled payment resource."
+              type: "string"
+              minLength: 1
+              maxLength: 40
+            ConsentId:
+              description: "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+              type: "string"
+              minLength: 1
+              maxLength: 128
+            CreationDateTime:
+              description: "Date and time at which the message was created.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            Status:
+              description: "Specifies the status of the payment order resource."
+              type: "string"
+              enum:
+                - "Cancelled"
+                - "InitiationCompleted"
+                - "InitiationFailed"
+                - "InitiationPending"
+            StatusUpdateDateTime:
+              description: "Date and time at which the resource status was updated.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            ExpectedExecutionDateTime:
+              description: "Expected execution date and time for the payment resource.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            ExpectedSettlementDateTime:
+              description: "Expected settlement date and time for the payment resource.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            Refund:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "Account"
+              properties:
+                Creditor:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Set of elements used to identify a person or an organisation."
+                  properties:
+                    Name:
+                      description: "Name by which a party is known and which is usually used to identify that party."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 140
+                    PostalAddress:
+                      $ref: "#/components/schemas/OBPostalAddress6"
+                Agent:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Set of elements used to uniquely and unambiguously identify a financial institution or a branch of a financial institution."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalFinancialInstitutionIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_1"
+                    Name:
+                      $ref: "#/components/schemas/Name"
+                    PostalAddress:
+                      $ref: "#/components/schemas/OBPostalAddress6"
+                Account:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                    - "Name"
+                  description: "Provides the details to identify an account."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "Name of the account, as assigned by the account servicing institution.\nUsage: The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account.\nOB: ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+            Charges:
+              type: "array"
+              items:
+                type: "object"
+                additionalProperties: false
+                description: "Set of elements used to provide details of a charge for the payment initiation."
+                required:
+                  - "ChargeBearer"
+                  - "Type"
+                  - "Amount"
+                properties:
+                  ChargeBearer:
+                    $ref: "#/components/schemas/OBChargeBearerType1Code"
+                  Type:
+                    $ref: "#/components/schemas/OBExternalPaymentChargeType1Code"
+                  Amount:
+                    $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount"
+            ExchangeRateInformation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "UnitCurrency"
+                - "ExchangeRate"
+                - "RateType"
+              description: "Further detailed information on the exchange rate that has been used in the payment transaction."
+              properties:
+                UnitCurrency:
+                  description: "Currency in which the rate of exchange is expressed in a currency exchange. In the example 1GBP = xxxCUR, the unit currency is GBP."
+                  type: "string"
+                  pattern: "^[A-Z]{3,3}$"
+                ExchangeRate:
+                  description: "The factor used for conversion of an amount from one currency to another. This reflects the price at which one currency was bought with another currency."
+                  type: "number"
+                RateType:
+                  description: "Specifies the type used to complete the currency exchange."
+                  type: "string"
+                  enum:
+                    - "Actual"
+                    - "Agreed"
+                    - "Indicative"
+                ContractIdentification:
+                  description: "Unique and unambiguous reference to the foreign exchange contract agreed between the initiating party/creditor and the debtor agent."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 256
+                ExpirationDateTime:
+                  description: "Specified date and time the exchange rate agreement will expire.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+            Initiation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "InstructionIdentification"
+                - "RequestedExecutionDateTime"
+                - "CurrencyOfTransfer"
+                - "InstructedAmount"
+                - "CreditorAccount"
+              description: "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for a single scheduled international payment."
+              properties:
+                InstructionIdentification:
+                  description: "Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction.\nUsage: the  instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. It can be included in several messages related to the instruction."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                EndToEndIdentification:
+                  description: "Unique identification assigned by the initiating party to unambiguously identify the transaction. This identification is passed on, unchanged, throughout the entire end-to-end chain.\nUsage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. It can be included in several messages related to the transaction.\nOB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                LocalInstrument:
+                  $ref: "#/components/schemas/OBExternalLocalInstrument1Code"
+                InstructionPriority:
+                  description: "Indicator of the urgency or order of importance that the instructing party would like the instructed party to apply to the processing of the instruction."
+                  type: "string"
+                  enum:
+                    - "Normal"
+                    - "Urgent"
+                Purpose:
+                  description: "Specifies the external purpose code in the format of character string with a maximum length of 4 characters.\nThe list of valid codes is an external code list published separately.\nExternal code sets can be downloaded from www.iso20022.org."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 4
+                ExtendedPurpose:
+                  description: "Specifies the purpose of an international payment, when there is no corresponding 4 character code available in the ISO20022 list of Purpose Codes."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 140
+                ChargeBearer:
+                  $ref: "#/components/schemas/OBChargeBearerType1Code"
+                RequestedExecutionDateTime:
+                  description: "Date at which the initiating party requests the clearing agent to process the payment. \nUsage: This is the date on which the debtor's account is to be debited.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+                CurrencyOfTransfer:
+                  description: "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+                  type: "string"
+                  pattern: "^[A-Z]{3,3}$"
+                DestinationCountryCode:
+                  description: "Country in which Credit Account is domiciled. Code to identify a country, a dependency, or another area of particular geopolitical interest, on the basis of country names obtained from the United Nations (ISO 3166, Alpha-2 code)."
+                  type: "string"
+                  pattern: "[A-Z]{2,2}"
+                InstructedAmount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "Amount"
+                    - "Currency"
+                  description: "Amount of money to be moved between the debtor and creditor, before deduction of charges, expressed in the currency as ordered by the initiating party.\nUsage: This amount has to be transported unchanged through the transaction chain."
+                  properties:
+                    Amount:
+                      $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+                    Currency:
+                      $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode"
+                ExchangeRateInformation:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "UnitCurrency"
+                    - "RateType"
+                  description: "Provides details on the currency exchange rate and contract."
+                  properties:
+                    UnitCurrency:
+                      description: "Currency in which the rate of exchange is expressed in a currency exchange. In the example 1GBP = xxxCUR, the unit currency is GBP."
+                      type: "string"
+                      pattern: "^[A-Z]{3,3}$"
+                    ExchangeRate:
+                      description: "The factor used for conversion of an amount from one currency to another. This reflects the price at which one currency was bought with another currency."
+                      type: "number"
+                    RateType:
+                      description: "Specifies the type used to complete the currency exchange."
+                      type: "string"
+                      enum:
+                        - "Actual"
+                        - "Agreed"
+                        - "Indicative"
+                    ContractIdentification:
+                      description: "Unique and unambiguous reference to the foreign exchange contract agreed between the initiating party/creditor and the debtor agent."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 256
+                DebtorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                  description: "Unambiguous identification of the account of the debtor to which a debit entry will be made as a result of the transaction."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels.\nNote, the account name is not the product name or the nickname of the account."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                Creditor:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Party to which an amount of money is due."
+                  properties:
+                    Name:
+                      description: "Name by which a party is known and which is usually used to identify that party."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 140
+                    PostalAddress:
+                      $ref: "#/components/schemas/OBPostalAddress6"
+                CreditorAgent:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Financial institution servicing an account for the creditor."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalFinancialInstitutionIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_1"
+                    Name:
+                      $ref: "#/components/schemas/Name"
+                    PostalAddress:
+                      $ref: "#/components/schemas/OBPostalAddress6"
+                CreditorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                    - "Name"
+                  description: "Unambiguous identification of the account of the creditor to which a credit entry will be posted as a result of the payment transaction."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level.\nNote, the account name is not the product name or the nickname of the account.\nOB: ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                RemittanceInformation:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Information supplied to enable the matching of an entry with the items that the transfer is intended to settle, such as commercial invoices in an accounts' receivable system."
+                  properties:
+                    Unstructured:
+                      description: "Information supplied to enable the matching/reconciliation of an entry with the items that the payment is intended to settle, such as commercial invoices in an accounts' receivable system, in an unstructured form."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 140
+                    Reference:
+                      description: "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction.\nUsage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money.\nIf the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.\nOB: The Faster Payments Scheme can only accept 18 characters for the ReferenceInformation field - which is where this ISO field will be mapped."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 35
+                SupplementaryData:
+                  $ref: "#/components/schemas/OBSupplementaryData1"
+            MultiAuthorisation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "Status"
+              description: "The multiple authorisation flow response from the ASPSP."
+              properties:
+                Status:
+                  description: "Specifies the status of the authorisation flow in code form."
+                  type: "string"
+                  enum:
+                    - "Authorised"
+                    - "AwaitingFurtherAuthorisation"
+                    - "Rejected"
+                NumberRequired:
+                  description: "Number of authorisations required for payment order (total required at the start of the multi authorisation journey)."
+                  type: "integer"
+                NumberReceived:
+                  description: "Number of authorisations received."
+                  type: "integer"
+                LastUpdateDateTime:
+                  description: "Last date and time at the authorisation flow was updated.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+                ExpirationDateTime:
+                  description: "Date and time at which the requested authorisation flow must be completed.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+            Debtor:
+              $ref: "#/components/schemas/OBCashAccountDebtor4"
+        Links:
+          $ref: "#/components/schemas/Links"
+        Meta:
+          $ref: "#/components/schemas/Meta"
+    OBWriteInternationalStandingOrder4:
+      type: "object"
+      additionalProperties: false
+      required:
+        - "Data"
+        - "Risk"
+      properties:
+        Data:
+          type: "object"
+          additionalProperties: false
+          required:
+            - "ConsentId"
+            - "Initiation"
+          properties:
+            ConsentId:
+              description: "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+              type: "string"
+              minLength: 1
+              maxLength: 128
+            Initiation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "Frequency"
+                - "FirstPaymentDateTime"
+                - "CurrencyOfTransfer"
+                - "InstructedAmount"
+                - "CreditorAccount"
+              description: "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for an international standing order."
+              properties:
+                Frequency:
+                  description: "Individual Definitions:\nEvryDay - Every day\nEvryWorkgDay - Every working day\nIntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07)\nWkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07)\nIntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31)\nQtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED). \nENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December. \nSCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November.\nRECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December. \nIndividual Patterns:\nEvryDay (ScheduleCode)\nEvryWorkgDay (ScheduleCode)\nIntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek)\nWkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek)\nIntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth)\nQtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay\nThe regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here:\nEvryDay\nEvryWorkgDay\nIntrvlWkDay:0[1-9]:0[1-7]\nWkInMnthDay:0[1-5]:0[1-7]\nIntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01])\nQtrDay:(ENGLISH|SCOTTISH|RECEIVED)\nFull Regular Expression:\n^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+                  type: "string"
+                  pattern: "^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]))$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+                Reference:
+                  description: "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction.\nUsage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money.\nIf the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                NumberOfPayments:
+                  description: "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                FirstPaymentDateTime:
+                  description: "The date on which the first payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+                FinalPaymentDateTime:
+                  description: "The date on which the final payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+                Purpose:
+                  description: "Specifies the external purpose code in the format of character string with a maximum length of 4 characters.\nThe list of valid codes is an external code list published separately.\nExternal code sets can be downloaded from www.iso20022.org."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 4
+                ExtendedPurpose:
+                  description: "Specifies the purpose of an international payment, when there is no corresponding 4 character code available in the ISO20022 list of Purpose Codes."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 140
+                ChargeBearer:
+                  $ref: "#/components/schemas/OBChargeBearerType1Code"
+                CurrencyOfTransfer:
+                  description: "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+                  type: "string"
+                  pattern: "^[A-Z]{3,3}$"
+                DestinationCountryCode:
+                  description: "Country in which Credit Account is domiciled. Code to identify a country, a dependency, or another area of particular geopolitical interest, on the basis of country names obtained from the United Nations (ISO 3166, Alpha-2 code)."
+                  type: "string"
+                  pattern: "[A-Z]{2,2}"
+                InstructedAmount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "Amount"
+                    - "Currency"
+                  description: "Amount of money to be moved between the debtor and creditor, before deduction of charges, expressed in the currency as ordered by the initiating party.\nUsage: This amount has to be transported unchanged through the transaction chain."
+                  properties:
+                    Amount:
+                      $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+                    Currency:
+                      $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode"
+                DebtorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                  description: "Provides the details to identify the debtor account."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels.\nNote, the account name is not the product name or the nickname of the account."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                Creditor:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Party to which an amount of money is due."
+                  properties:
+                    Name:
+                      description: "Name by which a party is known and which is usually used to identify that party."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    PostalAddress:
+                      $ref: "#/components/schemas/OBPostalAddress6"
+                CreditorAgent:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account.\nThis is the servicer of the beneficiary account."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalFinancialInstitutionIdentification4Code"
+                    Identification:
+                      description: "Unique and unambiguous identification of the servicing institution."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 35
+                    Name:
+                      $ref: "#/components/schemas/Name"
+                    PostalAddress:
+                      $ref: "#/components/schemas/OBPostalAddress6"
+                CreditorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                    - "Name"
+                  description: "Provides the details to identify the beneficiary account."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level.\nNote, the account name is not the product name or the nickname of the account.\nOB: ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                SupplementaryData:
+                  $ref: "#/components/schemas/OBSupplementaryData1"
+        Risk:
+          $ref: "#/components/schemas/OBRisk1"
+    OBWriteInternationalStandingOrderConsent6:
+      type: "object"
+      additionalProperties: false
+      required:
+        - "Data"
+        - "Risk"
+      properties:
+        Data:
+          type: "object"
+          additionalProperties: false
+          required:
+            - "Permission"
+            - "Initiation"
+          properties:
+            Permission:
+              description: "Specifies the Open Banking service request types."
+              type: "string"
+              enum:
+                - "Create"
+            ReadRefundAccount:
+              description: "Specifies to share the refund account details with PISP"
+              type: "string"
+              enum:
+                - "No"
+                - "Yes"
+            Initiation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "Frequency"
+                - "FirstPaymentDateTime"
+                - "CurrencyOfTransfer"
+                - "InstructedAmount"
+                - "CreditorAccount"
+              description: "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for an international standing order."
+              properties:
+                Frequency:
+                  description: "Individual Definitions:\nEvryDay - Every day\nEvryWorkgDay - Every working day\nIntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07)\nWkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07)\nIntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31)\nQtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED). \nENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December. \nSCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November.\nRECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December. \nIndividual Patterns:\nEvryDay (ScheduleCode)\nEvryWorkgDay (ScheduleCode)\nIntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek)\nWkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek)\nIntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth)\nQtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay\nThe regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here:\nEvryDay\nEvryWorkgDay\nIntrvlWkDay:0[1-9]:0[1-7]\nWkInMnthDay:0[1-5]:0[1-7]\nIntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01])\nQtrDay:(ENGLISH|SCOTTISH|RECEIVED)\nFull Regular Expression:\n^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+                  type: "string"
+                  pattern: "^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]))$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+                Reference:
+                  description: "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction.\nUsage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money.\nIf the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                NumberOfPayments:
+                  description: "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                FirstPaymentDateTime:
+                  description: "The date on which the first payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+                FinalPaymentDateTime:
+                  description: "The date on which the final payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+                Purpose:
+                  description: "Specifies the external purpose code in the format of character string with a maximum length of 4 characters.\nThe list of valid codes is an external code list published separately.\nExternal code sets can be downloaded from www.iso20022.org."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 4
+                ExtendedPurpose:
+                  description: "Specifies the purpose of an international payment, when there is no corresponding 4 character code available in the ISO20022 list of Purpose Codes."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 140
+                ChargeBearer:
+                  $ref: "#/components/schemas/OBChargeBearerType1Code"
+                CurrencyOfTransfer:
+                  description: "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+                  type: "string"
+                  pattern: "^[A-Z]{3,3}$"
+                DestinationCountryCode:
+                  description: "Country in which Credit Account is domiciled. Code to identify a country, a dependency, or another area of particular geopolitical interest, on the basis of country names obtained from the United Nations (ISO 3166, Alpha-2 code)."
+                  type: "string"
+                  pattern: "[A-Z]{2,2}"
+                InstructedAmount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "Amount"
+                    - "Currency"
+                  description: "Amount of money to be moved between the debtor and creditor, before deduction of charges, expressed in the currency as ordered by the initiating party.\nUsage: This amount has to be transported unchanged through the transaction chain."
+                  properties:
+                    Amount:
+                      $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+                    Currency:
+                      $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode"
+                DebtorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                  description: "Provides the details to identify the debtor account."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels.\nNote, the account name is not the product name or the nickname of the account."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                Creditor:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Party to which an amount of money is due."
+                  properties:
+                    Name:
+                      description: "Name by which a party is known and which is usually used to identify that party."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    PostalAddress:
+                      $ref: "#/components/schemas/OBPostalAddress6"
+                CreditorAgent:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account.\nThis is the servicer of the beneficiary account."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalFinancialInstitutionIdentification4Code"
+                    Identification:
+                      description: "Unique and unambiguous identification of the servicing institution."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 35
+                    Name:
+                      $ref: "#/components/schemas/Name"
+                    PostalAddress:
+                      $ref: "#/components/schemas/OBPostalAddress6"
+                CreditorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                    - "Name"
+                  description: "Provides the details to identify the beneficiary account."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level.\nNote, the account name is not the product name or the nickname of the account.\nOB: ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                SupplementaryData:
+                  $ref: "#/components/schemas/OBSupplementaryData1"
+            Authorisation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "AuthorisationType"
+              description: "The authorisation type request from the TPP."
+              properties:
+                AuthorisationType:
+                  description: "Type of authorisation flow requested."
+                  type: "string"
+                  enum:
+                    - "Any"
+                    - "Single"
+                CompletionDateTime:
+                  description: "Date and time at which the requested authorisation flow must be completed.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+            SCASupportData:
+              $ref: "#/components/schemas/OBSCASupportData1"
+        Risk:
+          $ref: "#/components/schemas/OBRisk1"
+    OBWriteInternationalStandingOrderConsentResponse7:
+      type: "object"
+      additionalProperties: false
+      required:
+        - "Data"
+        - "Risk"
+      properties:
+        Data:
+          type: "object"
+          additionalProperties: false
+          required:
+            - "ConsentId"
+            - "CreationDateTime"
+            - "Status"
+            - "StatusUpdateDateTime"
+            - "Permission"
+            - "Initiation"
+          properties:
+            ConsentId:
+              description: "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+              type: "string"
+              minLength: 1
+              maxLength: 128
+            CreationDateTime:
+              description: "Date and time at which the resource was created.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            Status:
+              description: "Specifies the status of resource in code form."
+              type: "string"
+              enum:
+                - "Authorised"
+                - "AwaitingAuthorisation"
+                - "Consumed"
+                - "Rejected"
+            StatusUpdateDateTime:
+              description: "Date and time at which the resource status was updated.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            Permission:
+              description: "Specifies the Open Banking service request types."
+              type: "string"
+              enum:
+                - "Create"
+            ReadRefundAccount:
+              description: "Specifies to share the refund account details with PISP"
+              type: "string"
+              enum:
+                - "No"
+                - "Yes"
+            CutOffDateTime:
+              description: "Specified cut-off date and time for the payment consent.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            Charges:
+              type: "array"
+              items:
+                type: "object"
+                additionalProperties: false
+                description: "Set of elements used to provide details of a charge for the payment initiation."
+                required:
+                  - "ChargeBearer"
+                  - "Type"
+                  - "Amount"
+                properties:
+                  ChargeBearer:
+                    $ref: "#/components/schemas/OBChargeBearerType1Code"
+                  Type:
+                    $ref: "#/components/schemas/OBExternalPaymentChargeType1Code"
+                  Amount:
+                    $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount"
+            Initiation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "Frequency"
+                - "FirstPaymentDateTime"
+                - "CurrencyOfTransfer"
+                - "InstructedAmount"
+                - "CreditorAccount"
+              description: "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for an international standing order."
+              properties:
+                Frequency:
+                  description: "Individual Definitions:\nEvryDay - Every day\nEvryWorkgDay - Every working day\nIntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07)\nWkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07)\nIntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31)\nQtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED). \nENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December. \nSCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November.\nRECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December. \nIndividual Patterns:\nEvryDay (ScheduleCode)\nEvryWorkgDay (ScheduleCode)\nIntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek)\nWkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek)\nIntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth)\nQtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay\nThe regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here:\nEvryDay\nEvryWorkgDay\nIntrvlWkDay:0[1-9]:0[1-7]\nWkInMnthDay:0[1-5]:0[1-7]\nIntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01])\nQtrDay:(ENGLISH|SCOTTISH|RECEIVED)\nFull Regular Expression:\n^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+                  type: "string"
+                  pattern: "^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]))$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+                Reference:
+                  description: "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction.\nUsage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money.\nIf the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                NumberOfPayments:
+                  description: "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                FirstPaymentDateTime:
+                  description: "The date on which the first payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+                FinalPaymentDateTime:
+                  description: "The date on which the final payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+                Purpose:
+                  description: "Specifies the external purpose code in the format of character string with a maximum length of 4 characters.\nThe list of valid codes is an external code list published separately.\nExternal code sets can be downloaded from www.iso20022.org."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 4
+                ExtendedPurpose:
+                  description: "Specifies the purpose of an international payment, when there is no corresponding 4 character code available in the ISO20022 list of Purpose Codes."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 140
+                ChargeBearer:
+                  $ref: "#/components/schemas/OBChargeBearerType1Code"
+                CurrencyOfTransfer:
+                  description: "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+                  type: "string"
+                  pattern: "^[A-Z]{3,3}$"
+                DestinationCountryCode:
+                  description: "Country in which Credit Account is domiciled. Code to identify a country, a dependency, or another area of particular geopolitical interest, on the basis of country names obtained from the United Nations (ISO 3166, Alpha-2 code)."
+                  type: "string"
+                  pattern: "[A-Z]{2,2}"
+                InstructedAmount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "Amount"
+                    - "Currency"
+                  description: "Amount of money to be moved between the debtor and creditor, before deduction of charges, expressed in the currency as ordered by the initiating party.\nUsage: This amount has to be transported unchanged through the transaction chain."
+                  properties:
+                    Amount:
+                      $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+                    Currency:
+                      $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode"
+                DebtorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                  description: "Unambiguous identification of the account of the debtor to which a debit entry will be made as a result of the transaction."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels.\nNote, the account name is not the product name or the nickname of the account."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                Creditor:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Party to which an amount of money is due."
+                  properties:
+                    Name:
+                      description: "Name by which a party is known and which is usually used to identify that party."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    PostalAddress:
+                      $ref: "#/components/schemas/OBPostalAddress6"
+                CreditorAgent:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account.\nThis is the servicer of the beneficiary account."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalFinancialInstitutionIdentification4Code"
+                    Identification:
+                      description: "Unique and unambiguous identification of the servicing institution."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 35
+                    Name:
+                      $ref: "#/components/schemas/Name"
+                    PostalAddress:
+                      $ref: "#/components/schemas/OBPostalAddress6"
+                CreditorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                    - "Name"
+                  description: "Provides the details to identify the beneficiary account."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level.\nNote, the account name is not the product name or the nickname of the account.\nOB: ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                SupplementaryData:
+                  $ref: "#/components/schemas/OBSupplementaryData1"
+            Authorisation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "AuthorisationType"
+              description: "The authorisation type request from the TPP."
+              properties:
+                AuthorisationType:
+                  description: "Type of authorisation flow requested."
+                  type: "string"
+                  enum:
+                    - "Any"
+                    - "Single"
+                CompletionDateTime:
+                  description: "Date and time at which the requested authorisation flow must be completed.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+            SCASupportData:
+              $ref: "#/components/schemas/OBSCASupportData1"
+            Debtor:
+              $ref: "#/components/schemas/OBCashAccountDebtor4"
+        Risk:
+          $ref: "#/components/schemas/OBRisk1"
+        Links:
+          $ref: "#/components/schemas/Links"
+        Meta:
+          $ref: "#/components/schemas/Meta"
+    OBWriteInternationalStandingOrderResponse7:
+      type: "object"
+      additionalProperties: false
+      required:
+        - "Data"
+      properties:
+        Data:
+          type: "object"
+          additionalProperties: false
+          required:
+            - "InternationalStandingOrderId"
+            - "ConsentId"
+            - "CreationDateTime"
+            - "Status"
+            - "StatusUpdateDateTime"
+            - "Initiation"
+          properties:
+            InternationalStandingOrderId:
+              description: "OB: Unique identification as assigned by the ASPSP to uniquely identify the international standing order resource."
+              type: "string"
+              minLength: 1
+              maxLength: 40
+            ConsentId:
+              description: "OB: Unique identification as assigned by the ASPSP to uniquely identify the consent resource."
+              type: "string"
+              minLength: 1
+              maxLength: 128
+            CreationDateTime:
+              description: "Date and time at which the resource was created.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            Status:
+              description: "Specifies the status of resource in code form."
+              type: "string"
+              enum:
+                - "Cancelled"
+                - "InitiationCompleted"
+                - "InitiationFailed"
+                - "InitiationPending"
+            StatusUpdateDateTime:
+              description: "Date and time at which the resource status was updated.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+              type: "string"
+              format: "date-time"
+            Refund:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "Account"
+              properties:
+                Creditor:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Set of elements used to identify a person or an organisation."
+                  properties:
+                    Name:
+                      description: "Name by which a party is known and which is usually used to identify that party."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    PostalAddress:
+                      $ref: "#/components/schemas/OBPostalAddress6"
+                Agent:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Set of elements used to uniquely and unambiguously identify a financial institution or a branch of a financial institution."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalFinancialInstitutionIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_1"
+                    Name:
+                      $ref: "#/components/schemas/Name"
+                    PostalAddress:
+                      $ref: "#/components/schemas/OBPostalAddress6"
+                Account:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                    - "Name"
+                  description: "Provides the details to identify an account."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "Name of the account, as assigned by the account servicing institution.\nUsage: The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account.\nOB: ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+            Charges:
+              type: "array"
+              items:
+                type: "object"
+                additionalProperties: false
+                description: "Set of elements used to provide details of a charge for the payment initiation."
+                required:
+                  - "ChargeBearer"
+                  - "Type"
+                  - "Amount"
+                properties:
+                  ChargeBearer:
+                    $ref: "#/components/schemas/OBChargeBearerType1Code"
+                  Type:
+                    $ref: "#/components/schemas/OBExternalPaymentChargeType1Code"
+                  Amount:
+                    $ref: "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount"
+            Initiation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "Frequency"
+                - "FirstPaymentDateTime"
+                - "CurrencyOfTransfer"
+                - "InstructedAmount"
+                - "CreditorAccount"
+              description: "The Initiation payload is sent by the initiating party to the ASPSP. It is used to request movement of funds from the debtor account to a creditor for an international standing order."
+              properties:
+                Frequency:
+                  description: "Individual Definitions:\nEvryDay - Every day\nEvryWorkgDay - Every working day\nIntrvlWkDay - An interval specified in weeks (01 to 09), and the day within the week (01 to 07)\nWkInMnthDay - A monthly interval, specifying the week of the month (01 to 05) and day within the week (01 to 07)\nIntrvlMnthDay - An interval specified in months (between 01 to 06, 12, 24), specifying the day within the month (-5 to -1, 1 to 31)\nQtrDay - Quarterly (either ENGLISH, SCOTTISH, or RECEIVED). \nENGLISH = Paid on the 25th March, 24th June, 29th September and 25th December. \nSCOTTISH = Paid on the 2nd February, 15th May, 1st August and 11th November.\nRECEIVED = Paid on the 20th March, 19th June, 24th September and 20th December. \nIndividual Patterns:\nEvryDay (ScheduleCode)\nEvryWorkgDay (ScheduleCode)\nIntrvlWkDay:IntervalInWeeks:DayInWeek (ScheduleCode + IntervalInWeeks + DayInWeek)\nWkInMnthDay:WeekInMonth:DayInWeek (ScheduleCode + WeekInMonth + DayInWeek)\nIntrvlMnthDay:IntervalInMonths:DayInMonth (ScheduleCode + IntervalInMonths + DayInMonth)\nQtrDay: + either (ENGLISH, SCOTTISH or RECEIVED) ScheduleCode + QuarterDay\nThe regular expression for this element combines five smaller versions for each permitted pattern. To aid legibility - the components are presented individually here:\nEvryDay\nEvryWorkgDay\nIntrvlWkDay:0[1-9]:0[1-7]\nWkInMnthDay:0[1-5]:0[1-7]\nIntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01])\nQtrDay:(ENGLISH|SCOTTISH|RECEIVED)\nFull Regular Expression:\n^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+                  type: "string"
+                  pattern: "^(EvryDay)$|^(EvryWorkgDay)$|^(IntrvlDay:((0[2-9])|([1-2][0-9])|3[0-1]))$|^(IntrvlWkDay:0[1-9]:0[1-7])$|^(WkInMnthDay:0[1-5]:0[1-7])$|^(IntrvlMnthDay:(0[1-6]|12|24):(-0[1-5]|0[1-9]|[12][0-9]|3[01]))$|^(QtrDay:(ENGLISH|SCOTTISH|RECEIVED))$"
+                Reference:
+                  description: "Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction.\nUsage: If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money.\nIf the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                NumberOfPayments:
+                  description: "Number of the payments that will be made in completing this frequency sequence including any executed since the sequence start date."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 35
+                FirstPaymentDateTime:
+                  description: "The date on which the first payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+                FinalPaymentDateTime:
+                  description: "The date on which the final payment for a Standing Order schedule will be made.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+                Purpose:
+                  description: "Specifies the external purpose code in the format of character string with a maximum length of 4 characters.\nThe list of valid codes is an external code list published separately.\nExternal code sets can be downloaded from www.iso20022.org."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 4
+                ExtendedPurpose:
+                  description: "Specifies the purpose of an international payment, when there is no corresponding 4 character code available in the ISO20022 list of Purpose Codes."
+                  type: "string"
+                  minLength: 1
+                  maxLength: 140
+                ChargeBearer:
+                  $ref: "#/components/schemas/OBChargeBearerType1Code"
+                CurrencyOfTransfer:
+                  description: "Specifies the currency of the to be transferred amount, which is different from the currency of the debtor's account."
+                  type: "string"
+                  pattern: "^[A-Z]{3,3}$"
+                DestinationCountryCode:
+                  description: "Country in which Credit Account is domiciled. Code to identify a country, a dependency, or another area of particular geopolitical interest, on the basis of country names obtained from the United Nations (ISO 3166, Alpha-2 code)."
+                  type: "string"
+                  pattern: "[A-Z]{2,2}"
+                InstructedAmount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "Amount"
+                    - "Currency"
+                  description: "Amount of money to be moved between the debtor and creditor, before deduction of charges, expressed in the currency as ordered by the initiating party.\nUsage: This amount has to be transported unchanged through the transaction chain."
+                  properties:
+                    Amount:
+                      $ref: "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
+                    Currency:
+                      $ref: "#/components/schemas/ActiveOrHistoricCurrencyCode"
+                DebtorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                  description: "Unambiguous identification of the account of the debtor to which a debit entry will be made as a result of the transaction."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level, as displayed by the ASPSP's online channels.\nNote, the account name is not the product name or the nickname of the account."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                Creditor:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Party to which an amount of money is due."
+                  properties:
+                    Name:
+                      description: "Name by which a party is known and which is usually used to identify that party."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    PostalAddress:
+                      $ref: "#/components/schemas/OBPostalAddress6"
+                CreditorAgent:
+                  type: "object"
+                  additionalProperties: false
+                  description: "Party that manages the account on behalf of the account owner, that is manages the registration and booking of entries on the account, calculates balances on the account and provides information about the account.\nThis is the servicer of the beneficiary account."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalFinancialInstitutionIdentification4Code"
+                    Identification:
+                      description: "Unique and unambiguous identification of the servicing institution."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 35
+                    Name:
+                      $ref: "#/components/schemas/Name"
+                    PostalAddress:
+                      $ref: "#/components/schemas/OBPostalAddress6"
+                CreditorAccount:
+                  type: "object"
+                  additionalProperties: false
+                  required:
+                    - "SchemeName"
+                    - "Identification"
+                    - "Name"
+                  description: "Provides the details to identify the beneficiary account."
+                  properties:
+                    SchemeName:
+                      $ref: "#/components/schemas/OBExternalAccountIdentification4Code"
+                    Identification:
+                      $ref: "#/components/schemas/Identification_0"
+                    Name:
+                      description: "The account name is the name or names of the account owner(s) represented at an account level.\nNote, the account name is not the product name or the nickname of the account.\nOB: ASPSPs may carry out name validation for Confirmation of Payee, but it is not mandatory."
+                      type: "string"
+                      minLength: 1
+                      maxLength: 350
+                    SecondaryIdentification:
+                      $ref: "#/components/schemas/SecondaryIdentification"
+                SupplementaryData:
+                  $ref: "#/components/schemas/OBSupplementaryData1"
+            MultiAuthorisation:
+              type: "object"
+              additionalProperties: false
+              required:
+                - "Status"
+              description: "The multiple authorisation flow response from the ASPSP."
+              properties:
+                Status:
+                  description: "Specifies the status of the authorisation flow in code form."
+                  type: "string"
+                  enum:
+                    - "Authorised"
+                    - "AwaitingFurtherAuthorisation"
+                    - "Rejected"
+                NumberRequired:
+                  description: "Number of authorisations required for payment order (total required at the start of the multi authorisation journey)."
+                  type: "integer"
+                NumberReceived:
+                  description: "Number of authorisations received."
+                  type: "integer"
+                LastUpdateDateTime:
+                  description: "Last date and time at the authorisation flow was updated.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+                ExpirationDateTime:
+                  description: "Date and time at which the requested authorisation flow must be completed.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                  type: "string"
+                  format: "date-time"
+            Debtor:
+              $ref: "#/components/schemas/OBCashAccountDebtor4"
+        Links:
+          $ref: "#/components/schemas/Links"
+        Meta:
+          $ref: "#/components/schemas/Meta"
+    OBWritePaymentDetailsResponse1:
+      type: "object"
+      additionalProperties: false
+      required:
+        - "Data"
+      properties:
+        Data:
+          type: "object"
+          additionalProperties: false
+          properties:
+            PaymentStatus:
+              type: "array"
+              items:
+                type: "object"
+                additionalProperties: false
+                description: "Payment status details."
+                required:
+                  - "PaymentTransactionId"
+                  - "Status"
+                  - "StatusUpdateDateTime"
+                properties:
+                  PaymentTransactionId:
+                    description: "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable."
+                    type: "string"
+                    minLength: 1
+                    maxLength: 210
+                  Status:
+                    description: "Status of a transfe, as assigned by the transaction administrator."
+                    type: "string"
+                    enum:
+                      - "Accepted"
+                      - "AcceptedCancellationRequest"
+                      - "AcceptedCreditSettlementCompleted"
+                      - "AcceptedCustomerProfile"
+                      - "AcceptedFundsChecked"
+                      - "AcceptedSettlementCompleted"
+                      - "AcceptedSettlementInProcess"
+                      - "AcceptedTechnicalValidation"
+                      - "AcceptedWithChange"
+                      - "AcceptedWithoutPosting"
+                      - "Cancelled"
+                      - "NoCancellationProcess"
+                      - "PartiallyAcceptedCancellationRequest"
+                      - "PartiallyAcceptedTechnicalCorrect"
+                      - "PaymentCancelled"
+                      - "Pending"
+                      - "PendingCancellationRequest"
+                      - "Received"
+                      - "Rejected"
+                      - "RejectedCancellationRequest"
+                  StatusUpdateDateTime:
+                    description: "Date and time at which the status was assigned to the transfer.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
+                    type: "string"
+                    format: "date-time"
+                  StatusDetail:
+                    type: "object"
+                    additionalProperties: false
+                    required:
+                      - "Status"
+                    description: "Payment status details as per underlying Payment Rail."
+                    properties:
+                      LocalInstrument:
+                        $ref: "#/components/schemas/OBExternalLocalInstrument1Code"
+                      Status:
+                        description: "Status of a transfer, as assigned by the transaction administrator."
+                        type: "string"
+                        minLength: 1
+                        maxLength: 128
+                      StatusReason:
+                        description: "Reason Code provided for the status of a transfer."
+                        type: "string"
+                        enum:
+                          - "Cancelled"
+                          - "PendingFailingSettlement"
+                          - "PendingSettlement"
+                          - "Proprietary"
+                          - "ProprietaryRejection"
+                          - "Suspended"
+                          - "Unmatched"
+                      StatusReasonDescription:
+                        description: "Reason provided for the status of a transfer."
+                        type: "string"
+                        minLength: 1
+                        maxLength: 256
+        Links:
+          $ref: "#/components/schemas/Links"
+        Meta:
+          $ref: "#/components/schemas/Meta"
+    PostCode:
+      description: "Identifier consisting of a group of letters and/or numbers that is added to a postal address to assist the sorting of mail."
+      type: "string"
+      minLength: 1
+      maxLength: 16
+    SecondaryIdentification:
+      description: "This is secondary identification of the account, as assigned by the account servicing institution. \nThis can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination)."
+      type: "string"
+      minLength: 1
+      maxLength: 34
+    StreetName:
+      description: "Name of a street or thoroughfare."
+      type: "string"
+      minLength: 1
+      maxLength: 70
+    SubDepartment:
+      description: "Identification of a sub-division of a large organisation or building."
+      type: "string"
+      minLength: 1
+      maxLength: 70
+    TownName:
+      description: "Name of a built-up area, with defined boundaries, and a local government."
+      type: "string"
+      minLength: 1
+      maxLength: 35
+

--- a/src/main/resources/specification/vrp-openapi.yaml
+++ b/src/main/resources/specification/vrp-openapi.yaml
@@ -1,0 +1,943 @@
+openapi: 3.0.0
+info:
+  title: OBIE VRP Profile
+  description: VRP OpenAPI Specification
+  version: 3.1.8
+tags:
+  - name: variable-recurring-payments
+paths:
+  /domestic-vrp-consents:
+    post:
+      tags:
+        - variable-recurring-payments
+      summary: create a domestic vrp
+      description: create a domestic vrp
+      responses:
+        '201':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OBDomesticVRPConsentResponse'
+
+  /domestic-vrp-consents/:consentId:
+    get:
+      tags:
+        - variable-recurring-payments
+      summary: create a domestic vrp
+      description: create a domestic vrp
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OBDomesticVRPConsentResponse'
+
+    delete:
+      tags:
+        - variable-recurring-payments
+      summary: create a domestic vrp
+      description: create a domestic vrp
+      responses:
+        '204':
+          description: 'all good'
+
+  /domestic-vrp-consents/:consentId/funds-confirmation:
+    post:
+      tags:
+        - variable-recurring-payments
+      summary: create a domestic vrp
+      description: create a domestic vrp
+      responses:
+        '200':
+          description: ''
+          content:
+            application/json:
+              schema:
+                $ref: '#components/schemas/OBVRPFundsConfirmationResponse'
+
+components:
+  schemas:
+    OBDomesticVRPConsentResponse:
+      type: object
+      required:
+        - Data
+        - Risk
+        - Links
+        - Meta
+
+      properties:
+        Data:
+          type: object
+          required:
+            - ConsentId
+            - CreationDateTime
+            - Status
+            - StatusUpdateDateTime
+            - ControlParameters
+            - Initiation
+            - DebtorAccount
+          properties:
+            ReadRefundAccount:
+              type: string
+              enum:
+                - Yes
+                - No
+              description: >
+                Indicates whether information about RefundAccount should be included in the payment response.
+            ConsentId:
+              type: string              
+              description: >
+                Unique identification as assigned by the ASPSP to uniquely identify the consent resource.      | Max128Text
+            CreationDateTime:
+              type: string
+              format: date-time
+              description: >
+                Date and time at which the resource was created.|ISODateTime
+            Status:
+              type: string
+              description: >
+                Specifies the status of resource in code form.  |Authorised AwaitingAuthorisation Rejected Revoked Expired
+            StatusUpdateDateTime:
+              type: string
+              format: date-time
+              description: >
+                Date and time at which the resource status was updated.  | ISODateTime  
+            ControlParameters:
+              $ref: '#/components/schemas/OBDomesticVRPControlParameters'
+            Initiation:
+              $ref: '#/components/schemas/OBDomesticVRPInitiation'
+            DebtorAccount:
+              $ref: '#/components/schemas/OBCashAccountDebtorWithName'
+        Risk:
+          $ref: '#/components/schemas/OBRisk1'
+        Links:
+          $ref: '#/components/schemas/Links'
+        Meta:
+          $ref: '#/components/schemas/Meta'
+
+    OBDomesticVRPConsentRequest:
+      type: object
+      required:
+        - Data
+        - Risk
+      properties:
+        Data:
+          type: object
+          required: 
+            - ControlParameters
+            - Initiation
+
+          properties:
+            ReadRefundAccount:
+              type: string
+              enum:
+                - Yes
+                - No
+              description: >
+                Indicates whether information about RefundAccount should be included in the payment response.
+            ControlParameters:
+              $ref: '#/components/schemas/OBDomesticVRPControlParameters'
+            Initiation:
+              $ref: '#/components/schemas/OBDomesticVRPInitiation'
+        Risk:
+          $ref: '#/components/schemas/OBRisk1'
+
+    OBDomesticVRPControlParameters:
+      type: object
+      required:
+        - VRPType
+
+      properties:
+        ValidFromDateTime:
+          type: string
+          format: date-time
+          description: ^
+            Start date time for which the consent remains valid. | ISODateTime
+        ValidToDateTime:
+          type: string
+          format: date-time
+          description: ^
+            End date time for which the consent remains valid. | ISODateTime
+        MaximumIndividualAmount:
+          type: object
+          required:
+            - Amount
+            - Currency
+          properties:
+            Amount:
+              type: string
+              description: ^
+                A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.
+            Currency:
+              type: string
+              description: ^
+                A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 "Codes for the representation of currencies and funds".   | ActiveOrHistoricCurrencyCode  
+        PeriodicLimits:
+          type: array
+          items:
+            type: object
+            required:
+              - PeriodType
+              - PeriodAlignment
+              - Amount
+              - Currency
+            properties:
+              PeriodType:
+                type: string
+                enum: 
+                  - Day
+                  - Week
+                  - Fortnight
+                  - Month
+                  - Half-year
+                  - Year
+                description: ^
+                  Period type for this period limit
+              PeriodAlignment:
+                type: string
+                enum:
+                  - Consent
+                  - Calendar
+                description: ^
+                  Specifies whether the period starts on the date of consent creation or lines up with a calendar 
+              Amount:
+                type: string
+                description: ^
+                  A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.
+              Currency:
+                type: string
+                description: ^
+                  A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 "Codes for the representation of currencies and funds".   | ActiveOrHistoricCurrencyCode          
+        VRPType:
+          type: array
+          items: 
+            type: string
+          minItems: 1
+          description: ^
+            The types of payments that can be made under this VRP consent. This can be used to indicate whether this include sweeping payment or other ecommerce payments.  | OBVRPConsentType - Namespaced Enumeration
+        PSUAuthenticationMethods:
+          type: array
+          minItems: 1
+          description: ^
+            Indicates that the PSU authentication methods supported.  | OBVRPAuthenticationMethods - Namespaced Enumeration
+          items:
+            type: string
+        SupplementaryData:
+          type: object
+          description: ^
+            Additional information that can not be captured in the structured fields and/or any other specific block 
+
+
+    OBDomesticVRPInitiation:
+      type: object
+      properties:
+        DebtorAccount:
+          $ref: '#/components/schemas/OBCashAccountDebtorWithName'
+        CreditorAgent:
+          $ref: '#/components/schemas/OBBranchAndFinancialInstitutionIdentification6'
+        CreditorAccount:
+          $ref: '#/components/schemas/OBCashAccountCreditor3'
+        RemittanceInformation:
+          type: object
+          description: ^
+            Information supplied to enable the matching of an entry with the items that the transfer is intended to settle, such as commercial invoices in an accounts' receivable system.
+          properties:
+            Unstructured:
+              type: string
+              maxLength: 140 
+              description: ^
+                Information supplied to enable the matching/reconciliation of an entry with the items that the payment is intended to settle, such as commercial invoices in an accounts' receivable system, in an unstructured form.
+            Reference:
+              type: string
+              maxLength: 35
+              description : ^
+                Unique reference, as assigned by the creditor,
+                to unambiguously refer to the payment transaction. 
+                Usage - If available, the initiating party should provide this reference in the structured remittance information, to enable reconciliation by the creditor upon receipt of the amount of money. If the business context requires the use of a creditor reference or a payment remit identification, and only one identifier can be passed through the end-to-end chain, the creditor's reference or payment remittance identification should be quoted in the end-to-end transaction identification.
+    OBCashAccountDebtorWithName:
+      type: object
+      required:
+        - SchemeName
+        - Identification
+        - Name
+      description: ^
+        Only incuded in the response if `Data. ReadRefundAccount` is set to `Yes` in the consent.
+
+      properties:
+        SchemeName:
+          type: string
+          description: ^
+            Name of the identification scheme, in a coded form as published in an external list. | Namespaced Enumeration OBExternalAccountIdentification4Code
+        Identification:
+          type: string
+          description: ^
+            Identification assigned by an institution to identify an account. This identification is known by the account owner. | Max256Text
+        Name:
+          type: string
+          description: ^
+            Name of the account, as assigned by the account servicing institution.  Usage The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account.
+        SecondaryIdentification:
+          type: string
+          description: ^
+            This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination) | Max34Text
+
+    OBCashAccountCreditor3:
+      type: object
+      required:
+        - SchemeName
+        - Identification
+        - Name
+      properties:
+        SchemeName:
+          type: string
+          description: ^
+            Name of the identification scheme, in a coded form as published in an external list. | Namespaced Enumeration OBExternalAccountIdentification4Code
+        Identification:
+          type: string
+          description: ^
+            Identification assigned by an institution to identify an account. This identification is known by the account owner. | Max256Text
+        Name:
+          type: string
+          description: ^
+            Name of the account, as assigned by the account servicing institution.  Usage The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account.
+        SecondaryIdentification:
+          type: string
+          description: ^
+            This is secondary identification of the account, as assigned by the account servicing institution.  This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination) | Max34Text
+
+    OBBranchAndFinancialInstitutionIdentification6:
+      type: object
+      properties:
+        SchemeName:
+          type: string
+          description: ^
+            0..1) | `SchemeName` |Name of the identification scheme, in a coded form as published in an external list. |OBExternalFinancialInstitutionIdentification4Code
+        Identification:
+          type: string
+          description: ^
+            0..1) | `Identification` |Unique and unambiguous identification of a financial institution or a branch of a financial institution.  | Max35Text  
+        Name:
+          type: string
+          description: ^
+            0..1) | `Name` | Name by which an agent is known and which is usually used to identify that agent. | Max140Text
+        PostalAddress:
+          type: object
+          description: ^
+            0..1) | `PostalAddress` |Information that locates and identifies a specific address, as defined by postal services.| OBPostalAddress6
+          properties:            
+            AddressType:
+              type: string
+              description: ^
+                0..1) | `PostalAddress. AddressType` |Identifies the nature of the postal address. |OBAddressTypeCode  |Business Correspondence DeliveryTo MailTo POBox Postal Residential Statement
+            Department:
+              type: string
+              description: ^
+                0..1) | `PostalAddress. Department` |Identification of a division of a large organisation or building. | Max70Text  
+            SubDepartment:
+              type: string
+              description: ^
+                0..1) | `PostalAddress. SubDepartment` |Identification of a sub-division of a large organisation or building. |Max70Text
+            StreetName:
+              type: string
+              description: ^
+                0..1) | `PostalAddress. StreetName`   |Name of a street or thoroughfare.    |Max70Text  
+            BuildingNumber:
+              type: string
+              description: ^
+                0..1) | `PostalAddress. BuildingNumber` |Number that identifies the position of a building on a street.   |Max16Text  
+            PostCode:
+              type: string
+              description: ^
+                0..1) | `PostalAddress. PostCode` |Identifier consisting of a group of letters and. or numbers that is added to a postal address to assist the sorting of mail.    |Max16Text  
+            TownName:
+              type: string
+              description: ^
+                0..1) | `PostalAddress. TownName` |Name of a built-up area, with defined boundaries, and a local government. |Max35Text  
+            CountrySubDivision:
+              type: string
+              description: ^
+                0..1) | `PostalAddress. CountrySubDivision` |Identifies a subdivision of a country such as state, region, county.      |Max35Text  
+            Country:
+              type: string
+              description: ^
+                0..1) | `PostalAddress. Country` | Nation with its own government.      |CountryCode
+            AddressLine:
+              type: array
+              minItems: 0
+              maxItems: 7
+              items:
+                type: string
+
+    OBDomesticVRPRequest:
+      type: object
+      required:
+        - Data
+        - Risk
+        - Links
+        - Meta
+      properties:
+        Data:
+          type: object
+          required:
+            - ConsentId
+            - PSUAuthenticationMethod
+            - Initiation
+            - Instruction
+            - Risk
+          properties:
+            ConsentId:
+              type: string
+              maxLength: 128
+              description: |-
+                Identifier for the Domestic VRP Consent that this payment is made under.
+            PSUAuthenticationMethod:
+              type: string
+              description: ^
+                The authentication method that was used to authenicate the PSU.   | OBVRPAuthenticationMethods - Namespaced Enumeration
+            Initiation:
+              $ref: '#/components/schemas/OBDomesticVRPInitiation'
+            Instruction:
+              $ref: '#/components/schemas/OBDomesticVRPInstruction'
+        Risk:
+          $ref: '#/components/schemas/OBRisk1'
+
+    OBDomesticVRPResponse:
+      type: object
+      required:
+        - Data
+        - Risk
+        - Links
+        - Meta
+      properties:
+        Data:
+          type: object
+          required:
+            - DomesticVRPId
+            - ConsentId
+            - CreationDateTime
+            - Status
+            - StatusUpdateDateTime
+            - Initiation
+            - Instruction
+            - DebtorAccount
+          properties:
+            DomesticVRPId:
+              type: string
+              maxLength: 40
+              description: >
+                Unique identification as assigned by the ASPSP to uniquely identify the domestic payment resource.
+            ConsentId:
+              type: string
+              maxLength: 128
+              description: >
+                Identifier for the Domestic VRP Consent that this payment is made under.
+            CreationDateTime:
+              type: string
+              format: date-time
+              description: >
+                Date and time at which the resource was created.
+            Status:
+              type: string
+              description: Specifies the status of the payment information group.
+              enum:
+              - AcceptedCreditSettlementCompleted
+              - AcceptedWithoutPosting
+              - AcceptedSettlementCompleted
+              - AcceptedSettlementInProcess
+              - Pending
+              - Rejected
+            StatusUpdateDateTime:
+              type: string
+              format: date-time
+              description: >
+                Date and time at which the resource status was updated.
+            ExpectedExecutionDateTime:
+              type: string
+              format: date-time
+              description: >
+                Expected execution date and time for the payment resource.
+            ExpectedSettlementDateTime:
+              type: string
+              format: date-time
+              description: >
+                Expected settlement date and time for the payment resource.
+            Refund:
+              $ref: '#/components/schemas/OBCashAccountDebtorWithName'
+            Charges:
+              type: array
+              items:
+                required:
+                - Amount
+                - ChargeBearer
+                - Type
+                type: object
+                properties:
+                  ChargeBearer:
+                    $ref: '#/components/schemas/OBChargeBearerType1Code'
+                  Type:
+                    $ref: '#/components/schemas/OBExternalPaymentChargeType1Code'
+                  Amount:
+                    $ref: '#/components/schemas/OBActiveOrHistoricCurrencyAndAmount'
+                description: Set of elements used to provide details of a charge for
+                  the payment initiation.
+            Initiation:
+              $ref: '#/components/schemas/OBDomesticVRPInitiation'
+            Instruction:
+              $ref: '#/components/schemas/OBDomesticVRPInstruction'
+            DebtorAccount:
+              $ref: '#/components/schemas/OBCashAccountDebtorWithName'
+        Risk:
+          $ref: '#/components/schemas/OBRisk1'
+        Links:
+          $ref: '#/components/schemas/Links'
+        Meta:
+          $ref: '#/components/schemas/Meta'
+
+    OBDomesticVRPDetails:
+      type: object
+      properties:
+        Data:
+          type: object
+          required:
+            - PaymentTransactionId
+          properties:
+            PaymentStatus:
+              type: array
+              items:
+                # TODO: extract (would do it but i'm not fully getting the naming convention)
+                required:
+                  - PaymentTransactionId
+                  - Status
+                  - StatusUpdateDateTime
+                type: object
+                properties:
+                  PaymentTransactionId:
+                    type: string
+                    maxLength: 210
+                    description: |-
+                      Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable.
+                  Status:
+                    type: string
+                    description: |-
+                      Status of a transfer, as assigned by the transaction administrator.
+                    enum:
+                      - Accepted 
+                      - AcceptedCancellationRequest 
+                      - AcceptedCreditSettlementCompleted 
+                      - AcceptedCustomerProfile 
+                      - AcceptedFundsChecked 
+                      - AcceptedSettlementCompleted 
+                      - AcceptedSettlementInProcess
+                      - AcceptedTechnicalValidation
+                      - AcceptedWithChange
+                      - AcceptedWithoutPosting
+                      - Cancelled
+                      - NoCancellationProcess
+                      - PartiallyAcceptedCancellationRequest
+                      - PartiallyAcceptedTechnicalCorrect
+                      - PaymentCancelled
+                      - Pending
+                      - PendingCancellationRequest
+                      - Received
+                      - Rejected
+                      - RejectedCancellationRequest
+                  StatusUpdateDateTime:
+                    type: string
+                    format: date-time
+                    description: >
+                      Date and time at which the status was assigned to the transfer.
+                  StatusDetail:
+                    type: object
+                    required:
+                      - Status
+                    properties:
+                      LocalInstrument:
+                        $ref: '#/components/schemas/OBExternalLocalInstrument1Code'
+                      Status:
+                        type: string
+                        maxLength: 128
+                        description: |-
+                          Status of a transfer, as assigned by the transaction administrator.
+                      StatusReason:
+                        type: string
+                        description: |- 
+                          Reason Code provided for the status of a transfer.
+                        enum:
+                          - Cancelled 
+                          - PendingFailingSettlement 
+                          - PendingSettlement 
+                          - Proprietary 
+                          - ProprietaryRejection 
+                          - Suspended 
+                          - Unmatched
+                      StatusReasonDescription:
+                        type: string
+                        maxLength: 128
+                        description: |-
+                          Reason provided for the status of a transfer.
+
+    OBVRPFundsConfirmationRequest:
+      type: object
+      description: |-
+        The OBVRPFundsConfirmationRequest object must be used to request funds availability for a specific amount in the Debtor Account included in the VRP consents.
+      properties:
+        Data:
+          type: object
+          required:
+            - ConsentId
+            - Reference
+            - InstructedAmount
+          properties:
+            ConsentId:
+              type: string
+              maxLength: 128
+              description: |-
+                Unique identification as assigned by the ASPSP to uniquely identify the funds confirmation consent resource.
+            Reference:
+              type: string
+              maxLength: 35
+              description: |-
+                nique reference, as assigned by the PISP, to unambiguously refer to the request related to the payment transaction.
+            InstructedAmount:
+              $ref: '#/components/schemas/OBActiveOrHistoricCurrencyAndAmount'
+    
+    OBVRPFundsConfirmationResponse:
+      type: object
+      description: |-
+        The confirmation of funds response contains the result of a funds availability check.
+      properties:
+        Data:
+          type: object
+          required:
+            - FundsConfirmationId
+            - ConsentId
+            - CreationDateTime
+            - Reference
+            - FundsAvailableResult
+            - InstructedAmount
+          properties:
+            FundsConfirmationId:
+              type: string
+              maxLength: 40
+              description: |-
+                Unique identification as assigned by the ASPSP to uniquely identify the funds confirmation resource.
+            ConsentId:
+              type: string
+              maxLength: 128
+              description: |-
+                Unique identification as assigned by the ASPSP to uniquely identify the funds confirmation consent resource.
+            CreationDateTime:
+              type: string
+              format: date-time
+              description: |-
+                Date and time at which the resource was created.
+            Reference:
+              type: string
+              maxLength: 35
+              description: |-
+                Unique reference, as assigned by the CBPII, to unambiguously refer to the request related to the payment transaction.
+            FundsAvailableResult:
+              $ref: '#/components/schemas/OBPAFundsAvailableResult1'
+            InstructedAmount:
+              $ref: '#/components/schemas/OBActiveOrHistoricCurrencyAndAmount'
+        
+    OBPAFundsAvailableResult1:
+      type: object
+      description: |-
+          Availaility result, clearly indicating the availability of funds given the Amount in the request.
+      required:
+        - FundsAvailableDateTime
+        - FundsAvailable
+      properties:
+        FundsAvailableDateTime:
+          type: string
+          format: date-time
+          description: |-
+            Date and time at which the funds availability check was generated.
+        FundsAvailable:
+          type: string
+          description: |-
+            Availaility result, clearly indicating the availability of funds given the Amount in the request.
+          enum:
+            - Available
+            - NotAvailable
+
+    OBCharge2:
+      type: object
+      required:
+        - ChargeBearer
+        - Type
+        - Amount
+      properties:
+        ChargeBearer:
+          $ref: '#/components/schemas/OBChargeBearerType1Code'
+
+    OBExternalStatus2Code:
+      type: string
+      enum:
+       - Authorised
+       - AwaitingFurtherAuthorisation
+       - Rejected
+
+    OBChargeBearerType1Code:
+      type: string
+      description: |-
+        Specifies which party/parties will bear the charges associated with the processing of the payment transaction.
+      enum:
+        - BorneByCreditor
+        - BorneByDebtor
+        - FollowingServiceLevel
+        - Shared
+
+    OBDomesticVRPInstruction:
+      type: object
+      required:
+        - InstructionIdentification
+        - EndToEndIdentification
+        - CreditorAccount
+      properties:
+        InstructionIdentification:
+          type: string
+          maxLength: 35
+          description: |-
+            Unique identification as assigned by an instructing party for an instructed party to unambiguously identify the instruction. 
+            Usage: the instruction identification is a point to point reference that can be used between the instructing party and the instructed party to refer to the individual instruction. 
+            It can be included in several messages related to the instruction.
+        EndToEndIdentification:
+          type: string
+          maxLength: 35
+          description: |-
+              Unique identification assigned by the initiating party to unambiguously identify the transaction. 
+              This identification is passed on, unchanged, throughout the entire end-to-end chain. 
+              Usage: The end-to-end identification can be used for reconciliation or to link tasks relating to the transaction. 
+              It can be included in several messages related to the transaction. 
+              OB: The Faster Payments Scheme can only access 31 characters for the EndToEndIdentification field
+        RemittanceInformation:
+          $ref: '#/components/schemas/OBVRPRemittanceInformation'
+        LocalInstrument:
+          $ref: '#/components/schemas/OBExternalLocalInstrument1Code'
+        InstructedAmount:
+          $ref: '#/components/schemas/OBActiveOrHistoricCurrencyAndAmount'
+        CreditorAgent:
+          $ref: '#/components/schemas/OBBranchAndFinancialInstitutionIdentification6'
+        CreditorAccount:
+          $ref: '#/components/schemas/OBCashAccountCreditor3'
+        SupplementaryData:
+          type: object
+          description: ^
+            Additional information that can not be captured in the structured fields and/or any other specific block 
+
+    OBVRPRemittanceInformation:
+      type: object
+      description: |
+        Information supplied to enable the matching of an entry with the items that the transfer is intended to settle, such as commercial invoices in an accounts' receivable system.
+      properties:
+        Unstructured:
+          type: string
+          maxLength: 140
+          description: |
+            Information supplied to enable the matching/reconciliation of an entry with the items that the payment is intended to settle, such as commercial invoices in an accounts' receivable system, in an unstructured form. 
+        Reference:
+          type: string
+          maxLength: 35
+          description: |
+            Unique reference, as assigned by the creditor, to unambiguously refer to the payment transaction. The PISP must populate this with the same value as specified in the ControlParameters.Reference field of the consent.
+
+    OBExternalAccountIdentification4Code:
+      type: string
+      description: |-
+        Name of the identification scheme, in a coded form as published in an external list.
+      x-namespaced-enum:
+        - UK.OBIE.BBAN
+        - UK.OBIE.IBAN
+        - UK.OBIE.PAN
+        - UK.OBIE.Paym
+        - UK.OBIE.SortCodeAccountNumber
+
+    OBExternalLocalInstrument1Code:
+      type: string
+      description: |-
+        User community specific instrument.
+        Usage: This element is used to specify a local instrument, local clearing option and/or further qualify the service or service level.
+      x-namespaced-enum:
+      - UK.OBIE.BACS
+      - UK.OBIE.BalanceTransfer
+      - UK.OBIE.CHAPS
+      - UK.OBIE.Euro1
+      - UK.OBIE.FPS
+      - UK.OBIE.Link
+      - UK.OBIE.MoneyTransfer
+      - UK.OBIE.Paym
+      - UK.OBIE.SEPACreditTransfer
+      - UK.OBIE.SEPAInstantCreditTransfer
+      - UK.OBIE.SWIFT
+      - UK.OBIE.Target2
+
+    OBActiveOrHistoricCurrencyAndAmount:
+      required:
+      - Amount
+      - Currency
+      type: object
+      properties:
+        Amount:
+          $ref: '#/components/schemas/OBActiveCurrencyAndAmount_SimpleType'
+        Currency:
+          $ref: '#/components/schemas/ActiveOrHistoricCurrencyCode'
+
+    ActiveOrHistoricCurrencyCode:
+      pattern: ^[A-Z]{3,3}$
+      type: string
+      description: A code allocated to a currency by a Maintenance Agency under an
+        international identification scheme, as described in the latest edition of
+        the international standard ISO 4217 "Codes for the representation of currencies
+        and funds".
+
+    OBActiveCurrencyAndAmount_SimpleType:
+      pattern: ^\d{1,13}$|^\d{1,13}\.\d{1,5}$
+      type: string
+      description: A number of monetary units specified in an active currency where
+        the unit of currency is explicit and compliant with ISO 4217.
+    
+    OBExternalPaymentChargeType1Code:
+      type: string
+      enum:
+        - UK.OBIE.CHAPSOut
+        - UK.OBIE.BalanceTransferOut
+        - UK.OBIE.MoneyTransferOut
+
+    OBRisk1:
+      type: object
+      properties:
+        PaymentContextCode:
+          type: string
+          description: Specifies the payment context
+          enum:
+          - BillPayment
+          - EcommerceGoods
+          - EcommerceServices
+          - Other
+          - PartyToParty
+        MerchantCategoryCode:
+          maxLength: 4
+          minLength: 3
+          type: string
+          description: Category code conform to ISO 18245, related to the type of
+            services or goods the merchant provides for the transaction.
+        MerchantCustomerIdentification:
+          maxLength: 70
+          minLength: 1
+          type: string
+          description: The unique customer identifier of the PSU with the merchant.
+        DeliveryAddress:
+          required:
+          - Country
+          - TownName
+          type: object
+          properties:
+            AddressLine:
+              maxItems: 2
+              minItems: 0
+              type: array
+              items:
+                maxLength: 70
+                minLength: 1
+                type: string
+                description: Information that locates and identifies a specific address,
+                  as defined by postal services, that is presented in free format
+                  text.
+            StreetName:
+              $ref: '#/components/schemas/StreetName'
+            BuildingNumber:
+              $ref: '#/components/schemas/BuildingNumber'
+            PostCode:
+              $ref: '#/components/schemas/PostCode'
+            TownName:
+              $ref: '#/components/schemas/TownName'
+            CountrySubDivision:
+              $ref: '#/components/schemas/CountrySubDivision'
+            Country:
+              pattern: ^[A-Z]{2,2}$
+              type: string
+              description: Nation with its own government, occupying a particular
+                territory.
+          description: Information that locates and identifies a specific address,
+            as defined by postal services or in free format text.
+      description: The Risk section is sent by the initiating party to the ASPSP.
+        It is used to specify additional details for risk scoring for Payments.
+    StreetName:
+      maxLength: 70
+      minLength: 1
+      type: string
+      description: Name of a street or thoroughfare.
+    TownName:
+      maxLength: 35
+      minLength: 1
+      type: string
+      description: Name of a built-up area, with defined boundaries, and a local government.
+    PostCode:
+      maxLength: 16
+      minLength: 1
+      type: string
+      description: Identifier consisting of a group of letters and/or numbers that
+        is added to a postal address to assist the sorting of mail.
+    BuildingNumber:
+      maxLength: 16
+      minLength: 1
+      type: string
+      description: Number that identifies the position of a building on a street.
+    CountrySubDivision:
+      maxLength: 35
+      minLength: 1
+      type: string
+      description: Identifies a subdivision of a country such as state, region, county.
+
+    Links:
+      required:
+      - Self
+      type: object
+      properties:
+        Self:
+          type: string
+          format: uri
+        First:
+          type: string
+          format: uri
+        Prev:
+          type: string
+          format: uri
+        Next:
+          type: string
+          format: uri
+        Last:
+          type: string
+          format: uri
+      description: Links relevant to the payload
+    Meta:
+      title: MetaData
+      type: object
+      description: Meta Data relevant to the payload. At present no fields are used for VRP.
+  
+
+
+  securitySchemes:
+    TPPOAuth2Security:
+      type: oauth2
+      description: TPP client credential authorisation flow with the ASPSP
+      flows:
+        clientCredentials:
+          tokenUrl: https://authserver.example/token
+          scopes:
+            payments: Generic payment scope
+    PSUOAuth2Security:
+      type: oauth2
+      description: OAuth flow, it is required when the PSU needs to perform SCA with
+        the ASPSP when a TPP wants to access an ASPSP resource owned by the PSU
+      flows:
+        authorizationCode:
+          authorizationUrl: https://authserver.example/authorization
+          tokenUrl: https://authserver.example/token
+          scopes:
+            payments: Generic payment scope
+            


### PR DESCRIPTION
### Open API generator maven plugin

Using the `openapi-generator-maven-plugin` to generate datamodel classes. I wish I did this ages ago! It's much better at generating the java classes. Crucially it keeps the `@ApiProperty` annotations when generating them from the Open API specification (as opposed to the swagger files which do not yet exist for v3.1.8).

**Issue**: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/33