### PR TITLE
Release/3.1.8.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,7 @@
                                     <!--<inputSpec>${project.basedir}/src/main/resources/specification/events-openapi.yaml</inputSpec>-->
                                     <!--<inputSpec>${project.basedir}/src/main/resources/specification/payment-initiation-openapi.yaml</inputSpec>-->
 				    <!--<inputSpec>${project.basedir}/src/main/resources/specification/event-notifications-openapi.yaml</inputSpec>-->
-				    <inputSpec>${project.basedir}/src/main/resources/specification/vrp-openapi-3.1.9r3.yaml</inputSpec>-->
+				    <!--<inputSpec>${project.basedir}/src/main/resources/specification/vrp-openapi-3.1.9r3.yaml</inputSpec>-->
                                     <output>${project.build.directory}/generated-sources/swagger</output>
                                     <generatorName>spring</generatorName>
                                     <!-- Change the package here as per the chosen spec above -->

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <groupId>com.forgerock.openbanking.uk</groupId>
     <artifactId>openbanking-uk-datamodel</artifactId>
     <packaging>jar</packaging>
-    <version>3.1.8.3</version>
+    <version>3.1.8.4-SNAPSHOT</version>
     <name>openbanking-uk-datamodel</name>
     <description>
         A Java UK Data Model, generated from the swagger, to help implementing the Open Banking standard :
@@ -239,7 +239,7 @@
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-uk-datamodel.git
         </developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-uk-datamodel.git</url>
-        <tag>3.1.8.3</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <groupId>com.forgerock.openbanking.uk</groupId>
     <artifactId>openbanking-uk-datamodel</artifactId>
     <packaging>jar</packaging>
-    <version>3.1.8.3-SNAPSHOT</version>
+    <version>3.1.8.3</version>
     <name>openbanking-uk-datamodel</name>
     <description>
         A Java UK Data Model, generated from the swagger, to help implementing the Open Banking standard :
@@ -239,7 +239,7 @@
         <developerConnection>scm:git:git@github.com:OpenBankingToolkit/openbanking-uk-datamodel.git
         </developerConnection>
         <url>https://github.com/OpenBankingToolkit/openbanking-uk-datamodel.git</url>
-        <tag>HEAD</tag>
+        <tag>3.1.8.3</tag>
     </scm>
 
     <distributionManagement>


### PR DESCRIPTION
- Release [3.1.8.3](https://github.com/OpenBankingToolkit/openbanking-uk-datamodel/releases/tag/3.1.8.3) published
- Prepare for the next development iteration