### PR TITLE
49: Add OBDomesticVRPResponseTestDataFactory - Use java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,8 +126,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>11</source>
+                    <target>11</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPResponse.java
+++ b/src/main/java/uk/org/openbanking/datamodel/vrp/OBDomesticVRPResponse.java
@@ -28,6 +28,8 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import java.util.Objects;
 
+import uk.org.openbanking.datamodel.account.Links;
+
 /**
  * OBDomesticVRPResponse
  */

--- a/src/test/java/uk/org/openbanking/testsupport/vrp/OBDomesticVRPCommonTestDataFactory.java
+++ b/src/test/java/uk/org/openbanking/testsupport/vrp/OBDomesticVRPCommonTestDataFactory.java
@@ -103,4 +103,11 @@ public class OBDomesticVRPCommonTestDataFactory {
                 .country("UK");
     }
 
+    public static OBDomesticVRPResponseDataCharges aValidOBDomesticVRPResponseDataCharges(){
+        return (new OBDomesticVRPResponseDataCharges())
+                .amount(aValidOBActiveOrHistoricCurrencyAndAmount())
+                .chargeBearer(OBChargeBearerType1Code.BORNEBYCREDITOR)
+                .type(OBExternalPaymentChargeType1Code.BALANCETRANSFEROUT);
+    }
+
 }

--- a/src/test/java/uk/org/openbanking/testsupport/vrp/OBDomesticVRPResponseTestDataFactory.java
+++ b/src/test/java/uk/org/openbanking/testsupport/vrp/OBDomesticVRPResponseTestDataFactory.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2019 ForgeRock AS.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package uk.org.openbanking.testsupport.vrp;
+
+import org.joda.time.DateTime;
+import uk.org.openbanking.datamodel.vrp.OBDomesticVRPRequest;
+import uk.org.openbanking.datamodel.vrp.OBDomesticVRPResponseData;
+
+import java.util.List;
+
+public class OBDomesticVRPResponseTestDataFactory {
+
+    public static OBDomesticVRPResponseData aValidOBDomesticVRPResponseData(OBDomesticVRPRequest request) {
+        OBDomesticVRPResponseData domesticVRPResponse = new OBDomesticVRPResponseData();
+        domesticVRPResponse
+                .domesticVRPId("123456")
+                .consentId("VRP_1233456")
+                .creationDateTime(new DateTime())
+                .status(OBDomesticVRPResponseData.StatusEnum.ACCEPTEDSETTLEMENTCOMPLETED)
+                .statusUpdateDateTime(new DateTime())
+                .expectedExecutionDateTime(new DateTime())
+                .expectedSettlementDateTime(new DateTime())
+                .refund(OBDomesticVRPCommonTestDataFactory.aValidOBCashAccountDebtorWithName())
+                .charges(List.of(OBDomesticVRPCommonTestDataFactory.aValidOBDomesticVRPResponseDataCharges()))
+                .initiation(OBDomesticVRPCommonTestDataFactory.aValidOBDomesticVRPInitiation())
+                .instruction(OBDomesticVRPRequestTestDataFactory.aValidOBDomesticVRPInstruction())
+                .debtorAccount(OBDomesticVRPCommonTestDataFactory.aValidOBCashAccountDebtorWithName());
+
+        return domesticVRPResponse;
+    }
+}


### PR DESCRIPTION
Changed mvn compiler version to 11 in line with openbanking-parent
Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/48