### PR TITLE
33: v3.1.8 Accounts API OBSupplementaryData1 rollback

### DIFF
--- a/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary5Basic.java
+++ b/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary5Basic.java
@@ -25,8 +25,6 @@ import io.swagger.annotations.ApiModelProperty;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Size;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -49,7 +47,7 @@ public class OBBeneficiary5Basic {
 
   @JsonProperty("SupplementaryData")
   @Valid
-  private Map<String, Object> supplementaryData = null;
+  private OBSupplementaryData1 supplementaryData = null;
 
   public OBBeneficiary5Basic accountId(String accountId) {
     this.accountId = accountId;
@@ -131,16 +129,8 @@ public class OBBeneficiary5Basic {
     this.reference = reference;
   }
 
-  public OBBeneficiary5Basic supplementaryData(Map<String, Object> supplementaryData) {
+  public OBBeneficiary5Basic supplementaryData(OBSupplementaryData1 supplementaryData) {
     this.supplementaryData = supplementaryData;
-    return this;
-  }
-
-  public OBBeneficiary5Basic putSupplementaryDataItem(String key, Object supplementaryDataItem) {
-    if (this.supplementaryData == null) {
-      this.supplementaryData = new HashMap<String, Object>();
-    }
-    this.supplementaryData.put(key, supplementaryDataItem);
     return this;
   }
 
@@ -152,11 +142,11 @@ public class OBBeneficiary5Basic {
   @ApiModelProperty(value = "Additional information that can not be captured in the structured fields and/or any other specific block.")
 
 
-  public Map<String, Object> getSupplementaryData() {
+  public OBSupplementaryData1 getSupplementaryData() {
     return supplementaryData;
   }
 
-  public void setSupplementaryData(Map<String, Object> supplementaryData) {
+  public void setSupplementaryData(OBSupplementaryData1 supplementaryData) {
     this.supplementaryData = supplementaryData;
   }
 

--- a/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary5Detail.java
+++ b/src/main/java/uk/org/openbanking/datamodel/account/OBBeneficiary5Detail.java
@@ -26,7 +26,6 @@ import io.swagger.annotations.ApiModelProperty;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -50,7 +49,7 @@ public class OBBeneficiary5Detail {
 
   @JsonProperty("SupplementaryData")
   @Valid
-  private Map<String, Object> supplementaryData = null;
+  private OBSupplementaryData1 supplementaryData = null;
 
   @JsonProperty("CreditorAgent")
   private OBBranchAndFinancialInstitutionIdentification60 creditorAgent;
@@ -138,16 +137,8 @@ public class OBBeneficiary5Detail {
     this.reference = reference;
   }
 
-  public OBBeneficiary5Detail supplementaryData(Map<String, Object> supplementaryData) {
+  public OBBeneficiary5Detail supplementaryData(OBSupplementaryData1 supplementaryData) {
     this.supplementaryData = supplementaryData;
-    return this;
-  }
-
-  public OBBeneficiary5Detail putSupplementaryDataItem(String key, Object supplementaryDataItem) {
-    if (this.supplementaryData == null) {
-      this.supplementaryData = new HashMap<String, Object>();
-    }
-    this.supplementaryData.put(key, supplementaryDataItem);
     return this;
   }
 
@@ -159,11 +150,11 @@ public class OBBeneficiary5Detail {
   @ApiModelProperty(value = "Additional information that can not be captured in the structured fields and/or any other specific block.")
 
 
-  public Map<String, Object> getSupplementaryData() {
+  public OBSupplementaryData1 getSupplementaryData() {
     return supplementaryData;
   }
 
-  public void setSupplementaryData(Map<String, Object> supplementaryData) {
+  public void setSupplementaryData(OBSupplementaryData1 supplementaryData) {
     this.supplementaryData = supplementaryData;
   }
 

--- a/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductType.java
+++ b/src/main/java/uk/org/openbanking/datamodel/account/OBReadProduct2DataOtherProductType.java
@@ -63,7 +63,7 @@ public class OBReadProduct2DataOtherProductType {
 
     @JsonProperty("SupplementaryData")
     @Valid
-    private Map<String, Object> supplementaryData = null;
+    private OBSupplementaryData1 supplementaryData = null;
 
     public OBReadProduct2DataOtherProductType name(String name) {
         this.name = name;
@@ -235,16 +235,8 @@ public class OBReadProduct2DataOtherProductType {
         this.otherFeesCharges = otherFeesCharges;
     }
 
-    public OBReadProduct2DataOtherProductType supplementaryData(Map<String, Object> supplementaryData) {
+    public OBReadProduct2DataOtherProductType supplementaryData(OBSupplementaryData1 supplementaryData) {
         this.supplementaryData = supplementaryData;
-        return this;
-    }
-
-    public OBReadProduct2DataOtherProductType putSupplementaryDataItem(String key, Object supplementaryDataItem) {
-        if (this.supplementaryData == null) {
-            this.supplementaryData = new HashMap<String, Object>();
-        }
-        this.supplementaryData.put(key, supplementaryDataItem);
         return this;
     }
 
@@ -254,11 +246,11 @@ public class OBReadProduct2DataOtherProductType {
      * @return supplementaryData
      */
     @ApiModelProperty(value = "Additional information that can not be captured in the structured fields and/or any other specific block.")
-    public Map<String, Object> getSupplementaryData() {
+    public OBSupplementaryData1 getSupplementaryData() {
         return supplementaryData;
     }
 
-    public void setSupplementaryData(Map<String, Object> supplementaryData) {
+    public void setSupplementaryData(OBSupplementaryData1 supplementaryData) {
         this.supplementaryData = supplementaryData;
     }
 

--- a/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder6Basic.java
+++ b/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder6Basic.java
@@ -28,7 +28,6 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -86,7 +85,7 @@ public class OBStandingOrder6Basic {
 
   @JsonProperty("SupplementaryData")
   @Valid
-  private Map<String, Object> supplementaryData = null;
+  private OBSupplementaryData1 supplementaryData = null;
 
   public OBStandingOrder6Basic accountId(String accountId) {
     this.accountId = accountId;
@@ -370,16 +369,8 @@ public class OBStandingOrder6Basic {
     this.finalPaymentAmount = finalPaymentAmount;
   }
 
-  public OBStandingOrder6Basic supplementaryData(Map<String, Object> supplementaryData) {
+  public OBStandingOrder6Basic supplementaryData(OBSupplementaryData1 supplementaryData) {
     this.supplementaryData = supplementaryData;
-    return this;
-  }
-
-  public OBStandingOrder6Basic putSupplementaryDataItem(String key, Object supplementaryDataItem) {
-    if (this.supplementaryData == null) {
-      this.supplementaryData = new HashMap<String, Object>();
-    }
-    this.supplementaryData.put(key, supplementaryDataItem);
     return this;
   }
 
@@ -391,11 +382,11 @@ public class OBStandingOrder6Basic {
   @ApiModelProperty(value = "Additional information that can not be captured in the structured fields and/or any other specific block.")
 
 
-  public Map<String, Object> getSupplementaryData() {
+  public OBSupplementaryData1 getSupplementaryData() {
     return supplementaryData;
   }
 
-  public void setSupplementaryData(Map<String, Object> supplementaryData) {
+  public void setSupplementaryData(OBSupplementaryData1 supplementaryData) {
     this.supplementaryData = supplementaryData;
   }
 

--- a/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder6Detail.java
+++ b/src/main/java/uk/org/openbanking/datamodel/account/OBStandingOrder6Detail.java
@@ -28,7 +28,6 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
@@ -92,7 +91,7 @@ public class OBStandingOrder6Detail {
 
     @JsonProperty("SupplementaryData")
     @Valid
-    private Map<String, Object> supplementaryData = null;
+    private OBSupplementaryData1 supplementaryData = null;
 
     public OBStandingOrder6Detail accountId(String accountId) {
         this.accountId = accountId;
@@ -417,16 +416,8 @@ public class OBStandingOrder6Detail {
         this.creditorAccount = creditorAccount;
     }
 
-    public OBStandingOrder6Detail supplementaryData(Map<String, Object> supplementaryData) {
+    public OBStandingOrder6Detail supplementaryData(OBSupplementaryData1 supplementaryData) {
         this.supplementaryData = supplementaryData;
-        return this;
-    }
-
-    public OBStandingOrder6Detail putSupplementaryDataItem(String key, Object supplementaryDataItem) {
-        if (this.supplementaryData == null) {
-            this.supplementaryData = new HashMap<String, Object>();
-        }
-        this.supplementaryData.put(key, supplementaryDataItem);
         return this;
     }
 
@@ -436,11 +427,11 @@ public class OBStandingOrder6Detail {
      * @return supplementaryData
      */
     @ApiModelProperty(value = "Additional information that can not be captured in the structured fields and/or any other specific block.")
-    public Map<String, Object> getSupplementaryData() {
+    public OBSupplementaryData1 getSupplementaryData() {
         return supplementaryData;
     }
 
-    public void setSupplementaryData(Map<String, Object> supplementaryData) {
+    public void setSupplementaryData(OBSupplementaryData1 supplementaryData) {
         this.supplementaryData = supplementaryData;
     }
 

--- a/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction6Basic.java
+++ b/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction6Basic.java
@@ -90,7 +90,7 @@ public class OBTransaction6Basic {
 
   @JsonProperty("SupplementaryData")
   @Valid
-  private Map<String, Object> supplementaryData = null;
+  private OBSupplementaryData1 supplementaryData = null;
 
   public OBTransaction6Basic accountId(String accountId) {
     this.accountId = accountId;
@@ -426,16 +426,8 @@ public class OBTransaction6Basic {
     this.cardInstrument = cardInstrument;
   }
 
-  public OBTransaction6Basic supplementaryData(Map<String, Object> supplementaryData) {
+  public OBTransaction6Basic supplementaryData(OBSupplementaryData1 supplementaryData) {
     this.supplementaryData = supplementaryData;
-    return this;
-  }
-
-  public OBTransaction6Basic putSupplementaryDataItem(String key, Object supplementaryDataItem) {
-    if (this.supplementaryData == null) {
-      this.supplementaryData = new HashMap<String, Object>();
-    }
-    this.supplementaryData.put(key, supplementaryDataItem);
     return this;
   }
 
@@ -447,11 +439,11 @@ public class OBTransaction6Basic {
   @ApiModelProperty(value = "Additional information that can not be captured in the structured fields and/or any other specific block.")
 
 
-  public Map<String, Object> getSupplementaryData() {
+  public OBSupplementaryData1 getSupplementaryData() {
     return supplementaryData;
   }
 
-  public void setSupplementaryData(Map<String, Object> supplementaryData) {
+  public void setSupplementaryData(OBSupplementaryData1 supplementaryData) {
     this.supplementaryData = supplementaryData;
   }
 

--- a/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction6Detail.java
+++ b/src/main/java/uk/org/openbanking/datamodel/account/OBTransaction6Detail.java
@@ -111,7 +111,7 @@ public class OBTransaction6Detail {
 
   @JsonProperty("SupplementaryData")
   @Valid
-  private Map<String, Object> supplementaryData = null;
+  private OBSupplementaryData1 supplementaryData = null;
 
   public OBTransaction6Detail accountId(String accountId) {
     this.accountId = accountId;
@@ -587,16 +587,8 @@ public class OBTransaction6Detail {
     this.cardInstrument = cardInstrument;
   }
 
-  public OBTransaction6Detail supplementaryData(Map<String, Object> supplementaryData) {
+  public OBTransaction6Detail supplementaryData(OBSupplementaryData1 supplementaryData) {
     this.supplementaryData = supplementaryData;
-    return this;
-  }
-
-  public OBTransaction6Detail putSupplementaryDataItem(String key, Object supplementaryDataItem) {
-    if (this.supplementaryData == null) {
-      this.supplementaryData = new HashMap<String, Object>();
-    }
-    this.supplementaryData.put(key, supplementaryDataItem);
     return this;
   }
 
@@ -608,11 +600,11 @@ public class OBTransaction6Detail {
   @ApiModelProperty(value = "Additional information that can not be captured in the structured fields and/or any other specific block.")
 
 
-  public Map<String, Object> getSupplementaryData() {
+  public OBSupplementaryData1 getSupplementaryData() {
     return supplementaryData;
   }
 
-  public void setSupplementaryData(Map<String, Object> supplementaryData) {
+  public void setSupplementaryData(OBSupplementaryData1 supplementaryData) {
     this.supplementaryData = supplementaryData;
   }
 


### PR DESCRIPTION
### Accounts API OBSupplementaryData1 rollback

The benefit of overwriting existing classes is that you're less likely to miss changes to them, but it's not without risk. It looks like I shouldn't have changed `OBSupplementaryData1` to a `Map` (since we deliberately have `OBSupplementaryData1Serializer` and `OBSupplementaryData1Deserializer` for this).

**Issue**: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/33