### PR TITLE
47: vrp payment consent controller

### DIFF
--- a/src/test/java/uk/org/openbanking/testsupport/vrp/OBDomesticVRPConsentRequestTestDataFactory.java
+++ b/src/test/java/uk/org/openbanking/testsupport/vrp/OBDomesticVRPConsentRequestTestDataFactory.java
@@ -64,6 +64,7 @@ public class OBDomesticVRPConsentRequestTestDataFactory {
 
     public static OBDomesticVRPConsentRequestData aValidOBDomesticVRPConsentRequestData(List<String> psuAuthenticationMethods, List<String> vrpTypes) {
         return (new OBDomesticVRPConsentRequestData())
+                .readRefundAccount(OBDomesticVRPConsentRequestData.ReadRefundAccountEnum.YES)
                 .controlParameters(aValidOBDomesticVRPControlParameters(psuAuthenticationMethods, vrpTypes))
                 .initiation(aValidOBDomesticVRPInitiation());
     }


### PR DESCRIPTION
- Fix readRefundAccount in support tests for VRP payments
Issue: https://github.com/OpenBankingToolkit/openbanking-toolkit/issues/47